### PR TITLE
fix: no throw on unknown config value

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -425,7 +425,7 @@ export class Config extends ConfigFile<ConfigFile.Options> {
    */
   private async cryptProperties(encrypt: boolean): Promise<void> {
     const hasEncryptedProperties = this.entries().some(([key]) => {
-      return !!ensure(Config.propertyConfigMap[key]).encrypted;
+      return !!Config.propertyConfigMap[key]?.encrypted;
     });
 
     if (hasEncryptedProperties) {

--- a/src/config/configAggregator.ts
+++ b/src/config/configAggregator.ts
@@ -245,6 +245,7 @@ export class ConfigAggregator extends AsyncOptionalCreatable<JsonMap> {
    */
   public getConfigInfo(): ConfigInfo[] {
     const infos = Object.keys(this.getConfig())
+      .filter((key) => this.getAllowedProperties().some((element) => key === element.key))
       .map((key) => this.getInfo(key))
       .filter((info): info is ConfigInfo => !!info);
     return sortBy(infos, 'key');

--- a/test/unit/config/configAggregatorTest.ts
+++ b/test/unit/config/configAggregatorTest.ts
@@ -160,7 +160,7 @@ describe('ConfigAggregator', () => {
       expect(aggregator.getLocation(Config.DEFAULT_USERNAME)).to.equal('Environment');
     });
 
-    it('configInfo', async () => {
+    it('configInfo with env', async () => {
       process.env.SFDX_DEFAULTUSERNAME = 'test';
       $$.SANDBOX.stub(fs, 'readJson').returns(Promise.resolve({}));
 
@@ -169,6 +169,16 @@ describe('ConfigAggregator', () => {
       expect(info.key).to.equal('defaultusername');
       expect(info.value).to.equal('test');
       expect(info.location).to.equal('Environment');
+    });
+
+    it('configInfo ignores invalid entries', async () => {
+      $$.SANDBOX.stub(fs, 'readJsonMap').returns(Promise.resolve({ invalid: 'entry', apiVersion: 49.0 }));
+
+      const aggregator: ConfigAggregator = await ConfigAggregator.create();
+      const info = aggregator.getConfigInfo()[0];
+      expect(info.key).to.equal('apiVersion');
+      expect(info.value).to.equal(49.0);
+      expect(info.location).to.equal('Local');
     });
   });
 });

--- a/test/unit/config/configTest.ts
+++ b/test/unit/config/configTest.ts
@@ -268,6 +268,15 @@ describe('Config', () => {
 
       expect(writeStub.called).to.be.true;
     });
+
+    it('calls ConfigFile.read with unknown key and does not throw on crypt', async () => {
+      stubMethod($$.SANDBOX, ConfigFile.prototype, ConfigFile.prototype.read.name).callsFake(async function () {
+        this.setContentsFromObject({ unknown: 'unknown config key and value' });
+      });
+
+      const config: Config = await Config.create(Config.getDefaultOptions(true));
+      expect(config).to.exist;
+    });
   });
 
   describe('allowed properties', () => {


### PR DESCRIPTION
Right now, old versions of the core library will throw if there is an unknown key in the config file. If a new key is added in future versions of core, the old version doesn't know about it and will throw. THis prevents this from happening in the future.

@W-8880355@