### PR TITLE
fix: revert dns polling timeout to 30 and frequency to 10

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -39,7 +39,10 @@ export const SFDX_HTTP_HEADERS = {
 };
 
 export const DNS_ERROR_NAME = 'Domain Not Found';
-const DNS_TIMEOUT = Math.max(3, new Env().getNumber('SFDX_DNS_TIMEOUT') || 3);
+// Timeout for DNS lookup polling defaults to 30 seconds and should always be at least 3 seconds
+const DNS_TIMEOUT = Math.max(3, new Env().getNumber('SFDX_DNS_TIMEOUT', 30) as number);
+// Retry frequency for DNS lookup polling should be at least 10 seconds
+const DNS_RETRY_FREQ = Math.max(10, new Env().getNumber('SFDX_DNS_RETRY_FREQUENCY', 10) as number);
 
 // This interface is so we can add the autoFetchQuery method to both the Connection
 // and Tooling classes and get nice typing info for it within editors.  JSForce is
@@ -220,7 +223,7 @@ export class Connection extends JSForceConnection {
     const resolver = await MyDomainResolver.create({
       url: new URL(this.options.connectionOptions.instanceUrl),
       timeout: Duration.seconds(DNS_TIMEOUT),
-      frequency: Duration.seconds(DNS_TIMEOUT),
+      frequency: Duration.seconds(DNS_RETRY_FREQ),
     });
     try {
       await resolver.resolve();

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -39,10 +39,10 @@ export const SFDX_HTTP_HEADERS = {
 };
 
 export const DNS_ERROR_NAME = 'Domain Not Found';
-// Timeout for DNS lookup polling defaults to 30 seconds and should always be at least 3 seconds
-const DNS_TIMEOUT = Math.max(3, new Env().getNumber('SFDX_DNS_TIMEOUT', 30) as number);
-// Retry frequency for DNS lookup polling should be at least 10 seconds
-const DNS_RETRY_FREQ = Math.max(10, new Env().getNumber('SFDX_DNS_RETRY_FREQUENCY', 10) as number);
+// Timeout for DNS lookup polling defaults to 3 seconds and should always be at least 3 seconds
+const DNS_TIMEOUT = Math.max(3, new Env().getNumber('SFDX_DNS_TIMEOUT', 3) as number);
+// Retry frequency for DNS lookup polling defaults to 1 second and should be at least 1 second
+const DNS_RETRY_FREQ = Math.max(1, new Env().getNumber('SFDX_DNS_RETRY_FREQUENCY', 1) as number);
 
 // This interface is so we can add the autoFetchQuery method to both the Connection
 // and Tooling classes and get nice typing info for it within editors.  JSForce is
@@ -233,6 +233,7 @@ export class Connection extends JSForceConnection {
         'Verify that the org still exists',
         'If your org is newly created, wait a minute and run your command again',
         "If you deployed or updated the org's My Domain, logout from the CLI and authenticate again",
+        'If you are running in a CI environment with a DNS that blocks external IPs, try setting SFDX_DISABLE_DNS_CHECK=true',
       ]);
     }
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { URL } from 'url';
-import { Duration, maxBy, merge, Env } from '@salesforce/kit';
+import { maxBy, merge } from '@salesforce/kit';
 import { asString, ensure, getNumber, isString, JsonCollection, JsonMap, Optional } from '@salesforce/ts-types';
 import {
   Connection as JSForceConnection,
@@ -39,10 +39,6 @@ export const SFDX_HTTP_HEADERS = {
 };
 
 export const DNS_ERROR_NAME = 'Domain Not Found';
-// Timeout for DNS lookup polling defaults to 3 seconds and should always be at least 3 seconds
-const DNS_TIMEOUT = Math.max(3, new Env().getNumber('SFDX_DNS_TIMEOUT', 3) as number);
-// Retry frequency for DNS lookup polling defaults to 1 second and should be at least 1 second
-const DNS_RETRY_FREQ = Math.max(1, new Env().getNumber('SFDX_DNS_RETRY_FREQUENCY', 1) as number);
 
 // This interface is so we can add the autoFetchQuery method to both the Connection
 // and Tooling classes and get nice typing info for it within editors.  JSForce is
@@ -222,8 +218,6 @@ export class Connection extends JSForceConnection {
     }
     const resolver = await MyDomainResolver.create({
       url: new URL(this.options.connectionOptions.instanceUrl),
-      timeout: Duration.seconds(DNS_TIMEOUT),
-      frequency: Duration.seconds(DNS_RETRY_FREQ),
     });
     try {
       await resolver.resolve();

--- a/src/status/myDomainResolver.ts
+++ b/src/status/myDomainResolver.ts
@@ -17,6 +17,11 @@ import { sfdc } from '../util/sfdc';
 import { StatusResult } from './client';
 import { PollingClient } from './pollingClient';
 
+// Timeout for DNS lookup polling defaults to 3 seconds and should always be at least 3 seconds
+const DNS_TIMEOUT = Math.max(3, new Env().getNumber('SFDX_DNS_TIMEOUT', 3) as number);
+// Retry frequency for DNS lookup polling defaults to 1 second and should be at least 1 second
+const DNS_RETRY_FREQ = Math.max(1, new Env().getNumber('SFDX_DNS_RETRY_FREQUENCY', 1) as number);
+
 /**
  * A class used to resolve MyDomains. After a ScratchOrg is created it's host name my not be propagated to the
  * Salesforce DNS service. This service is not exclusive to Salesforce My Domain URL and could be used for any hostname.
@@ -95,8 +100,8 @@ export class MyDomainResolver extends AsyncOptionalCreatable<MyDomainResolver.Op
           };
         }
       },
-      timeout: this.options.timeout || Duration.seconds(30),
-      frequency: this.options.frequency || Duration.seconds(10),
+      timeout: this.options.timeout || Duration.seconds(DNS_TIMEOUT),
+      frequency: this.options.frequency || Duration.seconds(DNS_RETRY_FREQ),
       timeoutErrorName: 'MyDomainResolverTimeoutError',
     };
     const client = await PollingClient.create(pollingOptions);

--- a/src/status/myDomainResolver.ts
+++ b/src/status/myDomainResolver.ts
@@ -11,7 +11,7 @@ import { promisify } from 'util';
 
 import { ensureString } from '@salesforce/ts-types';
 
-import { AsyncOptionalCreatable, Duration } from '@salesforce/kit';
+import { AsyncOptionalCreatable, Duration, Env } from '@salesforce/kit';
 import { Logger } from '../logger';
 import { sfdc } from '../util/sfdc';
 import { StatusResult } from './client';
@@ -55,8 +55,16 @@ export class MyDomainResolver extends AsyncOptionalCreatable<MyDomainResolver.Op
   /**
    * Method that performs the dns lookup of the host. If the lookup fails the internal polling client will try again
    * given the optional interval. Returns the resolved ip address.
+   *
+   * If SFDX_DISABLE_DNS_CHECK environment variable is set to true, it will immediately return the host without
+   * executing the dns loookup.
    */
   public async resolve(): Promise<string> {
+    if (new Env().getBoolean('SFDX_DISABLE_DNS_CHECK', false)) {
+      this.logger.debug('SFDX_DISABLE_DNS_CHECK set to true. Skipping DNS check...');
+      return this.options.url.host;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self: MyDomainResolver = this;
     const pollingOptions: PollingClient.Options = {


### PR DESCRIPTION
This PR does the following:
- adds env var for retry frequency (`SFDX_DNS_RETRY_FREQUENCY`), which defaults to 1 second
- adds env var for disabling DNS lookup (`SFDX_DISABLE_DNS_CHECK`)

Hopefully addresses https://github.com/forcedotcom/cli/issues/820

@W-8896111@

Testing:
- edit `instanceUrl` in `~/.sfdx/<username>.json` to invalid url
- run `sfdx force:org:display -u <username>`. Command should error and show suggested actions:
```
ERROR running force:org:display:  The org cannot be found

Try this:
Verify that the org still exists
If your org is newly created, wait a minute and run your command again
If you deployed or updated the org's My Domain, logout from the CLI and authenticate again
If you are running in a CI environment with a DNS that blocks external IPs, try setting SFDX_DISABLE_DNS_CHECK=true
```
- run `SFDX_DISABLE_DNS_CHECK=true sfdx force:org:display -u <username>`. Command will error like this:
```
Error: getaddrinfo ENOTFOUND su0503.my.fsalesforce.com
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:67:26) {
  errno: -3008,
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'su0503.my.fsalesforce.com'
}
ERROR:  Error: getaddrinfo ENOTFOUND su0503.my.fsalesforce.com
ERROR running force:org:display:  getaddrinfo ENOTFOUND su0503.my.fsalesforce.com
```

That error is okay to have. We're assuming that people setting `SFDX_DISABLE_DNS_CHECK=true` are in a CI with a dns that blocks external IPs