### PR TITLE
chore: remove circle merge step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ workflows:
       - release-management/release-package:
           github-release: true
           post-job-steps:
-            - release-management/merge
             - run: yarn ci-docs
           requires:
             - node-latest


### PR DESCRIPTION
@W-8667882@

Tweak to previously merged branch.  Hard to QA circle changes without actually running them.
Removes the /merge step which 
1. is no longer needed without a develop branch when we just merge into main
2. defaults to develop -> master