### PR TITLE
fix: single package entry is defaulted to default package @W-8222081@

### DIFF
--- a/messages/config.json
+++ b/messages/config.json
@@ -14,5 +14,6 @@
   "InvalidPackageDirectory": "The path %s, specified in sfdx-project.json, does not exist. Be sure this directory is included in your project root.",
   "InvalidAbsolutePath": "The path %s, specified in sfdx-project.json, must be indicated as a relative path to the project root.",
   "MultipleDefaultPaths": "In sfdx-project.json, indicate only one package directory (path) as the default.",
-  "InvalidWrite": "The writeSync method is not allowed on SfdxConfig. Use the async write method instead."
+  "InvalidWrite": "The writeSync method is not allowed on SfdxConfig. Use the async write method instead.",
+  "SingleNonDefaultPackage": "The sfdx-project.json file must include one, and only one, default package directory (path). Because your sfdx-project.json file contains only one package directory, it must be the default. Remove the '\"default\": false' key and try again."
 }

--- a/src/sfdxProject.ts
+++ b/src/sfdxProject.ts
@@ -248,8 +248,17 @@ export class SfdxProjectJson extends ConfigFile<ConfigFile.Options> {
       return Object.assign({}, packageDir, { name, path, fullPath });
     });
 
-    const defaultDirs = packageDirs.filter((packageDir) => packageDir.default);
+    // If we only have one package entry, it must be the default even if not explicitly labelled
+    if (packageDirs.length === 1) {
+      if (packageDirs[0].default === false) {
+        // we have one package but it is explicitly labelled as default=false
+        throw new SfdxError(this.messages.getMessage('SingleNonDefaultPackage'));
+      }
+      // add default=true to the package
+      packageDirs[0].default = true;
+    }
 
+    const defaultDirs = packageDirs.filter((packageDir) => packageDir.default);
     // Don't throw about a missing default path if we are in the global file.
     // Package directories are not really meant to be set at the global level.
     if (defaultDirs.length === 0 && !this.isGlobal()) {


### PR DESCRIPTION
if a there's only one package entry in `sfdx-project.json` and it doesn't include `default: true` we will now assume that it is the default