### PR TITLE
refactor: move isInternalUrl to sfdc

### DIFF
--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -199,18 +199,6 @@ export enum SfdcUrl {
   PRODUCTION = 'https://login.salesforce.com',
 }
 
-const INTERNAL_URL_PARTS = [
-  '.internal.',
-  '.vpod.',
-  'stm.salesforce.com',
-  '.blitz.salesforce.com',
-  'mobile1.t.salesforce.com',
-];
-
-function isInternalUrl(loginUrl = ''): boolean {
-  return loginUrl.startsWith('https://gs1.') || INTERNAL_URL_PARTS.some((part) => loginUrl.includes(part));
-}
-
 function getJwtAudienceUrl(options: OAuth2Options) {
   // default audience must be...
   let audienceUrl: string = SfdcUrl.PRODUCTION;
@@ -219,7 +207,7 @@ function getJwtAudienceUrl(options: OAuth2Options) {
 
   if (process.env.SFDX_AUDIENCE_URL) {
     audienceUrl = process.env.SFDX_AUDIENCE_URL;
-  } else if (isInternalUrl(loginUrl)) {
+  } else if (sfdc.isInternalUrl(loginUrl)) {
     // This is for internal developers when just doing authorize;
     audienceUrl = loginUrl;
   } else if (

--- a/src/util/sfdc.ts
+++ b/src/util/sfdc.ts
@@ -120,4 +120,21 @@ export const sfdc = {
   matchesAccessToken: (value: string): boolean => {
     return /^(00D\w{12,15})![.\w]*$/.test(value);
   },
+
+  /**
+   * Tests whether a given url is an internal Salesforce domain
+   *
+   * @param url
+   */
+  isInternalUrl: (url: string): boolean => {
+    const INTERNAL_URL_PARTS = [
+      '.internal.',
+      '.vpod.',
+      'stm.salesforce.com',
+      '.blitz.salesforce.com',
+      'mobile1.t.salesforce.com',
+    ];
+
+    return url.startsWith('https://gs1.') || INTERNAL_URL_PARTS.some((part) => url.includes(part));
+  },
 };

--- a/src/util/sfdc.ts
+++ b/src/util/sfdc.ts
@@ -127,13 +127,7 @@ export const sfdc = {
    * @param url
    */
   isInternalUrl: (url: string): boolean => {
-    const INTERNAL_URL_PARTS = [
-      '.internal.',
-      '.vpod.',
-      'stm.salesforce.com',
-      '.blitz.salesforce.com',
-      'mobile1.t.salesforce.com',
-    ];
+    const INTERNAL_URL_PARTS = ['.internal.', '.vpod.', 'stm.salesforce.com', '.blitz.salesforce.com'];
 
     return url.startsWith('https://gs1.') || INTERNAL_URL_PARTS.some((part) => url.includes(part));
   },

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -1643,11 +1643,6 @@ describe('AuthInfo', () => {
       await runTest({ loginUrl: stmUrl }, stmUrl);
     });
 
-    it('should use the correct audience URL for an internal URL (.mobile1)', async () => {
-      const mobile1Url = 'http://mobile1.t.salesforce.com';
-      await runTest({ loginUrl: mobile1Url }, mobile1Url);
-    });
-
     it('should use the correct audience URL for createdOrgInstance beginning with "cs"', async () => {
       await runTest({ createdOrgInstance: 'cs17' }, 'https://test.salesforce.com');
     });


### PR DESCRIPTION
@W-8792196@ 

centralizes internal domains and exports via sfdc for all plugins to use