### PR TITLE
fix: use empty string in place of undefined client secret

### DIFF
--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -551,7 +551,7 @@ export class AuthInfo extends AsyncCreatable<AuthInfo.Options> {
     let sfdxAuthUrl = 'force://';
 
     if (decryptedFields.clientId) {
-      sfdxAuthUrl += `${decryptedFields.clientId}:${decryptedFields.clientSecret}:`;
+      sfdxAuthUrl += `${decryptedFields.clientId}:${decryptedFields.clientSecret || ''}:`;
     }
 
     sfdxAuthUrl += `${decryptedFields.refreshToken}@${instanceUrl}`;

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -1252,6 +1252,38 @@ describe('AuthInfo', () => {
         }@mydevhub.localhost.internal.salesforce.com:6109`
       );
     });
+
+    it('should hanlde undefined client secret', async () => {
+      const username = 'authInfoTest_username_RefreshToken';
+      const refreshTokenConfig = {
+        refreshToken: testMetadata.refreshToken,
+        loginUrl: testMetadata.loginUrl
+      };
+
+      const authResponse = {
+        access_token: testMetadata.accessToken,
+        instance_url: testMetadata.instanceUrl,
+        id: '00DAuthInfoTest_orgId/005AuthInfoTest_userId'
+      };
+
+      // Stub the http request (OAuth2.refreshToken())
+      _postParmsStub.returns(Promise.resolve(authResponse));
+
+      // Create the refresh token AuthInfo instance
+      const authInfo = await AuthInfo.create({
+        username,
+        oauth2Options: refreshTokenConfig
+      });
+
+      // delete the client secret
+      delete authInfo.getFields().clientSecret;
+
+      expect(authInfo.getSfdxAuthUrl()).to.contain(
+        `force://SalesforceDevelopmentExperience::${
+          testMetadata.refreshToken
+        }@mydevhub.localhost.internal.salesforce.com:6109`
+      );
+    });
   });
 
   describe('audienceUrl', () => {


### PR DESCRIPTION
Use empty string for client secret when client secret is undefined