### PR TITLE
fix: Update SecureBuffer cipherName to use aes-256-cbc

### DIFF
--- a/src/secureBuffer.ts
+++ b/src/secureBuffer.ts
@@ -8,7 +8,7 @@
 import { ensure, Optional } from '@salesforce/ts-types';
 import * as crypto from 'crypto';
 
-const cipherName = 'aes256';
+const cipherName = 'aes-256-cbc';
 const cipherSize = 32;
 
 /**


### PR DESCRIPTION
aes256 is the short name for aes-256-cbc. See https://wiki.openssl.org/index.php/Enc under Cypher Algorithms.

Issue: #143 