### PR TITLE
Added LifecycleEvents to Core

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@salesforce/bunyan": "^2.0.0",
-    "@salesforce/kit": "^1.0.0",
+    "@salesforce/kit": "^1.2.2",
     "@salesforce/schemas": "^1.0.1",
     "@salesforce/ts-types": "^1.0.0",
     "@types/jsforce": "1.9.2",

--- a/src/exported.ts
+++ b/src/exported.ts
@@ -30,6 +30,8 @@ export { Connection, SFDX_HTTP_HEADERS } from './connection';
 
 export { Mode, Global } from './global';
 
+export { Lifecycle } from './lifecycleEvents';
+
 export {
   Fields,
   FieldValue,

--- a/src/lifecycleEvents.ts
+++ b/src/lifecycleEvents.ts
@@ -11,9 +11,23 @@ import * as Debug from 'debug';
 type callback = (data: AnyJson) => Promise<void>;
 
 /**
- * An asynchronous event listener and emitter that follows the singleton pattern.
+ * An asynchronous event listener and emitter that follows the singleton pattern. The singleton pattern allows lifecycle events to be emitted from deep within a library and still be consumed by any other library or tool. It allows other developers to react to certain situations or events in your library without them having to manually call the method themselves.
+ *
+ * An example might be transforming metadata before it is deployed to an environment. As long as an event was emitted from the deploy library and you were listening on that event in the same process, you could transform the metadata before the deploy regardless of where in the code that metadata was initiated.
+ *
+ * @example
+ * ```
+ * // Listen for an event in a plugin hook
+ * Lifecycle.getInstance().on('deploy-metadata', transformMetadata)
+ *
+ * // Deep in the deploy code, fire the event for all libraries and plugins to hear.
+ * Lifecycle.getInstance().emit('deploy-metadata', metadataToBeDeployed);
+ * ```
  */
 export class Lifecycle {
+  /**
+   * Retrieve the singleton instance of this class so that all listeners and emitters can interact from any library or tool
+   */
   public static getInstance(): Lifecycle {
     if (!this.instance) {
       this.instance = new Lifecycle();
@@ -29,10 +43,18 @@ export class Lifecycle {
     this.listeners = {};
   }
 
+  /**
+   * Remove all listeners for a given event
+   * @param eventName The name of the event to remove listeners of
+   */
   public removeAllListeners(eventName: string) {
     this.listeners[eventName] = [];
   }
 
+  /**
+   * Get an array of listeners (callback functions) for a given event
+   * @param eventName The name of the event to get listeners of
+   */
   public getListeners(eventName: string): callback[] {
     const listeners = this.listeners[eventName];
     if (listeners) {
@@ -43,6 +65,11 @@ export class Lifecycle {
     }
   }
 
+  /**
+   * Create a new listener for a given event
+   * @param eventName The name of the event that is being listened for
+   * @param cb The callback function to run when the event is emitted
+   */
   public on<T extends AnyJson>(eventName: string, cb: (data: T | AnyJson) => Promise<void>) {
     const listeners = this.getListeners(eventName);
     if (listeners.length !== 0) {
@@ -56,6 +83,11 @@ export class Lifecycle {
     this.listeners[eventName] = listeners;
   }
 
+  /**
+   * Emit a given event, causing all callback functions to be run in the order they were registered
+   * @param eventName The name of the event to emit
+   * @param data The argument to be passed to the callback function
+   */
   public async emit(eventName: string, data: AnyJson) {
     const listeners = this.getListeners(eventName);
     if (listeners.length === 0) {
@@ -63,9 +95,9 @@ export class Lifecycle {
         `A lifecycle event with the name ${eventName} does not exist. An event must be registered before it can be emitted.`
       );
     } else {
-      listeners.forEach(async cb => {
+      for (const cb of listeners) {
         await cb(data);
-      });
+      }
     }
   }
 }

--- a/src/lifecycleEvents.ts
+++ b/src/lifecycleEvents.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { AnyJson } from '@salesforce/ts-types';
+import * as Debug from 'debug';
+
+type callback = (data: AnyJson) => Promise<void>;
+
+interface CallbackDictionary {
+  [key: string]: callback[];
+}
+
+/**
+ * An asynchronous event listener and emitter that follows the singleton pattern.
+ */
+export class Lifecycle {
+  public static getInstance(): Lifecycle {
+    if (!this.instance) {
+      this.instance = new Lifecycle();
+    }
+    return this.instance;
+  }
+
+  private static instance: Lifecycle;
+  private debug = Debug(`sfdx:${this.constructor.name}`);
+  private listeners: CallbackDictionary;
+
+  private constructor() {
+    this.listeners = {};
+  }
+
+  public removeAllListeners(eventName: string) {
+    this.listeners[eventName] = [];
+  }
+
+  public getListeners(eventName: string): callback[] {
+    if (!this.listeners[eventName]) {
+      this.listeners[eventName] = [];
+    }
+    return this.listeners[eventName];
+  }
+
+  public on<T extends AnyJson>(eventName: string, cb: (data: T | AnyJson) => Promise<void>) {
+    if (this.getListeners(eventName).length !== 0) {
+      this.debug(
+        `${this.listeners[eventName].length +
+          1} lifecycle events with the name ${eventName} have now been registered. When this event is emitted all ${this
+          .listeners[eventName].length + 1} listeners will fire.`
+      );
+    }
+    this.listeners[eventName].push(cb);
+  }
+
+  public async emit(eventName: string, data: AnyJson) {
+    if (this.getListeners(eventName).length === 0) {
+      this.debug(
+        `A lifecycle event with the name ${eventName} does not exist. An event must be registered before it can be emitted.`
+      );
+    } else {
+      this.listeners[eventName].forEach(async cb => {
+        await cb(data);
+      });
+    }
+  }
+}

--- a/src/lifecycleEvents.ts
+++ b/src/lifecycleEvents.ts
@@ -11,9 +11,13 @@ import * as Debug from 'debug';
 type callback = (data: AnyJson) => Promise<void>;
 
 /**
- * An asynchronous event listener and emitter that follows the singleton pattern. The singleton pattern allows lifecycle events to be emitted from deep within a library and still be consumed by any other library or tool. It allows other developers to react to certain situations or events in your library without them having to manually call the method themselves.
+ * An asynchronous event listener and emitter that follows the singleton pattern. The singleton pattern allows lifecycle
+ * events to be emitted from deep within a library and still be consumed by any other library or tool. It allows other
+ * developers to react to certain situations or events in your library without them having to manually call the method themselves.
  *
- * An example might be transforming metadata before it is deployed to an environment. As long as an event was emitted from the deploy library and you were listening on that event in the same process, you could transform the metadata before the deploy regardless of where in the code that metadata was initiated.
+ * An example might be transforming metadata before it is deployed to an environment. As long as an event was emitted from the
+ * deploy library and you were listening on that event in the same process, you could transform the metadata before the deploy
+ * regardless of where in the code that metadata was initiated.
  *
  * @example
  * ```

--- a/test/unit/lifecycleEventsTest.ts
+++ b/test/unit/lifecycleEventsTest.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { stubMethod } from '@salesforce/ts-sinon';
+import * as chai from 'chai';
+import { Lifecycle } from '../../src/LifecycleEvents';
+import { testSetup } from '../../src/testSetup';
+
+const $$ = testSetup();
+
+describe('lifecycleEvents', () => {
+  let fake;
+  let fakeSpy;
+  let loggerSpy;
+
+  class Foo {
+    public bar(name: string, result: string) {
+      return result[name];
+    }
+  }
+
+  beforeEach(() => {
+    loggerSpy = stubMethod($$.SANDBOX, Lifecycle.getInstance(), 'debug');
+    fake = new Foo();
+    fakeSpy = stubMethod($$.SANDBOX, fake, 'bar');
+  });
+
+  it('getInstance is a functioning singleton pattern', async () => {
+    chai.assert(Lifecycle.getInstance() === Lifecycle.getInstance());
+  });
+
+  it('succsssful event registration and emitting causes runHook to be called', async () => {
+    Lifecycle.getInstance().on('test1', async result => {
+      fake.bar('test1', result);
+    });
+    Lifecycle.getInstance().on('test2', async result => {
+      fake.bar('test1', result);
+    });
+    chai.expect(fakeSpy.callCount).to.be.equal(0);
+
+    await Lifecycle.getInstance().emit('test1', 'Success');
+    chai.expect(fakeSpy.callCount).to.be.equal(1);
+    chai.expect(fakeSpy.args[0][1]).to.be.equal('Success');
+
+    await Lifecycle.getInstance().emit('test2', 'Also Success');
+    chai.expect(fakeSpy.callCount).to.be.equal(2);
+    chai.expect(fakeSpy.args[1][1]).to.be.equal('Also Success');
+  });
+
+  it('an event registering twice logs a warning but creates two listeners', async () => {
+    Lifecycle.getInstance().on('test3', async result => {
+      fake.bar('test3', result);
+    });
+    Lifecycle.getInstance().on('test3', async result => {
+      fake.bar('test3', result);
+    });
+    chai.expect(loggerSpy.callCount).to.be.equal(1);
+    chai
+      .expect(loggerSpy.args[0][0])
+      .to.be.equal(
+        '2 lifecycle events with the name test3 have now been registered. When this event is emitted all 2 listeners will fire.'
+      );
+
+    await Lifecycle.getInstance().emit('test3', 'Two Listeners');
+    chai.expect(fakeSpy.callCount).to.be.equal(2);
+  });
+
+  it('emitting an event that is not registered logs a warning and will not call runHook', async () => {
+    await Lifecycle.getInstance().emit('test4', 'Expect failure');
+    chai.expect(fakeSpy.callCount).to.be.equal(0);
+    chai.expect(loggerSpy.callCount).to.be.equal(1);
+    chai
+      .expect(loggerSpy.args[0][0])
+      .to.be.equal(
+        'A lifecycle event with the name test4 does not exist. An event must be registered before it can be emitted.'
+      );
+  });
+
+  it('removeAllListeners works', async () => {
+    Lifecycle.getInstance().on('test5', async result => {
+      fake.bar('test5', result);
+    });
+    await Lifecycle.getInstance().emit('test5', 'Success');
+    chai.expect(fakeSpy.callCount).to.be.equal(1);
+    chai.expect(fakeSpy.args[0][1]).to.be.equal('Success');
+
+    Lifecycle.getInstance().removeAllListeners('test5');
+    await Lifecycle.getInstance().emit('test5', 'Failure: Listener Removed');
+    chai.expect(fakeSpy.callCount).to.be.equal(1);
+    chai.expect(loggerSpy.callCount).to.be.equal(1);
+    chai
+      .expect(loggerSpy.args[0][0])
+      .to.be.equal(
+        'A lifecycle event with the name test5 does not exist. An event must be registered before it can be emitted.'
+      );
+  });
+
+  it('getListeners works', async () => {
+    const x = async result => {
+      fake.bar('test6', result);
+    };
+    Lifecycle.getInstance().on('test6', x);
+    chai.expect(Lifecycle.getInstance().getListeners('test6')[0]).to.be.equal(x);
+
+    chai.expect(Lifecycle.getInstance().getListeners('undefinedKey').length).to.be.equal(0);
+  });
+});

--- a/test/unit/lifecycleEventsTest.ts
+++ b/test/unit/lifecycleEventsTest.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { stubMethod } from '@salesforce/ts-sinon';
+import { spyMethod } from '@salesforce/ts-sinon';
 import * as chai from 'chai';
 import { Lifecycle } from '../../src/LifecycleEvents';
 import { testSetup } from '../../src/testSetup';
@@ -12,20 +12,19 @@ import { testSetup } from '../../src/testSetup';
 const $$ = testSetup();
 
 describe('lifecycleEvents', () => {
-  let fake;
-  let fakeSpy;
-  let loggerSpy;
-
   class Foo {
-    public bar(name: string, result: string) {
+    public bar(name: string, result: {}) {
       return result[name];
     }
   }
 
+  let fakeSpy;
+  let loggerSpy;
+  const fake = new Foo();
+
   beforeEach(() => {
-    loggerSpy = stubMethod($$.SANDBOX, Lifecycle.getInstance(), 'debug');
-    fake = new Foo();
-    fakeSpy = stubMethod($$.SANDBOX, fake, 'bar');
+    loggerSpy = spyMethod($$.SANDBOX, Lifecycle.getInstance(), 'debug');
+    fakeSpy = spyMethod($$.SANDBOX, fake, 'bar');
   });
 
   it('getInstance is a functioning singleton pattern', async () => {

--- a/test/unit/lifecycleEventsTest.ts
+++ b/test/unit/lifecycleEventsTest.ts
@@ -32,7 +32,7 @@ describe('lifecycleEvents', () => {
     chai.assert(Lifecycle.getInstance() === Lifecycle.getInstance());
   });
 
-  it('succsssful event registration and emitting causes runHook to be called', async () => {
+  it('succsssful event registration and emitting causes the callback to be called', async () => {
     Lifecycle.getInstance().on('test1', async result => {
       fake.bar('test1', result);
     });
@@ -68,7 +68,7 @@ describe('lifecycleEvents', () => {
     chai.expect(fakeSpy.callCount).to.be.equal(2);
   });
 
-  it('emitting an event that is not registered logs a warning and will not call runHook', async () => {
+  it('emitting an event that is not registered logs a warning and will not call the callback', async () => {
     await Lifecycle.getInstance().emit('test4', 'Expect failure');
     chai.expect(fakeSpy.callCount).to.be.equal(0);
     chai.expect(loggerSpy.callCount).to.be.equal(1);

--- a/test/unit/lifecycleEventsTest.ts
+++ b/test/unit/lifecycleEventsTest.ts
@@ -6,7 +6,7 @@
  */
 import { spyMethod } from '@salesforce/ts-sinon';
 import * as chai from 'chai';
-import { Lifecycle } from '../../src/LifecycleEvents';
+import { Lifecycle } from '../../src/lifecycleEvents';
 import { testSetup } from '../../src/testSetup';
 
 const $$ = testSetup();

--- a/test/unit/lifecycleEventsTest.ts
+++ b/test/unit/lifecycleEventsTest.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { Duration, sleep } from '@salesforce/kit/lib/duration';
 import { spyMethod } from '@salesforce/ts-sinon';
 import * as chai from 'chai';
 import { Lifecycle } from '../../src/lifecycleEvents';
@@ -49,11 +50,12 @@ describe('lifecycleEvents', () => {
     chai.expect(fakeSpy.args[1][1]).to.be.equal('Also Success');
   });
 
-  it('an event registering twice logs a warning but creates two listeners', async () => {
+  it('an event registering twice logs a warning but creates two listeners that both fire when emitted', async () => {
     Lifecycle.getInstance().on('test3', async result => {
       fake.bar('test3', result);
     });
     Lifecycle.getInstance().on('test3', async result => {
+      await sleep(Duration.milliseconds(1));
       fake.bar('test3', result);
     });
     chai.expect(loggerSpy.callCount).to.be.equal(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -363,11 +363,11 @@
     xunit-file "^1"
 
 "@salesforce/kit@^1.0.0":
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/@salesforce/kit/-/kit-1.2.1.tgz#123f0edad6a934848db054f51d6524a1e8419043"
-  integrity sha512-ytpDL5TO4QAPcMl1flXXADMeBzARtoOZekWTMdL2O8PVdJo5Wbo9TNpJk0u6SN7qcxZvdbb6RAJpprp4qN2TZw==
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.2.2.tgz#9efaee2f520fba4c87a1e138fb31579cc5de69bd"
+  integrity sha512-MQXUh8Ka8oB1SOPUF1kOynXQWcLeZ8YWOyqPtg6j8U9NxLlkTF2vfUfhZEm//jXjejDy7CEes5rEKRHm2df/OA==
   dependencies:
-    "@salesforce/ts-types" "^1.2.1"
+    "@salesforce/ts-types" "^1.2.2"
     tslib "^1.10.0"
 
 "@salesforce/schemas@^1.0.1":
@@ -388,6 +388,13 @@
   version "1.2.1"
   resolved "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-1.2.1.tgz#1f738d0e7df55843e78d2726617b9fdd17291842"
   integrity sha512-kEpyfvTRfwQFpDc1rfb6aaQbl5SDIwCksgr8ftJaooGXDVWFK9llso9cwimee+KVqTeQ6Jf4tZclcPb8I6G6sg==
+  dependencies:
+    tslib "^1.10.0"
+
+"@salesforce/ts-types@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-1.2.2.tgz#2e6dc771fa42a2cfc1a2e6b13d2f789add0cdf7c"
+  integrity sha512-inTkNP5jwJTbKqmBv6Cku/ezU6+ErYbUH4YorDfgZ/wDCsdLc9UyPGKGMO8aZ78vvyUTYWEiDxWlMqb1QXEfEw==
   dependencies:
     tslib "^1.10.0"
 


### PR DESCRIPTION
In line with the efforts of __@W-5796702@__ to add command specific hooks to the Salesforce CLI, the event emitter and listener class Lifecycle has been added along with tests to this repo. This class is generic and does not have to be used only for hooks in commands. 

The tests are basic but thorough in demonstrating that every method performs as intended.