### PR TITLE
fix: throw NoUsername error when missing required username

### DIFF
--- a/messages/core.json
+++ b/messages/core.json
@@ -16,5 +16,6 @@
   "NoAliasesFound": "Nothing to set",
   "InvalidFormat": "Setting aliases must be in the format <key>=<value> but found: [%s]",
   "NoAuthInfoFound": "No authorization information can be found.",
-  "InvalidJsonCasing": "All JSON input must have heads down camelcase keys.  E.g., { sfdcLoginUrl: \"https://login.salesforce.com\" }\nFound \"%s\" at %s"
+  "InvalidJsonCasing": "All JSON input must have heads down camelcase keys.  E.g., { sfdcLoginUrl: \"https://login.salesforce.com\" }\nFound \"%s\" at %s",
+  "NoUsername": "This command requires an org username set either with a flag or by default in the config."
 }

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -609,7 +609,7 @@ export class AuthInfo extends AsyncCreatable<AuthInfo.Options> {
     // Must specify either username and/or options
     const options = this.options.oauth2Options || this.options.accessTokenOptions;
     if (!this.options.username && !(this.options.oauth2Options || this.options.accessTokenOptions)) {
-      throw SfdxError.create('@salesforce/core', 'core', 'AuthInfoCreationError');
+      throw SfdxError.create('@salesforce/core', 'core', 'NoUsername');
     }
 
     // If a username AND oauth options were passed, ensure an auth file for the username doesn't

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -1146,7 +1146,7 @@ describe('AuthInfo', () => {
         await AuthInfo.create({});
         assert.fail('Expected AuthInfo.create() to throw an error when no params are passed');
       } catch (err) {
-        expect(err.name).to.equal('AuthInfoCreationError');
+        expect(err.name).to.equal('NoUsername');
       }
     });
   });


### PR DESCRIPTION
Throw `NoUsername` error instead of `AuthInfoCreationError` when required username is missing

@W-5907549@