### PR TITLE
perf: small queries to identify a devHub

### DIFF
--- a/src/org.ts
+++ b/src/org.ts
@@ -233,7 +233,7 @@ export class Org extends AsyncCreatable<Org.Options> {
     const conn = this.getConnection();
     let isDevHub = false;
     try {
-      await conn.query('SELECT Id FROM ScratchOrgInfo');
+      await conn.query('SELECT Id FROM ScratchOrgInfo limit 1');
       isDevHub = true;
     } catch (err) {
       /* Not a dev hub */


### PR DESCRIPTION
related to work for @W-8881661@

there's no reason to query every scratchOrgInfo (on a busy hub that someone's authenticating a new machine to, that could be a lot of data.  

The sobject either exists or doesn't so this'll be faster.