### PR TITLE
feat: singleRecordQuery

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -317,7 +317,7 @@ export class Connection extends JSForceConnection {
     }
     if (result.totalSize > 1) {
       throw new SfdxError(
-        options.returnChoicesOnMultiple && options.choiceField
+        options.returnChoicesOnMultiple
           ? `Multiple records found. ${result.records.map((item) => item[options.choiceField as keyof T]).join(',')}`
           : 'The query returned more than 1 record',
         SingleRecordQueryErrors.MultipleRecords

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -313,14 +313,12 @@ export class Connection extends JSForceConnection {
   ): Promise<T> {
     const result = options.tooling ? await this.tooling.query<T>(soql) : await this.query<T>(soql);
     if (result.totalSize === 0) {
-      throw new SfdxError(`No records found for ${soql}`, SingleRecordQueryErrors.NoRecords);
+      throw new SfdxError(`No record found for ${soql}`, SingleRecordQueryErrors.NoRecords);
     }
     if (result.totalSize > 1) {
       throw new SfdxError(
         options.returnChoicesOnMultiple && options.choiceField
-          ? `Multiple records found. ${result.records
-              .map((item) => item[(options.choiceField ?? 'Name') as keyof T])
-              .join(',')}`
+          ? `Multiple records found. ${result.records.map((item) => item[options.choiceField as keyof T]).join(',')}`
           : 'The query returned more than 1 record',
         SingleRecordQueryErrors.MultipleRecords
       );

--- a/test/unit/connectionTest.ts
+++ b/test/unit/connectionTest.ts
@@ -265,7 +265,6 @@ describe('Connection', () => {
       name: 'testName',
     };
     requestMock.returns(Promise.resolve({ totalSize: 1, records: [mockSingleRecord] }));
-    // const querySpy = $$.SANDBOX.spy(jsforce.Connection.prototype, 'query');
     const soql = 'TEST_SOQL';
 
     const conn = await Connection.create({ authInfo: testAuthInfo as AuthInfo });

--- a/test/unit/connectionTest.ts
+++ b/test/unit/connectionTest.ts
@@ -10,7 +10,7 @@ import { assert, expect } from 'chai';
 import * as jsforce from 'jsforce';
 import { AuthInfo } from '../../src/authInfo';
 import { ConfigAggregator, ConfigInfo } from '../../src/config/configAggregator';
-import { Connection, SFDX_HTTP_HEADERS } from '../../src/connection';
+import { Connection, SFDX_HTTP_HEADERS, SingleRecordQueryErrors } from '../../src/connection';
 import { testSetup } from '../../src/testSetup';
 
 // Setup the test environment.
@@ -205,5 +205,75 @@ describe('Connection', () => {
     } catch (err) {
       expect(err.message).to.equal(errorMsg);
     }
+  });
+
+  it('singleRecordQuery returns single-record result properly', async () => {
+    const mockSingleRecord = {
+      id: '123',
+      name: 'testName',
+    };
+    requestMock.returns(Promise.resolve({ totalSize: 1, records: [mockSingleRecord] }));
+    const soql = 'TEST_SOQL';
+
+    const conn = await Connection.create({ authInfo: testAuthInfo as AuthInfo });
+    const queryResult = await conn.singleRecordQuery(soql);
+    expect(queryResult).to.deep.equal({
+      ...mockSingleRecord,
+    });
+  });
+
+  it('singleRecordQuery throws on no-records', async () => {
+    requestMock.returns(Promise.resolve({ totalSize: 0, records: [] }));
+    const conn = await Connection.create({ authInfo: testAuthInfo as AuthInfo });
+
+    try {
+      await conn.singleRecordQuery('TEST_SOQL');
+      assert.fail('SingleRecordQuery query should have errored.');
+    } catch (err) {
+      expect(err.name).to.equal(SingleRecordQueryErrors.NoRecords);
+    }
+  });
+
+  it('singleRecordQuery throws on multiple records', async () => {
+    requestMock.returns(Promise.resolve({ totalSize: 2, records: [{ id: 1 }, { id: 2 }] }));
+    const conn = await Connection.create({ authInfo: testAuthInfo as AuthInfo });
+
+    try {
+      await conn.singleRecordQuery('TEST_SOQL');
+      assert.fail('singleRecordQuery should have errored.');
+    } catch (err) {
+      expect(err.name).to.equal(SingleRecordQueryErrors.MultipleRecords);
+    }
+  });
+
+  it('singleRecordQuery throws on multiple records with options', async () => {
+    requestMock.returns(Promise.resolve({ totalSize: 2, records: [{ id: 1 }, { id: 2 }] }));
+    const conn = await Connection.create({ authInfo: testAuthInfo as AuthInfo });
+
+    try {
+      await conn.singleRecordQuery('TEST_SOQL', { returnChoicesOnMultiple: true, choiceField: 'id' });
+      assert.fail('singleRecordQuery should have errored.');
+    } catch (err) {
+      expect(err.name).to.equal(SingleRecordQueryErrors.MultipleRecords);
+      expect(err.message).to.include('1,2');
+    }
+  });
+
+  it('singleRecordQuery handles tooling api flag', async () => {
+    const mockSingleRecord = {
+      id: '123',
+      name: 'testName',
+    };
+    requestMock.returns(Promise.resolve({ totalSize: 1, records: [mockSingleRecord] }));
+    // const querySpy = $$.SANDBOX.spy(jsforce.Connection.prototype, 'query');
+    const soql = 'TEST_SOQL';
+
+    const conn = await Connection.create({ authInfo: testAuthInfo as AuthInfo });
+    const toolingQuerySpy = $$.SANDBOX.spy(conn.tooling, 'query');
+    const queryResults = await conn.singleRecordQuery(soql, { tooling: true });
+    expect(queryResults).to.deep.equal({
+      ...mockSingleRecord,
+    });
+    expect(toolingQuerySpy.firstCall.args[0]).to.equal(soql);
   });
 });


### PR DESCRIPTION
Add a function to Connection.  @W-8529337@

Several plugins use conn.query get results back and optimistically use records[0].  This reduces duplicative checks and messaging for 0 and >1 records.