### PR TITLE
Feat: adds actOn / areFilesEqual / getContentHash from toolbelt

### DIFF
--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -7,11 +7,14 @@
 
 import { parseJson, parseJsonMap } from '@salesforce/kit';
 import { AnyJson, JsonMap, Optional } from '@salesforce/ts-types';
+import * as crypto from 'crypto';
 import * as fsLib from 'fs';
 import * as mkdirpLib from 'mkdirp';
 import * as path from 'path';
 import { promisify } from 'util';
 import { SfdxError } from '../sfdxError';
+
+type PerformFunction = (filePath: string, file?: string, dir?: string) => Promise<void>;
 
 export const fs = {
   /**
@@ -172,5 +175,68 @@ export const fs = {
     } catch (err) {
       return false;
     }
+  },
+
+  /**
+   * Recursively act on all files or directories in a directory
+   *
+   * @param dir path to directory
+   * @param perform function to be run on contents of dir
+   * @param onType optional parameter to specify type to actOn
+   * @returns void
+   */
+
+  actOn: async (dir: string, perform: PerformFunction, onType: 'file' | 'dir' = 'file'): Promise<void> => {
+    for (const file of await fs.readdir(dir)) {
+      const filePath = path.join(dir, file);
+      const stat = await fs.stat(filePath);
+
+      if (stat) {
+        if (stat.isDirectory()) {
+          await fs.actOn(filePath, perform, onType);
+          if (onType === 'dir') {
+            await perform(filePath);
+          }
+        } else if (stat.isFile() && onType === 'file') {
+          await perform(filePath, file, dir);
+        }
+      }
+    }
+  },
+
+  /**
+   * Checks if files are the same
+   *
+   * @param file1Path the first file path to check
+   * @param file2Path the second file path to check
+   * @returns boolean
+   */
+  areFilesEqual: async (file1Path: string, file2Path: string): Promise<boolean> => {
+    try {
+      const file1Size = (await fs.stat(file1Path)).size;
+      const file2Size = (await fs.stat(file2Path)).size;
+      if (file1Size !== file2Size) {
+        return false;
+      }
+
+      const contentA = await fs.readFile(file1Path);
+      const contentB = await fs.readFile(file2Path);
+
+      return fs.getContentHash(contentA) === fs.getContentHash(contentB);
+    } catch (err) {
+      throw new SfdxError(`The path: ${err.path} doesn't exist or access is denied.`, 'DirMissingOrNoAccess');
+    }
+  },
+
+  /**
+   * Creates a hash for the string that's passed in
+   * @param contents The string passed into the function
+   * @returns string
+   */
+  getContentHash(contents: string | Buffer) {
+    return crypto
+      .createHash('sha1')
+      .update(contents)
+      .digest('hex');
   }
 };

--- a/test/unit/util/fsTest.ts
+++ b/test/unit/util/fsTest.ts
@@ -226,4 +226,130 @@ describe('util/fs', () => {
       expect(exists).to.be.false;
     });
   });
+
+  describe('areFilesEqual', () => {
+    afterEach(() => {
+      $$.SANDBOX.restore();
+    });
+
+    it('should return false if the files stat.size are different', async () => {
+      $$.SANDBOX.stub(fs, 'readFile')
+        .onCall(0)
+        .resolves({})
+        .onCall(1)
+        .resolves({});
+      $$.SANDBOX.stub(fs, 'stat')
+        .onCall(0)
+        .resolves({
+          size: 1
+        })
+        .onCall(1)
+        .resolves({
+          size: 2
+        });
+
+      const results = await fs.areFilesEqual('foo/bar.json', 'foo/bar2.json');
+      expect(results).to.be.false;
+    });
+
+    it('should return true if the file hashes are the same', async () => {
+      $$.SANDBOX.stub(fs, 'readFile')
+        .onCall(0)
+        .resolves(
+          `{
+            "key": 12345,
+            "value": true,
+        }`
+        )
+        .onCall(1)
+        .resolves(
+          `{
+            "key": 12345,
+            "value": true,
+        }`
+        );
+      $$.SANDBOX.stub(fs, 'stat')
+        .onCall(0)
+        .resolves({})
+        .onCall(1)
+        .resolves({});
+
+      const results = await fs.areFilesEqual('foo/bar.json', 'foo/bar2.json');
+      expect(results).to.be.true;
+    });
+
+    it('should return false if the file hashes are different', async () => {
+      $$.SANDBOX.stub(fs, 'readFile')
+        .onCall(0)
+        .resolves(
+          `{
+              "key": 12345,
+              "value": true,
+          }`
+        )
+        .onCall(1)
+        .resolves(
+          `{
+              "key": 12345,
+              "value": false,
+          }`
+        );
+
+      $$.SANDBOX.stub(fs, 'stat')
+        .onCall(0)
+        .resolves({})
+        .onCall(1)
+        .resolves({});
+      const results = await fs.areFilesEqual('foo/bar.json', 'foo/bsar2.json');
+      expect(results).to.be.false;
+    });
+
+    it('should return error when fs.readFile throws error', async () => {
+      $$.SANDBOX.stub(fs, 'stat')
+        .onCall(0)
+        .resolves({
+          size: 1
+        })
+        .onCall(1)
+        .resolves({
+          size: 2
+        });
+      try {
+        await fs.areFilesEqual('foo', 'bar');
+      } catch (e) {
+        expect(e.name).to.equal('DirMissingOrNoAccess');
+      }
+    });
+
+    it('should return error when fs.stat throws error', async () => {
+      try {
+        await fs.areFilesEqual('foo', 'bar');
+      } catch (e) {
+        expect(e.name).to.equal('DirMissingOrNoAccess');
+      }
+    });
+  });
+
+  describe('actOn', () => {
+    afterEach(() => {
+      $$.SANDBOX.restore();
+    });
+
+    it('should run custom functions against contents of a directory', async () => {
+      const actedOnArray = [];
+      $$.SANDBOX.stub(fs, 'readdir').resolves(['test1.json', 'test2.json']);
+      $$.SANDBOX.stub(fs, 'stat').resolves({
+        isDirectory: () => false,
+        isFile: () => true
+      });
+      const pathToFolder = pathJoin(osTmpdir(), 'foo');
+
+      await fs.actOn(pathToFolder, async file => {
+        actedOnArray.push(file), 'file';
+      });
+      const example = [pathJoin(pathToFolder, 'test1.json'), pathJoin(pathToFolder, 'test2.json')];
+
+      expect(actedOnArray).to.eql(example);
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -362,7 +362,7 @@
     typedoc-plugin-external-module-name "1.1.3"
     xunit-file "^1"
 
-"@salesforce/kit@^1.0.0":
+"@salesforce/kit@^1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.2.2.tgz#9efaee2f520fba4c87a1e138fb31579cc5de69bd"
   integrity sha512-MQXUh8Ka8oB1SOPUF1kOynXQWcLeZ8YWOyqPtg6j8U9NxLlkTF2vfUfhZEm//jXjejDy7CEes5rEKRHm2df/OA==


### PR DESCRIPTION
**What does this PR do?**
Brings in a few functions from toolbelt. 

- **actOn** - Recursively act on all files or directories in a directory
- **areFilesEqual** - Checks if files are the same
- **getContentHash** - Creates a hash for any string that is passed in

**Acceptance Criteria**
Unit tests should pass in both core and npm/yarn linked toolbelt using these functions. 

**Testing Notes**
yarn link from core --> toolbelt. Update actOn / areFilesEqual references to core and run tests. 