### PR TITLE
feat: support array of messages when using getMessage

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -11,8 +11,18 @@
  */
 
 import { NamedError } from '@salesforce/kit';
-import { AnyJson, asString, ensureJsonMap, ensureString, isAnyJson, isObject, Optional } from '@salesforce/ts-types';
+import {
+  AnyJson,
+  asString,
+  ensureJsonMap,
+  ensureString,
+  isAnyJson,
+  isArray,
+  isObject,
+  Optional
+} from '@salesforce/ts-types';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as util from 'util';
 
@@ -339,7 +349,13 @@ export class Messages {
         `Missing message ${this.bundleName}:${key} for locale ${Messages.getLocale()}.`
       );
     }
-    const msg = ensureString(map.get(key));
-    return util.format(msg, ...tokens);
+    const msg = map.get(key);
+    const messages = (isArray(msg) ? msg : [msg]) as string[];
+    return messages
+      .map(message => {
+        ensureString(message);
+        return util.format(message, ...tokens);
+      })
+      .join(os.EOL);
   }
 }

--- a/test/unit/messagesTest.ts
+++ b/test/unit/messagesTest.ts
@@ -18,7 +18,8 @@ const $$ = testSetup();
 describe('Messages', () => {
   const testMessages = {
     msg1: 'test message 1',
-    msg2: 'test message 2 %s and %s'
+    msg2: 'test message 2 %s and %s',
+    manyMsgs: ['hello', 'world', 'test message 2 %s and %s']
   };
 
   const msgMap = new Map();
@@ -26,6 +27,7 @@ describe('Messages', () => {
   msgMap.set('msg2', testMessages.msg2);
   msgMap.set('msg3', cloneJson(testMessages));
   msgMap.get('msg3').msg3 = cloneJson(testMessages);
+  msgMap.set('manyMsgs', testMessages.manyMsgs);
 
   describe('getMessage', () => {
     const messages = new Messages('myBundle', Messages.getLocale(), msgMap);
@@ -58,6 +60,12 @@ describe('Messages', () => {
       } catch (err) {
         expect(err.message).to.equal('Missing message myBundle:msg4 for locale en_US.');
       }
+    });
+
+    it('should return single string from array of messages', () => {
+      expect(messages.getMessage('manyMsgs', ['blah', 864])).to.equal(
+        'hello blah 864\nworld blah 864\ntest message 2 blah and 864'
+      );
     });
   });
 


### PR DESCRIPTION
Support array of messages, e.g.

```json
"examples": [
    "sfdx config:get defaultusername",
    "sfdx config:get defaultusername defaultdevhubusername instanceUrl",
    "sfdx config:get defaultusername defaultdevhubusername --verbose"
  ]
```