### PR TITLE
Wr/max query limit @W-7293174@

### DIFF
--- a/messages/config.json
+++ b/messages/config.json
@@ -5,6 +5,7 @@
   "InvalidApiVersion": "Specify a valid Salesforce API version, for example, 42.0",
   "InvalidIsvDebuggerSid": "Specify a valid Debugger SID",
   "InvalidIsvDebuggerUrl": "Specify a valid Debugger URL",
+  "InvalidNumberConfigValue": "Specify a valid number, for example, 150000",
   "InvalidBooleanConfigValue": "The config value can only be set to true or false.",
   "InvalidProjectWorkspace": "This directory does not contain a valid Salesforce DX project",
   "SchemaValidationWarning": "The config file: %s is not schema valid\nDue to: %s",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -6,7 +6,7 @@
  */
 
 import { keyBy, set } from '@salesforce/kit';
-import { Dictionary, ensure, isString } from '@salesforce/ts-types';
+import { Dictionary, ensure, isNumber, isString } from '@salesforce/ts-types';
 import { Crypto } from '../crypto';
 import { Messages } from '../messages';
 import { SfdxError } from '../sfdxError';
@@ -100,6 +100,11 @@ export class Config extends ConfigFile<ConfigFile.Options> {
    * Disables telemetry reporting
    */
   public static readonly DISABLE_TELEMETRY = 'disableTelemetry';
+
+  /**
+   * allows users to override the 10,000 result query limit
+   */
+  public static readonly MAX_QUERY_LIMIT = 'maxQueryLimit';
 
   /**
    * Returns the default file name for a config file.
@@ -308,6 +313,13 @@ export class Config extends ConfigFile<ConfigFile.Options> {
           input: {
             validator: value => value != null && ['true', 'false'].includes(value.toString()),
             failedMessage: Config.messages.getMessage('InvalidBooleanConfigValue')
+          }
+        },
+        {
+          key: Config.MAX_QUERY_LIMIT,
+          input: {
+            validator: value => isNumber(value),
+            failedMessage: Config.messages.getMessage('InvalidNumberConfigValue')
           }
         }
       ];

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -6,14 +6,16 @@
  */
 
 import { maxBy, merge } from '@salesforce/kit';
-import { asString, ensure, isString, JsonCollection, JsonMap, Optional } from '@salesforce/ts-types';
-import { Tooling as JSForceTooling } from 'jsforce';
-import { ExecuteOptions } from 'jsforce';
-import { QueryResult } from 'jsforce';
-import { RequestInfo } from 'jsforce';
-import { ConnectionOptions } from 'jsforce';
-import { Connection as JSForceConnection } from 'jsforce';
-import { Promise as JsforcePromise } from 'jsforce';
+import { asString, ensure, getNumber, isString, JsonCollection, JsonMap, Optional } from '@salesforce/ts-types';
+import {
+  Connection as JSForceConnection,
+  ConnectionOptions,
+  ExecuteOptions,
+  Promise as JsforcePromise,
+  QueryResult,
+  RequestInfo,
+  Tooling as JSForceTooling
+} from 'jsforce';
 import { AuthFields, AuthInfo } from './authInfo';
 import { ConfigAggregator } from './config/configAggregator';
 import { Logger } from './logger';
@@ -258,25 +260,31 @@ export class Connection extends JSForceConnection {
    * @param options The query options. NOTE: the autoFetch option will always be true.
    */
   public async autoFetchQuery<T>(soql: string, options: ExecuteOptions = {}): Promise<QueryResult<T>> {
+    const config: ConfigAggregator = await ConfigAggregator.create();
+    // take the limit from the calling function, then the config, then default 10,000
+    const maxFetch: number = options.maxFetch || (config.getInfo('maxQueryLimit').value as number) || 10000;
+
     const _options: ExecuteOptions = Object.assign(options, {
-      autoFetch: true
+      autoFetch: true,
+      maxFetch
     });
-    const records: T[] = [];
 
     this._logger.debug(`Auto-fetching query: ${soql}`);
-
-    return new Promise<QueryResult<T>>((resolve, reject) =>
-      this.query<T>(soql, _options)
-        .on('record', rec => records.push(rec))
-        .on('error', err => reject(err))
-        .on('end', () =>
-          resolve({
-            done: true,
-            totalSize: records.length,
-            records
-          })
-        )
-    );
+    let returnedRecords = 0;
+    const query = this.query<T>(soql, _options)
+      .on('record', () => returnedRecords++)
+      .on('error', err => Promise.reject(err))
+      .on('end', () => {
+        // for compilation, if for some reason there's no 'totalSize' use the default fetch
+        const totalSize = getNumber(query, 'totalSize') || maxFetch;
+        if (totalSize >= returnedRecords) {
+          this._logger.warn(
+            `The query result is missing ${totalSize -
+              returnedRecords} records due to an API limit. Increase the number of records returned by setting the config value "maxQueryLimit" to ${totalSize} or greater than 10,000 (the default value).`
+          );
+        }
+      });
+    return query;
   }
 }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -273,7 +273,6 @@ export class Connection extends JSForceConnection {
     let returnedRecords = 0;
     const query = this.query<T>(soql, _options)
       .on('record', () => returnedRecords++)
-      .on('error', err => Promise.reject(err))
       .on('end', () => {
         // for compilation, if for some reason there's no 'totalSize' use the default fetch
         const totalSize = getNumber(query, 'totalSize') || maxFetch;


### PR DESCRIPTION
the logic and future proofing the maxQueryLimit config value

certain queries that use `autoFetchQuery` were being limited to 10k results, now you can override queries that use that method with a config value