### PR TITLE
fix: throw "No AuthInfo found" if alias doesn't exist

### DIFF
--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -630,6 +630,8 @@ export class AuthInfo extends AsyncCreatable<AuthInfo.Options> {
         // Fetch from the persisted auth file
         try {
           const config: AuthInfoConfig = await AuthInfoConfig.create(AuthInfoConfig.getOptions(username));
+          // Throw ENOENT if the config file doesn't exist
+          await config.read(true);
           authConfig = config.toObject();
         } catch (e) {
           if (e.code === 'ENOENT') {

--- a/src/config/configFile.ts
+++ b/src/config/configFile.ts
@@ -212,7 +212,8 @@ export class ConfigFile<T extends ConfigFile.Options> extends BaseConfigStore<T>
 
     this.path = pathJoin(configRootFolder, this.options.filePath ? this.options.filePath : '', this.options.filename);
 
-    await this.read();
+    // Explicit mention false as parameter to support stubMethod.withArgs() in unit tests
+    await this.read(false);
   }
 }
 


### PR DESCRIPTION
Suggested solution for #64 