### PR TITLE
fix: add new sandboxes

### DIFF
--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -221,7 +221,11 @@ function getJwtAudienceUrl(options: OAuth2Options) {
   } else if (isInternalUrl(loginUrl)) {
     // This is for internal developers when just doing authorize;
     audienceUrl = loginUrl;
-  } else if (createdOrgInstance.startsWith('cs') || urlParse(loginUrl).hostname === 'test.salesforce.com') {
+  } else if (
+    createdOrgInstance.startsWith('cs') ||
+    createdOrgInstance.endsWith('s') ||
+    urlParse(loginUrl).hostname === 'test.salesforce.com'
+  ) {
     audienceUrl = SfdcUrl.SANDBOX;
   } else if (createdOrgInstance.startsWith('gs1')) {
     audienceUrl = 'https://gs1.salesforce.com';

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -1642,6 +1642,14 @@ describe('AuthInfo', () => {
       await runTest({ createdOrgInstance: 'cs17' }, 'https://test.salesforce.com');
     });
 
+    it('should use the correct audience URL for createdOrgInstance ending with "s"', async () => {
+      await runTest({ createdOrgInstance: 'usa2s' }, 'https://test.salesforce.com');
+    });
+
+    it('should use the correct audience URL for createdOrgInstance capitalized and ending with "s"', async () => {
+      await runTest({ createdOrgInstance: 'IND2S' }, 'https://test.salesforce.com');
+    });
+
     it('should use the correct audience URL for createdOrgInstance beginning with "gs1"', async () => {
       await runTest({ createdOrgInstance: 'gs1' }, 'https://gs1.salesforce.com');
     });


### PR DESCRIPTION
There is a new set of production sandbox instances that end in `s` rather than the traditional starting with `cs`. This code enables those sandboxes to work during auth.

@W-8115230@