### PR TITLE
feat: allow setting allowedProperties on config

### DIFF
--- a/test/unit/config/configTest.ts
+++ b/test/unit/config/configTest.ts
@@ -201,4 +201,43 @@ describe('Config', () => {
       expect(writeStub.called).to.be.true;
     });
   });
+
+  describe('allowed properties', () => {
+    let originalAllowedProperties;
+
+    beforeEach(() => {
+      originalAllowedProperties = (Config as any).allowedProperties;
+      (Config as any).allowedProperties = [];
+    });
+
+    afterEach(() => {
+      (Config as any).allowedProperties = originalAllowedProperties;
+    });
+
+    it('has default properties assigned', () => {
+      expect(originalAllowedProperties.length).to.be.greaterThan(0);
+
+      expect(
+        originalAllowedProperties.some((meta) => meta.key === 'instanceUrl'),
+        'it has one of the default allowed properties'
+      ).to.be.true;
+    });
+
+    it('can add allowed properties', () => {
+      const configMetas = [
+        {
+          key: 'hello',
+          hidden: false,
+          encrypted: false,
+        },
+      ];
+
+      Config.addAllowedProperties(configMetas);
+      const addedConfigMeta = Config.getAllowedProperties().find((configMeta) => configMeta.key === 'hello');
+
+      expect(addedConfigMeta.key).to.equal('hello');
+      expect(addedConfigMeta.hidden).to.equal(false);
+      expect(addedConfigMeta.encrypted).to.equal(false);
+    });
+  });
 });


### PR DESCRIPTION
## What does this PR do?
This PR adds `addAllowedProperties` static method to the `Config` class to allow the dynamic addition of `ConfigPropertyMeta` values. This supports `plugin-config` to be able load files containing the `ConfigPropertyMeta` definitions and support plugins defining their own keys (https://github.com/salesforcecli/plugin-config/pull/15)

* `addAllowedProperties` will only add `ConfigPropertyMeta` for `key` values that do not already exist in `allowedProperties`
* The default set of `allowedProperties` has been moved from the being set by the constructor and is now set on `Config` directly
* `propertyConfigMap` is changed to being a getter based on the `allowedProperties`

⚠️ Following the merging of this PR the following will need to be updated to the latest version of sfdx-core:
* `plugin-config` https://github.com/salesforcecli/plugin-config/pull/15
* `@salesforce/command`

## What issues does this PR fix or reference?
@W-7187253@