### PR TITLE
test: improve AuthInfoConfig test resiliency

### DIFF
--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -337,7 +337,7 @@ export const testSetup = once(_testSetup);
  *
  * **See** {@link shouldThrow}
  */
-export const unexpectedResult: SfdxError = new SfdxError('This code was expected to failed', 'UnexpectedResult');
+export const unexpectedResult: SfdxError = new SfdxError('This code was expected to fail', 'UnexpectedResult');
 
 /**
  * Use for this testing pattern:

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -234,7 +234,6 @@ describe('AuthInfo', () => {
     });
 
     stubMethod($$.SANDBOX, ConfigFile.prototype, 'read').callsFake(async function(this: AuthInfoConfig) {
-      console.log(`this.constructor.name: ${JSON.stringify(this.constructor.name, null, 4)}`);
       this.setContentsFromObject(await testMetadata.fetchConfigInfo(this.getPath()));
       return this.getContents();
     });

--- a/test/unit/config/authInfoConfigTest.ts
+++ b/test/unit/config/authInfoConfigTest.ts
@@ -1,12 +1,12 @@
-import { expect } from 'chai';
-
 import { set } from '@salesforce/kit';
 import { stubMethod } from '@salesforce/ts-sinon';
-
-import { AuthInfoConfig } from '../../src/config/authInfoConfig';
-import { ConfigFile } from '../../src/config/configFile';
-import { SfdxError } from '../../src/sfdxError';
-import { shouldThrow, testSetup } from '../../src/testSetup';
+import { expect } from 'chai';
+import { AuthInfoConfig } from '../../../src/config/authInfoConfig';
+import { ConfigFile } from '../../../src/config/configFile';
+import { SfdxError } from '../../../src/sfdxError';
+import { shouldThrow, testSetup } from '../../../src/testSetup';
+import { fs } from '../../../src/util/fs';
+import { ErrnoException } from '../helpers';
 
 // Setup the test environment.
 const $$ = testSetup();
@@ -29,6 +29,7 @@ describe('AuthInfoConfigTest', () => {
   });
 
   it('init should throw', async () => {
+    $$.SANDBOX.stub(fs, 'readJsonMap').throws(new ErrnoException('File not found', { code: 'ENOENT' }));
     options.throwOnNotFound = true;
     try {
       await shouldThrow(AuthInfoConfig.create(options));

--- a/test/unit/helpers.ts
+++ b/test/unit/helpers.ts
@@ -1,0 +1,24 @@
+import { isString } from '@salesforce/ts-types';
+
+/**
+ * A test implementation of NodeJS.ErrnoException for mocking fs errors.
+ */
+export class ErrnoException extends Error implements NodeJS.ErrnoException {
+  public errno?: number;
+  public code?: string;
+  public path?: string;
+  public syscall?: string;
+  public stack?: string;
+
+  constructor(options?: Partial<NodeJS.ErrnoException>);
+  constructor(message: string, options?: Partial<NodeJS.ErrnoException>);
+  constructor(messageOrOptions?: string | Partial<NodeJS.ErrnoException>, options?: Partial<NodeJS.ErrnoException>) {
+    if (isString(messageOrOptions)) {
+      super(messageOrOptions);
+    } else {
+      super();
+      options = messageOrOptions;
+    }
+    Object.assign(this, options || {});
+  }
+}


### PR DESCRIPTION
This test was failing for me because I just so happened to have an auth info config on disk by the expected (to be not found) file name :P

https://github.com/forcedotcom/sfdx-core/compare/rb/authinfoconfig-test?expand=1#diff-0668b515849b2c8663f4ef5b0ca99cb8R31
