### PR TITLE
fix: multiple uncaught exception log fix @W-7558552@

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -654,11 +654,15 @@ export class Logger {
   }
 
   private uncaughtExceptionHandler = (err: Error) => {
-    // log the exception
-    // FIXME: good chance this won't be logged because
-    // process.exit was called before this is logged
-    // https://github.com/trentm/node-bunyan/issues/95
-    this.fatal(err);
+    // W-7558552
+    // Only log uncaught exceptions in root logger
+    if (this === Logger.rootLogger) {
+      // log the exception
+      // FIXME: good chance this won't be logged because
+      // process.exit was called before this is logged
+      // https://github.com/trentm/node-bunyan/issues/95
+      this.fatal(err);
+    }
   };
 
   private exitHandler = () => {

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -1452,6 +1452,10 @@ describe('AuthInfo', () => {
   describe('audienceUrl', () => {
     const sfdxAudienceUrlSetting = process.env.SFDX_AUDIENCE_URL;
 
+    beforeEach(() => {
+      process.env.SFDX_AUDIENCE_URL = '';
+    });
+
     afterEach(() => {
       process.env.SFDX_AUDIENCE_URL = sfdxAudienceUrlSetting || '';
     });

--- a/test/unit/loggerTest.ts
+++ b/test/unit/loggerTest.ts
@@ -157,6 +157,17 @@ describe('Logger', () => {
       expect(Logger.root['called']).to.be.true;
       expect(rootLogger.addLogFileStream['called']).to.be.false;
     });
+
+    it('should log uncaught exception in root logger', async () => {
+      process.env.SFDX_ENV = 'dev';
+
+      $$.SANDBOX.stub(Logger.prototype, 'fatal');
+      const rootLogger = await Logger.root();
+
+      // @ts-ignore
+      Logger.lifecycle.emit('uncaughtException', 'testException');
+      expect(rootLogger.fatal['called']).to.be.true;
+    });
   });
 
   describe('child', () => {
@@ -165,6 +176,18 @@ describe('Logger', () => {
       const childLogger = await Logger.child(childLoggerName);
       expect(childLogger).to.be.instanceof(Logger);
       expect(childLogger.getName()).to.equal(childLoggerName);
+    });
+
+    it('should not log uncaught exception in child logger', async () => {
+      process.env.SFDX_ENV = 'dev';
+
+      $$.SANDBOX.stub(Logger.prototype, 'fatal');
+      const childLoggerName = 'myChildLogger';
+      const childLogger = await Logger.child(childLoggerName);
+
+      // @ts-ignore
+      Logger.lifecycle.emit('uncaughtException', 'testException');
+      expect(childLogger.fatal['called']).to.be.true;
     });
   });
 

--- a/test/unit/loggerTest.ts
+++ b/test/unit/loggerTest.ts
@@ -164,7 +164,7 @@ describe('Logger', () => {
       const rootLogger = await Logger.root();
       $$.SANDBOX.stub(rootLogger, 'fatal');
 
-      // @ts-ignore
+      // @ts-ignore to access private property `lifecycle` for testing uncaughtException
       Logger.lifecycle.emit('uncaughtException', 'testException');
       expect(rootLogger.fatal['called']).to.be.true;
     });
@@ -185,7 +185,7 @@ describe('Logger', () => {
       const childLogger = await Logger.child(childLoggerName);
       $$.SANDBOX.stub(childLogger, 'fatal');
 
-      // @ts-ignore
+      // @ts-ignore to access private property `lifecycle` for testing uncaughtException
       Logger.lifecycle.emit('uncaughtException', 'testException');
       expect(childLogger.fatal['called']).to.be.false;
     });

--- a/test/unit/loggerTest.ts
+++ b/test/unit/loggerTest.ts
@@ -161,8 +161,8 @@ describe('Logger', () => {
     it('should log uncaught exception in root logger', async () => {
       process.env.SFDX_ENV = 'dev';
 
-      $$.SANDBOX.stub(Logger.prototype, 'fatal');
       const rootLogger = await Logger.root();
+      $$.SANDBOX.stub(rootLogger, 'fatal');
 
       // @ts-ignore
       Logger.lifecycle.emit('uncaughtException', 'testException');
@@ -181,13 +181,13 @@ describe('Logger', () => {
     it('should not log uncaught exception in child logger', async () => {
       process.env.SFDX_ENV = 'dev';
 
-      $$.SANDBOX.stub(Logger.prototype, 'fatal');
       const childLoggerName = 'myChildLogger';
       const childLogger = await Logger.child(childLoggerName);
+      $$.SANDBOX.stub(childLogger, 'fatal');
 
       // @ts-ignore
       Logger.lifecycle.emit('uncaughtException', 'testException');
-      expect(childLogger.fatal['called']).to.be.true;
+      expect(childLogger.fatal['called']).to.be.false;
     });
   });
 


### PR DESCRIPTION
Fix multiple log lines when an uncaught exception happens.

There're multiple loggers printing logs when an uncaught exception happens, for example in local dev server:
```js
["sfdx", "Start", "Org", "AuthInfo", "crypto", "keyChain", "connection", "Org", "AuthInfo", "crypto", "keyChain", "connection", "TelemetryReporter", "AppInsights"]
```
The fix is to only log uncaught exception in root logger.