### PR TITLE
fix: send oauth error to browser

### DIFF
--- a/messages/auth.json
+++ b/messages/auth.json
@@ -10,5 +10,6 @@
   "invalidRequestMethod": "Invalid request method: %s",
   "invalidRequestUri": "Invalid request uri: %s",
   "pollingTimeout": "The device authorization request timed out. After executing force:auth:device:login, you must approve access to the device within 10 minutes.  This can happen if the URL wasn’t copied into the browser, login was not attempted, or the 2FA process was not completed within 10 minutes. Request authorization again.",
-  "ServerErrorHTMLResponse": "<h1>%s</h1><br />This is most likely <b>not</b> an error with the Salesforce CLI. Please ensure all information is accurate and try again."
+  "serverErrorHTMLResponse": "<h1>%s</h1><br />This is most likely <b>not</b> an error with the Salesforce CLI. Please ensure all information is accurate and try again.",
+  "missingAuthCode": "No authentication code found on login response."
 }

--- a/messages/auth.json
+++ b/messages/auth.json
@@ -9,5 +9,6 @@
   "PortInUseAction": "Kill the process running on port %s or use a custom connected app and update OauthLocalPort in the sfdx-project.json file.",
   "invalidRequestMethod": "Invalid request method: %s",
   "invalidRequestUri": "Invalid request uri: %s",
-  "pollingTimeout": "The device authorization request timed out. After executing force:auth:device:login, you must approve access to the device within 10 minutes.  This can happen if the URL wasn’t copied into the browser, login was not attempted, or the 2FA process was not completed within 10 minutes. Request authorization again."
+  "pollingTimeout": "The device authorization request timed out. After executing force:auth:device:login, you must approve access to the device within 10 minutes.  This can happen if the URL wasn’t copied into the browser, login was not attempted, or the 2FA process was not completed within 10 minutes. Request authorization again.",
+  "ServerErrorHTMLResponse": "<h1>%s</h1><br />This is most likely <b>not</b> an error with the Salesforce CLI. Please ensure all information is accurate and try again."
 }

--- a/src/webOAuthServer.ts
+++ b/src/webOAuthServer.ts
@@ -96,6 +96,7 @@ export class WebOAuthServer extends AsyncCreatable<WebOAuthServer.Options> {
               response.end();
               resolve(authInfo);
             } catch (err) {
+              this.webServer.reportError(err, response);
               reject(err);
             }
           })
@@ -313,6 +314,19 @@ export class WebServer extends AsyncCreatable<WebServer.Options> {
     const body = `${status} - Redirecting to ${url}`;
     response.setHeader('Content-Length', Buffer.byteLength(body));
     response.writeHead(status, { Location: url });
+    response.end(body);
+  }
+
+  /**
+   * sends a response to the browser reporting an error.
+   *
+   * @param error the error
+   * @param response the response to write the redirect to.
+   */
+  public reportError(error: Error, response: http.ServerResponse): void {
+    response.setHeader('Content-Type', 'text/html');
+    const body = messages.getMessage('ServerErrorHTMLResponse', [error.message]);
+    response.setHeader('Content-Length', Buffer.byteLength(body));
     response.end(body);
   }
 

--- a/src/webOAuthServer.ts
+++ b/src/webOAuthServer.ts
@@ -147,6 +147,11 @@ export class WebOAuthServer extends AsyncCreatable<WebOAuthServer.Options> {
         if (request.method === 'GET') {
           if (url.pathname && url.pathname.startsWith('/OauthRedirect')) {
             request.query = parseQueryString(url.query as string);
+            if (request.query.error) {
+              const err = new SfdxError(request.query.error_description || request.query.error, request.query.error);
+              this.webServer.reportError(err, response);
+              return reject(err);
+            }
             this.logger.debug(`request.query.state: ${request.query.state as string}`);
             try {
               this.oauthConfig.authCode = asString(this.parseAuthCodeFromRequest(response, request));
@@ -190,6 +195,7 @@ export class WebOAuthServer extends AsyncCreatable<WebOAuthServer.Options> {
         this.logger.debug(`Successfully obtained auth code: ...${authCode.substring(authCode.length - 5)}`);
       } else {
         this.logger.debug('Expected an auth code but could not find one.');
+        throw SfdxError.create('@salesforce/core', 'auth', 'missingAuthCode');
       }
       this.logger.debug(`oauthConfig.loginUrl: ${this.oauthConfig.loginUrl}`);
       this.logger.debug(`oauthConfig.clientId: ${this.oauthConfig.clientId}`);
@@ -325,7 +331,7 @@ export class WebServer extends AsyncCreatable<WebServer.Options> {
    */
   public reportError(error: Error, response: http.ServerResponse): void {
     response.setHeader('Content-Type', 'text/html');
-    const body = messages.getMessage('ServerErrorHTMLResponse', [error.message]);
+    const body = messages.getMessage('serverErrorHTMLResponse', [error.message]);
     response.setHeader('Content-Length', Buffer.byteLength(body));
     response.end(body);
   }


### PR DESCRIPTION
Right now, the websever oauth flow will kill the server if an auth code exchange fails, leaving a no response in the browser. This change sends the error to the browser instead.

![image](https://user-images.githubusercontent.com/918434/105910772-43cfc380-5fde-11eb-93bc-3c9509b2b7d7.png)

To reproduce an auth code problem, you can deny a connected app or hack the code to introduce a character to the auth code.

@W-8789899@

