### PR TITLE
Sm/w 8206747

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -187,8 +187,9 @@ export class Connection extends JSForceConnection {
     await this.isResolvable();
     type Versioned = { version: string };
     const versions = (await this.request(`${this.instanceUrl}/services/data`)) as Versioned[];
-    this.logger.debug(`response for org versions: ${versions}`);
+    this.logger.debug(`response for org versions: ${versions.map((item) => item.version).join(',')}`);
     const max = ensure(maxBy(versions, (version: Versioned) => version.version));
+
     return max.version;
   }
   /**

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -38,6 +38,8 @@ export const SFDX_HTTP_HEADERS = {
   'user-agent': clientId,
 };
 
+const ORG_NOT_FOUND_ERROR_NAME = 'Org Not Found';
+
 // This interface is so we can add the autoFetchQuery method to both the Connection
 // and Tooling classes and get nice typing info for it within editors.  JSForce is
 // unlikely to accept a PR for this method, but that would be another approach.
@@ -196,7 +198,7 @@ export class Connection extends JSForceConnection {
     try {
       this.setApiVersion(await this.retrieveMaxApiVersion());
     } catch (err) {
-      if (err.name === 'Org Not Found') {
+      if (err.name === ORG_NOT_FOUND_ERROR_NAME) {
         throw err; // throws on DNS connection errors
       }
       // Don't fail if we can't use the latest, just use the default
@@ -222,7 +224,7 @@ export class Connection extends JSForceConnection {
       await resolver.resolve();
       return true;
     } catch (e) {
-      throw new SfdxError('The org cannot be found', 'Org Not Found', [
+      throw new SfdxError('The org cannot be found', ORG_NOT_FOUND_ERROR_NAME, [
         'Verify that the org still exists',
         'If your org is newly created, wait a minute and run your command again',
       ]);

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -227,7 +227,7 @@ export class Connection extends JSForceConnection {
       throw new SfdxError('The org cannot be found', DNS_ERROR_NAME, [
         'Verify that the org still exists',
         'If your org is newly created, wait a minute and run your command again',
-        "If you deployed or updated the org's My Domain, update your instanceUrl",
+        "If you deployed or updated the org's My Domain, logout from the CLI and authenticate again",
       ]);
     }
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -38,7 +38,7 @@ export const SFDX_HTTP_HEADERS = {
   'user-agent': clientId,
 };
 
-const ORG_NOT_FOUND_ERROR_NAME = 'Org Not Found';
+const ORG_NOT_FOUND_ERROR_NAME = 'Domain Not Found';
 
 // This interface is so we can add the autoFetchQuery method to both the Connection
 // and Tooling classes and get nice typing info for it within editors.  JSForce is
@@ -227,6 +227,7 @@ export class Connection extends JSForceConnection {
       throw new SfdxError('The org cannot be found', ORG_NOT_FOUND_ERROR_NAME, [
         'Verify that the org still exists',
         'If your org is newly created, wait a minute and run your command again',
+        "If you deployed or updated the org's My Domain, update your instanceUrl",
       ]);
     }
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -38,7 +38,7 @@ export const SFDX_HTTP_HEADERS = {
   'user-agent': clientId,
 };
 
-const ORG_NOT_FOUND_ERROR_NAME = 'Domain Not Found';
+export const DNS_ERROR_NAME = 'Domain Not Found';
 
 // This interface is so we can add the autoFetchQuery method to both the Connection
 // and Tooling classes and get nice typing info for it within editors.  JSForce is
@@ -198,7 +198,7 @@ export class Connection extends JSForceConnection {
     try {
       this.setApiVersion(await this.retrieveMaxApiVersion());
     } catch (err) {
-      if (err.name === ORG_NOT_FOUND_ERROR_NAME) {
+      if (err.name === DNS_ERROR_NAME) {
         throw err; // throws on DNS connection errors
       }
       // Don't fail if we can't use the latest, just use the default
@@ -224,7 +224,7 @@ export class Connection extends JSForceConnection {
       await resolver.resolve();
       return true;
     } catch (e) {
-      throw new SfdxError('The org cannot be found', ORG_NOT_FOUND_ERROR_NAME, [
+      throw new SfdxError('The org cannot be found', DNS_ERROR_NAME, [
         'Verify that the org still exists',
         'If your org is newly created, wait a minute and run your command again',
         "If you deployed or updated the org's My Domain, update your instanceUrl",

--- a/test/unit/connectionTest.ts
+++ b/test/unit/connectionTest.ts
@@ -45,7 +45,7 @@ describe('Connection', () => {
     initializeStub = $$.SANDBOX.stub(jsforce.Connection.prototype, 'initialize').returns();
     requestMock = $$.SANDBOX.stub(jsforce.Connection.prototype, 'request')
       .onFirstCall()
-      .returns(Promise.resolve([{ version: '42.0' }]));
+      .resolves([{ version: '42.0' }]);
   });
 
   it('create() should throw on DNS errors', async () => {
@@ -242,10 +242,11 @@ describe('Connection', () => {
       id: '123',
       name: 'testName',
     };
-    requestMock.returns(Promise.resolve({ totalSize: 1, records: [mockSingleRecord] }));
     const soql = 'TEST_SOQL';
+    requestMock.onSecondCall().resolves({ totalSize: 1, records: [mockSingleRecord] });
 
-    const conn = await Connection.create({ authInfo: testAuthInfo as AuthInfo });
+    const conn = await Connection.create({ authInfo: testAuthInfoWithDomain as AuthInfo });
+
     const queryResult = await conn.singleRecordQuery(soql);
     expect(queryResult).to.deep.equal({
       ...mockSingleRecord,
@@ -254,7 +255,7 @@ describe('Connection', () => {
 
   it('singleRecordQuery throws on no-records', async () => {
     requestMock.returns(Promise.resolve({ totalSize: 0, records: [] }));
-    const conn = await Connection.create({ authInfo: testAuthInfo as AuthInfo });
+    const conn = await Connection.create({ authInfo: testAuthInfoWithDomain as AuthInfo });
 
     try {
       await conn.singleRecordQuery('TEST_SOQL');
@@ -266,7 +267,7 @@ describe('Connection', () => {
 
   it('singleRecordQuery throws on multiple records', async () => {
     requestMock.returns(Promise.resolve({ totalSize: 2, records: [{ id: 1 }, { id: 2 }] }));
-    const conn = await Connection.create({ authInfo: testAuthInfo as AuthInfo });
+    const conn = await Connection.create({ authInfo: testAuthInfoWithDomain as AuthInfo });
 
     try {
       await conn.singleRecordQuery('TEST_SOQL');
@@ -278,7 +279,7 @@ describe('Connection', () => {
 
   it('singleRecordQuery throws on multiple records with options', async () => {
     requestMock.returns(Promise.resolve({ totalSize: 2, records: [{ id: 1 }, { id: 2 }] }));
-    const conn = await Connection.create({ authInfo: testAuthInfo as AuthInfo });
+    const conn = await Connection.create({ authInfo: testAuthInfoWithDomain as AuthInfo });
 
     try {
       await conn.singleRecordQuery('TEST_SOQL', { returnChoicesOnMultiple: true, choiceField: 'id' });
@@ -297,7 +298,7 @@ describe('Connection', () => {
     requestMock.returns(Promise.resolve({ totalSize: 1, records: [mockSingleRecord] }));
     const soql = 'TEST_SOQL';
 
-    const conn = await Connection.create({ authInfo: testAuthInfo as AuthInfo });
+    const conn = await Connection.create({ authInfo: testAuthInfoWithDomain as AuthInfo });
     const toolingQuerySpy = $$.SANDBOX.spy(conn.tooling, 'query');
     const queryResults = await conn.singleRecordQuery(soql, { tooling: true });
     expect(queryResults).to.deep.equal({

--- a/test/unit/connectionTest.ts
+++ b/test/unit/connectionTest.ts
@@ -12,7 +12,7 @@ import { AuthInfo } from '../../src/authInfo';
 import { MyDomainResolver } from '../../src/status/myDomainResolver';
 
 import { ConfigAggregator, ConfigInfo } from '../../src/config/configAggregator';
-import { Connection, SFDX_HTTP_HEADERS } from '../../src/connection';
+import { Connection, SFDX_HTTP_HEADERS, DNS_ERROR_NAME } from '../../src/connection';
 import { testSetup, shouldThrow } from '../../src/testSetup';
 
 // Setup the test environment.
@@ -51,12 +51,12 @@ describe('Connection', () => {
 
   it('create() should throw on DNS errors', async () => {
     $$.SANDBOX.restore();
-    $$.SANDBOX.stub(MyDomainResolver.prototype, 'resolve').rejects({ name: 'Org Not Found' });
+    $$.SANDBOX.stub(MyDomainResolver.prototype, 'resolve').rejects({ name: DNS_ERROR_NAME });
 
     try {
       await shouldThrow(Connection.create({ authInfo: testAuthInfoWithDomain as AuthInfo }));
     } catch (e) {
-      expect(e).to.have.property('name', 'Org Not Found');
+      expect(e).to.have.property('name', DNS_ERROR_NAME);
     }
   });
 

--- a/test/unit/connectionTest.ts
+++ b/test/unit/connectionTest.ts
@@ -12,7 +12,7 @@ import { AuthInfo } from '../../src/authInfo';
 import { MyDomainResolver } from '../../src/status/myDomainResolver';
 import { ConfigAggregator, ConfigInfo } from '../../src/config/configAggregator';
 import { Connection, SFDX_HTTP_HEADERS, DNS_ERROR_NAME, SingleRecordQueryErrors } from '../../src/connection';
-import { testSetup, shouldThrow } from '../../src/testSetup'
+import { testSetup, shouldThrow } from '../../src/testSetup';
 
 // Setup the test environment.
 const $$ = testSetup();

--- a/test/unit/connectionTest.ts
+++ b/test/unit/connectionTest.ts
@@ -10,7 +10,6 @@ import { assert, expect } from 'chai';
 import * as jsforce from 'jsforce';
 import { AuthInfo } from '../../src/authInfo';
 import { MyDomainResolver } from '../../src/status/myDomainResolver';
-
 import { ConfigAggregator, ConfigInfo } from '../../src/config/configAggregator';
 import { Connection, SFDX_HTTP_HEADERS, DNS_ERROR_NAME } from '../../src/connection';
 import { testSetup, shouldThrow } from '../../src/testSetup';

--- a/test/unit/orgTest.ts
+++ b/test/unit/orgTest.ts
@@ -27,6 +27,7 @@ import { Global } from '../../src/global';
 import { Org } from '../../src/org';
 import { MockTestOrgData, testSetup } from '../../src/testSetup';
 import { fs } from '../../src/util/fs';
+import { MyDomainResolver } from '../../src/status/myDomainResolver';
 
 const $$ = testSetup();
 
@@ -38,6 +39,8 @@ describe('Org Tests', () => {
   beforeEach(async () => {
     testData = new MockTestOrgData();
     $$.configStubs.AuthInfoConfig = { contents: await testData.getConfig() };
+    $$.SANDBOX.stub(MyDomainResolver.prototype, 'resolve').resolves('1.1.1.1');
+
     stubMethod($$.SANDBOX, Connection.prototype, 'useLatestApiVersion').returns(Promise.resolve());
   });
 
@@ -122,6 +125,9 @@ describe('Org Tests', () => {
       const org: Org = await Org.create({
         connection: await Connection.create({
           authInfo: await AuthInfo.create({ username: testData.username }),
+          connectionOptions: {
+            instanceUrl: 'https://orgTest.instanceUrl',
+          },
         }),
       });
       const apiVersion = await org.retrieveMaxApiVersion();


### PR DESCRIPTION
@W-8206747@

I hate everything about this fix.  From what I can tell, the stuff leaking into the stdout isn't from us, it's from jsforce > request > asap

![Screen Shot 2020-12-22 at 4 00 26 PM](https://user-images.githubusercontent.com/4261788/102937003-cfe64c80-446e-11eb-96cf-46045420c750.png)

Asap hasn't been updated in years and request is deprecated.  This'll happen whenever jsforce.request tries to use a domain that no longer exists and gets a DNS ENOTFOUND.

You can most easily repo by creating a sandbox, authing to it, and then deleting it, and then waiting for a while for it to be destroyed.

After a few tries, the best option I could think of is to pre-check a DNS using our existing domainResolver.  This required a number of updates to unit tests (where instanceUrl must exist to get past the pre-check).  It was either that or a serious rewrite the tests in a major way.

