### PR TITLE
fix: audiences use instanceURL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.15.3](https://github.com/forcedotcom/sfdx-core/compare/v2.15.2...v2.15.3) (2020-12-02)
+
+
+### Bug Fixes
+
+* added docs around MyDomainResolver constructor method ([68d8e52](https://github.com/forcedotcom/sfdx-core/commit/68d8e520353dae10cda4b04153ec7cc753cbc02a))
+* single package entry is defaulted to default package ([badff89](https://github.com/forcedotcom/sfdx-core/commit/badff89be92c492d990dc91ce79ff94eb88a7117))
+
 ### [2.15.2](https://github.com/forcedotcom/sfdx-core/compare/v2.15.1...v2.15.2) (2020-11-11)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/core",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "description": "Core libraries to interact with SFDX projects, orgs, and APIs.",
   "main": "lib/exported",
   "license": "BSD-3-Clause",

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -228,6 +228,7 @@ function getJwtAudienceUrl(options: OAuth2Options & { createdOrgInstance?: strin
     options.loginUrl?.includes('sandbox.my.salesforce.com') || // enhanced domains >= 230
     options.loginUrl?.match(/([Cc][Ss][0-9]+.my.salesforce.com)/g) || // my domains
     options.loginUrl?.match(/([Cc][Ss][0-9]+.salesforce.com)/g) || // instance without my domain
+    options.loginUrl?.match(/((usa)[0-9]+s\..+\.salesforce\.com)/g) || // falcon sandbox ex: usa2s.sfdc-whatever.salesforce.com
     (options.loginUrl && urlParse(options.loginUrl).hostname === 'test.salesforce.com')
   ) {
     return SfdcUrl.SANDBOX;

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -226,7 +226,7 @@ function getJwtAudienceUrl(options: OAuth2Options & { createdOrgInstance?: strin
     createdOrgInstance.startsWith('cs') ||
     createdOrgInstance.endsWith('s') ||
     options.loginUrl?.includes('sandbox.my.salesforce.com') || // enhanced domains >= 230
-    options.loginUrl?.match(/(cs[0-9]+.my.salesforce.com)/g) ||
+    options.loginUrl?.match(/([Cc][Ss][0-9]+.my.salesforce.com)/g) ||
     (options.loginUrl && urlParse(options.loginUrl).hostname === 'test.salesforce.com')
   ) {
     return SfdcUrl.SANDBOX;

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -225,6 +225,7 @@ function getJwtAudienceUrl(options: OAuth2Options & { createdOrgInstance?: strin
   if (
     createdOrgInstance.startsWith('cs') ||
     createdOrgInstance.endsWith('s') ||
+    options.loginUrl?.includes('sandbox.my.salesforce.com') || // enhanced domains >= 230
     options.loginUrl?.match(/(cs[0-9]+.my.salesforce.com)/g) ||
     (options.loginUrl && urlParse(options.loginUrl).hostname === 'test.salesforce.com')
   ) {

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -228,7 +228,7 @@ function getJwtAudienceUrl(options: OAuth2Options & { createdOrgInstance?: strin
     createdOrgInstance.endsWith('s') ||
     loginUrlLowercased?.includes('sandbox.my.salesforce.com') || // enhanced domains >= 230
     loginUrlLowercased?.match(/(cs[0-9]+(\.my|)\.salesforce\.com)/g) || // my domains on CS instance OR CS instance without my domain
-    loginUrlLowercased?.match(/(usa[0-9]+s\..+\.salesforce\.com)/g) || // falcon sandbox ex: usa2s.sfdc-whatever.salesforce.com
+    loginUrlLowercased?.match(/((usa|ind|aus)[0-9]+s\..+\.salesforce\.com)/g) || // falcon sandbox ex: usa2s.sfdc-whatever.salesforce.com
     (options.loginUrl && urlParse(options.loginUrl).hostname === 'test.salesforce.com')
   ) {
     return SfdcUrl.SANDBOX;

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -229,7 +229,7 @@ function getJwtAudienceUrl(options: OAuth2Options & { createdOrgInstance?: strin
     createdOrgInstance.endsWith('s') ||
     loginUrlLowercased?.includes('sandbox.my.salesforce.com') || // enhanced domains >= 230
     loginUrlLowercased?.match(/(cs[0-9]+(\.my|)\.salesforce\.com)/g) || // my domains on CS instance OR CS instance without my domain
-    loginUrlLowercased?.match(/((usa|ind|aus)[0-9]+s\..+\.salesforce\.com)/g) || // falcon sandbox ex: usa2s.sfdc-whatever.salesforce.com
+    loginUrlLowercased?.match(/([a-z]{3}[0-9]+s\.sfdc-.+\.salesforce\.com)/g) || // falcon sandbox ex: usa2s.sfdc-whatever.salesforce.com
     (options.loginUrl && urlParse(options.loginUrl).hostname === 'test.salesforce.com')
   ) {
     return SfdcUrl.SANDBOX;

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -226,7 +226,8 @@ function getJwtAudienceUrl(options: OAuth2Options & { createdOrgInstance?: strin
     createdOrgInstance.startsWith('cs') ||
     createdOrgInstance.endsWith('s') ||
     options.loginUrl?.includes('sandbox.my.salesforce.com') || // enhanced domains >= 230
-    options.loginUrl?.match(/([Cc][Ss][0-9]+.my.salesforce.com)/g) ||
+    options.loginUrl?.match(/([Cc][Ss][0-9]+.my.salesforce.com)/g) || // my domains
+    options.loginUrl?.match(/([Cc][Ss][0-9]+.salesforce.com)/g) || // instance without my domain
     (options.loginUrl && urlParse(options.loginUrl).hostname === 'test.salesforce.com')
   ) {
     return SfdcUrl.SANDBOX;

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -222,12 +222,13 @@ function getJwtAudienceUrl(options: OAuth2Options & { createdOrgInstance?: strin
   }
 
   const createdOrgInstance = getString(options, 'createdOrgInstance', '').trim().toLowerCase();
+  const loginUrlLowercased = options.loginUrl?.toLowerCase();
   if (
     createdOrgInstance.startsWith('cs') ||
     createdOrgInstance.endsWith('s') ||
-    options.loginUrl?.includes('sandbox.my.salesforce.com') || // enhanced domains >= 230
-    options.loginUrl?.match(/([Cc][Ss][0-9]+(\.my|)\.salesforce\.com)/g) || // my domains on CS instance OR CS instance without my domain
-    options.loginUrl?.match(/((usa)[0-9]+s\..+\.salesforce\.com)/g) || // falcon sandbox ex: usa2s.sfdc-whatever.salesforce.com
+    loginUrlLowercased?.includes('sandbox.my.salesforce.com') || // enhanced domains >= 230
+    loginUrlLowercased?.match(/(cs[0-9]+(\.my|)\.salesforce\.com)/g) || // my domains on CS instance OR CS instance without my domain
+    loginUrlLowercased?.match(/(usa[0-9]+s\..+\.salesforce\.com)/g) || // falcon sandbox ex: usa2s.sfdc-whatever.salesforce.com
     (options.loginUrl && urlParse(options.loginUrl).hostname === 'test.salesforce.com')
   ) {
     return SfdcUrl.SANDBOX;

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -226,8 +226,7 @@ function getJwtAudienceUrl(options: OAuth2Options & { createdOrgInstance?: strin
     createdOrgInstance.startsWith('cs') ||
     createdOrgInstance.endsWith('s') ||
     options.loginUrl?.includes('sandbox.my.salesforce.com') || // enhanced domains >= 230
-    options.loginUrl?.match(/([Cc][Ss][0-9]+.my.salesforce.com)/g) || // my domains
-    options.loginUrl?.match(/([Cc][Ss][0-9]+.salesforce.com)/g) || // instance without my domain
+    options.loginUrl?.match(/([Cc][Ss][0-9]+(\.my|)\.salesforce\.com)/g) || // my domains on CS instance OR CS instance without my domain
     options.loginUrl?.match(/((usa)[0-9]+s\..+\.salesforce\.com)/g) || // falcon sandbox ex: usa2s.sfdc-whatever.salesforce.com
     (options.loginUrl && urlParse(options.loginUrl).hostname === 'test.salesforce.com')
   ) {

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -1672,6 +1672,22 @@ describe('AuthInfo', () => {
       await runTest({ loginUrl: 'https://customdomain.my.salesforce.com' }, 'https://login.salesforce.com');
     });
 
+    it('should use the correct audience URL for scratch orgs with domains', async () => {
+      await runTest({ loginUrl: 'https://cs17.my.salesforce.com' }, 'https://test.salesforce.com');
+    });
+
+    it('should use the correct audience URL for scratch orgs with domains (capitalized)', async () => {
+      await runTest({ loginUrl: 'https://CS17.my.salesforce.com' }, 'https://test.salesforce.com');
+    });
+
+    it('should use the correct audience URL for scratch orgs without domains', async () => {
+      await runTest({ loginUrl: 'https://cs17.salesforce.com' }, 'https://test.salesforce.com');
+    });
+
+    it('should use the correct audience URL for scratch orgs without domains (capitalized)', async () => {
+      await runTest({ loginUrl: 'https://CS17.salesforce.com' }, 'https://test.salesforce.com');
+    });
+
     it('should use the correct audience URL for sandbox enhanced domains', async () => {
       await runTest(
         { loginUrl: 'https://customdomain--sandboxname.sandbox.my.salesforce.com' },

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -1652,6 +1652,10 @@ describe('AuthInfo', () => {
       await runTest({ createdOrgInstance: 'cs17' }, 'https://test.salesforce.com');
     });
 
+    it('should use the correct audience URL for createdOrgInstance beginning with "CS"', async () => {
+      await runTest({ createdOrgInstance: 'CS17' }, 'https://test.salesforce.com');
+    });
+
     it('should use the correct audience URL for createdOrgInstance ending with "s"', async () => {
       await runTest({ createdOrgInstance: 'usa2s' }, 'https://test.salesforce.com');
     });

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -1681,6 +1681,14 @@ describe('AuthInfo', () => {
         await runTest({ loginUrl: 'https://cs17.salesforce.com' }, 'https://test.salesforce.com');
       });
 
+      it('should use the correct audience URL for a typical scratch org domain', async () => {
+        await runTest(
+          { loginUrl: 'https://computing-nosoftware-9542-dev-ed.cs77.my.salesforce.com' },
+          'https://test.salesforce.com'
+        );
+      });
+      it;
+
       it('should use the correct audience URL for scratch orgs without domains (capitalized)', async () => {
         await runTest({ loginUrl: 'https://CS17.salesforce.com' }, 'https://test.salesforce.com');
       });

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -1615,53 +1615,98 @@ describe('AuthInfo', () => {
       expect(signStub.firstCall.args[0]).to.have.property('aud', expectedUrl);
     }
 
+    describe('internal urls', () => {
+      it('should use the correct audience URL for an internal URL (.internal)', async () => {
+        await runTest({ loginUrl: testMetadata.instanceUrl }, testMetadata.instanceUrl);
+      });
+
+      it('should use the correct audience URL for an internal URL (.vpod)', async () => {
+        const vpodUrl = 'http://mydevhub.vpod.salesforce.com';
+        await runTest({ loginUrl: vpodUrl }, vpodUrl);
+      });
+
+      it('should use the correct audience URL for an internal URL (.blitz)', async () => {
+        const blitzUrl = 'http://mydevhub.blitz.salesforce.com';
+        await runTest({ loginUrl: blitzUrl }, blitzUrl);
+      });
+
+      it('should use the correct audience URL for an internal URL (.stm)', async () => {
+        const stmUrl = 'http://mydevhub.stm.salesforce.com';
+        await runTest({ loginUrl: stmUrl }, stmUrl);
+      });
+
+      it('should use the correct audience URL for an internal URL (.mobile1)', async () => {
+        const mobile1Url = 'http://mobile1.t.salesforce.com';
+        await runTest({ loginUrl: mobile1Url }, mobile1Url);
+      });
+    });
+
+    describe('sandboxes', () => {
+      it('should use the correct audience URL for a sandbox', async () => {
+        await runTest({ loginUrl: 'http://test.salesforce.com/foo/bar' }, 'https://test.salesforce.com');
+      });
+
+      it('should use the correct audience URL for createdOrgInstance beginning with "cs"', async () => {
+        await runTest({ createdOrgInstance: 'cs17' }, 'https://test.salesforce.com');
+      });
+
+      it('should use the correct audience URL for createdOrgInstance beginning with "CS"', async () => {
+        await runTest({ createdOrgInstance: 'CS17' }, 'https://test.salesforce.com');
+      });
+
+      it('should use the correct audience URL for createdOrgInstance ending with "s"', async () => {
+        await runTest({ createdOrgInstance: 'usa2s' }, 'https://test.salesforce.com');
+      });
+
+      it('should use the correct audience URL for createdOrgInstance capitalized and ending with "s"', async () => {
+        await runTest({ createdOrgInstance: 'IND2S' }, 'https://test.salesforce.com');
+      });
+
+      it('should use the correct audience URL for sandbox enhanced domains', async () => {
+        await runTest(
+          { loginUrl: 'https://customdomain--sandboxname.sandbox.my.salesforce.com' },
+          'https://test.salesforce.com'
+        );
+      });
+
+      it('should use the correct audience URL for scratch orgs with domains', async () => {
+        await runTest({ loginUrl: 'https://cs17.my.salesforce.com' }, 'https://test.salesforce.com');
+      });
+
+      it('should use the correct audience URL for scratch orgs with domains (capitalized)', async () => {
+        await runTest({ loginUrl: 'https://CS17.my.salesforce.com' }, 'https://test.salesforce.com');
+      });
+
+      it('should use the correct audience URL for scratch orgs without domains', async () => {
+        await runTest({ loginUrl: 'https://cs17.salesforce.com' }, 'https://test.salesforce.com');
+      });
+
+      it('should use the correct audience URL for scratch orgs without domains (capitalized)', async () => {
+        await runTest({ loginUrl: 'https://CS17.salesforce.com' }, 'https://test.salesforce.com');
+      });
+    });
+
+    describe('falcon', () => {
+      it('returns sandbox audience for falcon domains', async () => {
+        await runTest({ loginUrl: 'https://usa2s.sfdc-yfeipo.salesforce.com/' }, 'https://test.salesforce.com');
+      });
+
+      it('returns sandbox audience for falcon domains in india', async () => {
+        await runTest({ loginUrl: 'https://ind2s.sfdc-yfeipo.salesforce.com/' }, 'https://test.salesforce.com');
+      });
+
+      it('returns sandbox audience for weirdly uppercased falcon domains', async () => {
+        await runTest({ loginUrl: 'https://USA2S.sfdc-yfeipo.salesforce.com/' }, 'https://test.salesforce.com');
+      });
+
+      it('returns prod audience for falcon domains', async () => {
+        await runTest({ loginUrl: 'https://usa2.sfdc-yfeipo.salesforce.com/' }, 'https://login.salesforce.com');
+      });
+    });
+
     it('should use the correct audience URL for SFDX_AUDIENCE_URL env var', async () => {
       process.env.SFDX_AUDIENCE_URL = 'http://authInfoTest/audienceUrl/test';
       await runTest({}, process.env.SFDX_AUDIENCE_URL);
-    });
-
-    it('should use the correct audience URL for a sandbox', async () => {
-      await runTest({ loginUrl: 'http://test.salesforce.com/foo/bar' }, 'https://test.salesforce.com');
-    });
-
-    it('should use the correct audience URL for an internal URL (.internal)', async () => {
-      await runTest({ loginUrl: testMetadata.instanceUrl }, testMetadata.instanceUrl);
-    });
-
-    it('should use the correct audience URL for an internal URL (.vpod)', async () => {
-      const vpodUrl = 'http://mydevhub.vpod.salesforce.com';
-      await runTest({ loginUrl: vpodUrl }, vpodUrl);
-    });
-
-    it('should use the correct audience URL for an internal URL (.blitz)', async () => {
-      const blitzUrl = 'http://mydevhub.blitz.salesforce.com';
-      await runTest({ loginUrl: blitzUrl }, blitzUrl);
-    });
-
-    it('should use the correct audience URL for an internal URL (.stm)', async () => {
-      const stmUrl = 'http://mydevhub.stm.salesforce.com';
-      await runTest({ loginUrl: stmUrl }, stmUrl);
-    });
-
-    it('should use the correct audience URL for an internal URL (.mobile1)', async () => {
-      const mobile1Url = 'http://mobile1.t.salesforce.com';
-      await runTest({ loginUrl: mobile1Url }, mobile1Url);
-    });
-
-    it('should use the correct audience URL for createdOrgInstance beginning with "cs"', async () => {
-      await runTest({ createdOrgInstance: 'cs17' }, 'https://test.salesforce.com');
-    });
-
-    it('should use the correct audience URL for createdOrgInstance beginning with "CS"', async () => {
-      await runTest({ createdOrgInstance: 'CS17' }, 'https://test.salesforce.com');
-    });
-
-    it('should use the correct audience URL for createdOrgInstance ending with "s"', async () => {
-      await runTest({ createdOrgInstance: 'usa2s' }, 'https://test.salesforce.com');
-    });
-
-    it('should use the correct audience URL for createdOrgInstance capitalized and ending with "s"', async () => {
-      await runTest({ createdOrgInstance: 'IND2S' }, 'https://test.salesforce.com');
     });
 
     it('should use the correct audience URL for createdOrgInstance beginning with "gs1"', async () => {
@@ -1670,41 +1715,6 @@ describe('AuthInfo', () => {
 
     it('should use the correct audience URL for production enhanced domains', async () => {
       await runTest({ loginUrl: 'https://customdomain.my.salesforce.com' }, 'https://login.salesforce.com');
-    });
-
-    it('should use the correct audience URL for scratch orgs with domains', async () => {
-      await runTest({ loginUrl: 'https://cs17.my.salesforce.com' }, 'https://test.salesforce.com');
-    });
-
-    it('should use the correct audience URL for scratch orgs with domains (capitalized)', async () => {
-      await runTest({ loginUrl: 'https://CS17.my.salesforce.com' }, 'https://test.salesforce.com');
-    });
-
-    it('should use the correct audience URL for scratch orgs without domains', async () => {
-      await runTest({ loginUrl: 'https://cs17.salesforce.com' }, 'https://test.salesforce.com');
-    });
-
-    it('should use the correct audience URL for scratch orgs without domains (capitalized)', async () => {
-      await runTest({ loginUrl: 'https://CS17.salesforce.com' }, 'https://test.salesforce.com');
-    });
-
-    it('should use the correct audience URL for sandbox enhanced domains', async () => {
-      await runTest(
-        { loginUrl: 'https://customdomain--sandboxname.sandbox.my.salesforce.com' },
-        'https://test.salesforce.com'
-      );
-    });
-
-    it('returns sandbox audience for falcon domains', async () => {
-      await runTest({ loginUrl: 'https://usa2s.sfdc-yfeipo.salesforce.com/' }, 'https://test.salesforce.com');
-    });
-
-    it('returns sandbox audience for weirdly uppercased falcon domains', async () => {
-      await runTest({ loginUrl: 'https://USA2S.sfdc-yfeipo.salesforce.com/' }, 'https://test.salesforce.com');
-    });
-
-    it('returns prod audience for falcon domains', async () => {
-      await runTest({ loginUrl: 'https://usa2.sfdc-yfeipo.salesforce.com/' }, 'https://login.salesforce.com');
     });
   });
 

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -1663,6 +1663,17 @@ describe('AuthInfo', () => {
     it('should use the correct audience URL for createdOrgInstance beginning with "gs1"', async () => {
       await runTest({ createdOrgInstance: 'gs1' }, 'https://gs1.salesforce.com');
     });
+
+    it('should use the correct audience URL for production enhanced domains', async () => {
+      await runTest({ loginUrl: 'https://customdomain.my.salesforce.com' }, 'https://login.salesforce.com');
+    });
+
+    it('should use the correct audience URL for sandbox enhanced domains', async () => {
+      await runTest(
+        { loginUrl: 'https://customdomain--sandboxname.sandbox.my.salesforce.com' },
+        'https://test.salesforce.com'
+      );
+    });
   });
 
   describe('getDefaultInstanceUrl', () => {

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -1699,6 +1699,10 @@ describe('AuthInfo', () => {
       await runTest({ loginUrl: 'https://usa2s.sfdc-yfeipo.salesforce.com/' }, 'https://test.salesforce.com');
     });
 
+    it('returns sandbox audience for weirdly uppercased falcon domains', async () => {
+      await runTest({ loginUrl: 'https://USA2S.sfdc-yfeipo.salesforce.com/' }, 'https://test.salesforce.com');
+    });
+
     it('returns prod audience for falcon domains', async () => {
       await runTest({ loginUrl: 'https://usa2.sfdc-yfeipo.salesforce.com/' }, 'https://login.salesforce.com');
     });

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -1694,6 +1694,14 @@ describe('AuthInfo', () => {
         'https://test.salesforce.com'
       );
     });
+
+    it('returns sandbox audience for falcon domains', async () => {
+      await runTest({ loginUrl: 'https://usa2s.sfdc-yfeipo.salesforce.com/' }, 'https://test.salesforce.com');
+    });
+
+    it('returns prod audience for falcon domains', async () => {
+      await runTest({ loginUrl: 'https://usa2.sfdc-yfeipo.salesforce.com/' }, 'https://login.salesforce.com');
+    });
   });
 
   describe('getDefaultInstanceUrl', () => {


### PR DESCRIPTION
@W-8543971@ primary: ignoring the instanceUrl flag in auth:jwt:grant and referencing non-existent properties

https://org62.lightning.force.com/lightning/r/0D50M00004IAqlISAT/view
forcedotcom/cli#217
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000006bEIUIA2/view
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008fosXIAQ/view

leaves the env as an override @amphro 

here's a file for QAing from plugin-auth.  requires a hub connected via jwt-key with some environment variables set.  https://github.com/salesforcecli/plugin-auth/blob/sm/qa-for-jwt-branches/test/commands/auth/jwt/grant.e2e.ts