### PR TITLE
fix: fs mocking 

### DIFF
--- a/src/sfdxProject.ts
+++ b/src/sfdxProject.ts
@@ -355,9 +355,9 @@ export class SfdxProject {
    * **Throws** *{@link SfdxError}{ name: 'InvalidProjectWorkspace' }* If the current folder is not located in a workspace.
    */
   public static async resolve(path?: string): Promise<SfdxProject> {
-    path = path || process.cwd();
+    path = await this.resolveProjectPath(path || process.cwd());
     if (!SfdxProject.instances.has(path)) {
-      const project = new SfdxProject(await this.resolveProjectPath(path));
+      const project = new SfdxProject(path);
       SfdxProject.instances.set(path, project);
     }
     return ensure(SfdxProject.instances.get(path));
@@ -371,9 +371,11 @@ export class SfdxProject {
    * **Throws** *{@link SfdxError}{ name: 'InvalidProjectWorkspace' }* If the current folder is not located in a workspace.
    */
   public static getInstance(path?: string): SfdxProject {
-    path = path || process.cwd();
+    // Store instance based on the path of the actual project.
+    path = this.resolveProjectPathSync(path || process.cwd());
+
     if (!SfdxProject.instances.has(path)) {
-      const project = new SfdxProject(this.resolveProjectPathSync(path));
+      const project = new SfdxProject(path);
       SfdxProject.instances.set(path, project);
     }
     return ensure(SfdxProject.instances.get(path));

--- a/src/sfdxProject.ts
+++ b/src/sfdxProject.ts
@@ -236,7 +236,7 @@ export class SfdxProjectJson extends ConfigFile<ConfigFile.Options> {
       // Always end in a path sep for standardization on folder paths
       const fullPath = `${dirname(this.getPath())}${sep}${name}${sep}`;
 
-      if (!fs.existsSync(fullPath)) {
+      if (!this.doesPackageExist(fullPath)) {
         throw new SfdxError(
           'InvalidPackageDirectory',
           this.messages.getMessage('InvalidPackageDirectory', [packageDir.path])
@@ -302,6 +302,10 @@ export class SfdxProjectJson extends ConfigFile<ConfigFile.Options> {
    */
   public hasMultiplePackages(): boolean {
     return this.getContents().packageDirectories && this.getContents().packageDirectories.length > 1;
+  }
+
+  private doesPackageExist(packagePath: string) {
+    return fs.existsSync(packagePath);
   }
 
   private validateKeys(): void {

--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -33,9 +33,8 @@ import { Crypto } from './crypto';
 import { Logger } from './logger';
 import { Messages } from './messages';
 import { SfdxError } from './sfdxError';
-import { SfdxProject } from './sfdxProject';
+import { SfdxProject, SfdxProjectJson } from './sfdxProject';
 import { CometClient, CometSubscription, StreamingExtension } from './status/streamingClient';
-import { fs } from './util/fs';
 
 /**
  * Different parts of the system that are mocked out. They can be restored for
@@ -345,7 +344,7 @@ export const stubContext = (testContext: TestContext) => {
     testContext.rootPathRetrieverSync(isGlobal, testContext.id)
   );
 
-  testContext.SANDBOXES.DEFAULT.stub(fs, 'existsSync').callsFake(() => true);
+  stubMethod(testContext.SANDBOXES.PROJECT, SfdxProjectJson.prototype, 'doesPackageExist').callsFake(() => true);
 
   const initStubForRead = (configFile: ConfigFile<ConfigFile.Options>): ConfigStub => {
     const stub: ConfigStub = testContext.configStubs[configFile.constructor.name] || {};

--- a/test/unit/projectTest.ts
+++ b/test/unit/projectTest.ts
@@ -230,11 +230,52 @@ describe('SfdxProject', () => {
       const sfdxProject = await project.retrieveSfdxProjectJson();
       expect(sfdxProject.getPath()).to.equal(`/path/${SfdxProjectJson.getFileName()}`);
     });
+    it('with path in project', async () => {
+      $$.SANDBOXES.PROJECT.restore();
+      const resolveStub = $$.SANDBOX.stub(SfdxProject, 'resolveProjectPath');
+      resolveStub.onFirstCall().resolves('/path');
+      resolveStub.onSecondCall().resolves('/path');
+      const project1 = await SfdxProject.resolve('/path');
+      const project2 = await SfdxProject.resolve('/path/in/side/project');
+      expect(project2.getPath()).to.equal('/path');
+      expect(project1).to.equal(project2);
+    });
     it('with path throws with no sfdx-project.json', async () => {
       $$.SANDBOXES.PROJECT.restore();
       $$.SANDBOX.stub(SfdxProject, 'resolveProjectPath').throws(new Error('InvalidProjectWorkspace'));
       try {
         await SfdxProject.resolve();
+        assert.fail();
+      } catch (e) {
+        expect(e.message).to.equal('InvalidProjectWorkspace');
+      }
+    });
+  });
+
+  describe('getInstance', () => {
+    it('with path', async () => {
+      $$.SANDBOXES.PROJECT.restore();
+      $$.SANDBOX.stub(SfdxProject, 'resolveProjectPathSync').returns('/path');
+      const project = SfdxProject.getInstance('/path');
+      expect(project.getPath()).to.equal('/path');
+      const sfdxProject = await project.retrieveSfdxProjectJson();
+      expect(sfdxProject.getPath()).to.equal(`/path/${SfdxProjectJson.getFileName()}`);
+    });
+    it('with path in project', async () => {
+      $$.SANDBOXES.PROJECT.restore();
+      const resolveStub = $$.SANDBOX.stub(SfdxProject, 'resolveProjectPathSync');
+      resolveStub.onFirstCall().returns('/path');
+      resolveStub.onSecondCall().returns('/path');
+      const project1 = SfdxProject.getInstance('/path');
+      const project2 = SfdxProject.getInstance('/path/in/side/project');
+      expect(project2.getPath()).to.equal('/path');
+      expect(project1).to.equal(project2);
+    });
+    it('with path throws with no sfdx-project.json', async () => {
+      $$.SANDBOXES.PROJECT.restore();
+      $$.SANDBOX.stub(SfdxProject, 'resolveProjectPathSync').throws(new Error('InvalidProjectWorkspace'));
+      try {
+        SfdxProject.getInstance();
         assert.fail();
       } catch (e) {
         expect(e.message).to.equal('InvalidProjectWorkspace');


### PR DESCRIPTION
Converting `salesforce-alm` to the exposure grateful-fs methods surfaced some mocking issues and other various bugs. Fix them all so we can update core usage in `salesforce-alm`.