### PR TITLE
feat: cache api version on auth info

### DIFF
--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -558,6 +558,12 @@ export class AuthInfo extends AsyncCreatable<AuthInfo.Options> {
   public async save(authData?: AuthFields): Promise<AuthInfo> {
     this.update(authData);
     const username = ensure(this.getUsername());
+
+    if (sfdc.matchesAccessToken(username)) {
+      this.logger.debug('Username is an accesstoken. Skip saving authinfo to disk.');
+      return this;
+    }
+
     AuthInfo.cache.set(username, this.fields);
 
     const dataToSave = cloneJson(this.fields);

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -58,6 +58,8 @@ export interface AuthFields {
   createdOrgInstance?: string;
   devHubUsername?: string;
   instanceUrl?: string;
+  instanceApiVersion?: string;
+  instanceApiVersionLastRetrieved?: number;
   isDevHub?: boolean;
   loginUrl?: string;
   orgId?: string;

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -59,7 +59,7 @@ export interface AuthFields {
   devHubUsername?: string;
   instanceUrl?: string;
   instanceApiVersion?: string;
-  instanceApiVersionLastRetrieved?: number;
+  instanceApiVersionLastRetrieved?: string;
   isDevHub?: boolean;
   loginUrl?: string;
   orgId?: string;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -6,7 +6,16 @@
  */
 import { URL } from 'url';
 import { Duration, maxBy, merge, env } from '@salesforce/kit';
-import { asString, ensure, getNumber, getString, isString, JsonCollection, JsonMap, Optional } from '@salesforce/ts-types';
+import {
+  asString,
+  ensure,
+  getNumber,
+  getString,
+  isString,
+  JsonCollection,
+  JsonMap,
+  Optional,
+} from '@salesforce/ts-types';
 import {
   Connection as JSForceConnection,
   ConnectionOptions,
@@ -117,7 +126,7 @@ export class Connection extends JSForceConnection {
     if (!baseOptions.version) {
       // Set the API version obtained from the config aggregator.
       const configAggregator = options.configAggregator || (await ConfigAggregator.create());
-      baseOptions.version = asString(configAggregator.getInfo('apiVersion').value); 
+      baseOptions.version = asString(configAggregator.getInfo('apiVersion').value);
     }
 
     // Get connection options from auth info and create a new jsForce connection
@@ -134,13 +143,17 @@ export class Connection extends JSForceConnection {
           conn.setApiVersion(cachedVersion);
         }
       } else {
-        conn.logger.debug(`The apiVersion ${baseOptions.version} was found from ${options.connectionOptions?.version ? 'passed in options' : 'config'}`);
+        conn.logger.debug(
+          `The apiVersion ${baseOptions.version} was found from ${
+            options.connectionOptions?.version ? 'passed in options' : 'config'
+          }`
+        );
       }
-    } catch(e) {
-        if (e.name === DNS_ERROR_NAME) {
-          throw e;
-        }
-        conn.logger.debug(`Error trying to load the API version: ${e.name} - ${e.message}`);
+    } catch (e) {
+      if (e.name === DNS_ERROR_NAME) {
+        throw e;
+      }
+      conn.logger.debug(`Error trying to load the API version: ${e.name} - ${e.message}`);
     }
     conn.logger.debug(`Using apiVersion ${conn.getApiVersion()}`);
     return conn;
@@ -398,12 +411,16 @@ export class Connection extends JSForceConnection {
     if (lastChecked && !ignoreCache) {
       const now = Date.now();
       const has24HoursPastSinceLastCheck = now - lastChecked > Duration.hours(24).milliseconds;
-      this.logger.debug(`Last checked on ${lastChecked} (now is ${now}) - ${has24HoursPastSinceLastCheck ? '' : 'not '}getting latest`);
+      this.logger.debug(
+        `Last checked on ${lastChecked} (now is ${now}) - ${has24HoursPastSinceLastCheck ? '' : 'not '}getting latest`
+      );
       if (has24HoursPastSinceLastCheck) {
         await useLatest();
       }
     } else {
-      this.logger.debug(`Using the latest because lastChecked=${lastChecked} and SFDX_IGNORE_API_VERSION_CACHE=${ignoreCache}`);
+      this.logger.debug(
+        `Using the latest because lastChecked=${lastChecked} and SFDX_IGNORE_API_VERSION_CACHE=${ignoreCache}`
+      );
       // No version found in the file (we never checked before)
       // so get the latest.
       await useLatest();

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -1223,6 +1223,27 @@ describe('AuthInfo', () => {
       // and that data is encrypted when saved (because we have to decrypt it to verify here).
       expect(decryptedActualFields).to.deep.equal(expectedFields);
     });
+
+    it('should not save accesstoken files', async () => {
+      // invalid access token
+      const username =
+        '00DB0000000H3bm!AQcAQFpuHljRg_fn_n.0g_3GJTXeCI_sQEucmwq2o5yd3.mwof3ODbsfWrJ4MCro8DOjpaloqoRFzAJ8w8f.TrjRiSaFSpvo';
+
+      // Create the AuthInfo instance
+      const authInfo = await AuthInfo.create({
+        username,
+        accessTokenOptions: {
+          accessToken: username,
+          instanceUrl: testMetadata.instanceUrl,
+        },
+      });
+
+      expect(authInfo.getUsername()).to.equal(username);
+
+      configFileWrite.rejects(new Error('Should not call save'));
+      await authInfo.save();
+      // If the test doesn't blow up, it is a success because the write (reject) never happened
+    });
   });
 
   describe('update()', () => {

--- a/test/unit/connectionTest.ts
+++ b/test/unit/connectionTest.ts
@@ -8,13 +8,13 @@ import { get, JsonMap } from '@salesforce/ts-types';
 
 import { assert, expect } from 'chai';
 import * as jsforce from 'jsforce';
+import { fromStub, stubInterface, StubbedType } from '@salesforce/ts-sinon';
+import { Duration } from '@salesforce/kit';
 import { AuthInfo } from '../../src/authInfo';
 import { MyDomainResolver } from '../../src/status/myDomainResolver';
 import { ConfigAggregator, ConfigInfo } from '../../src/config/configAggregator';
 import { Connection, SFDX_HTTP_HEADERS, DNS_ERROR_NAME, SingleRecordQueryErrors } from '../../src/connection';
 import { testSetup, shouldThrow } from '../../src/testSetup';
-import { fromStub, stubInterface, StubbedType } from '@salesforce/ts-sinon';
-import { Duration } from '@salesforce/kit';
 
 // Setup the test environment.
 const $$ = testSetup();
@@ -39,7 +39,7 @@ describe('Connection', () => {
       .onFirstCall()
       .resolves([{ version: '42.0' }]);
 
-      // Create proxied instances of AuthInfo
+    // Create proxied instances of AuthInfo
     testAuthInfo = stubInterface<AuthInfo>($$.SANDBOX, {
       isOauth: () => true,
       getFields: () => ({}),
@@ -84,17 +84,17 @@ describe('Connection', () => {
   });
 
   it('create() should create a connection with the provided API version', async () => {
-    const conn = await Connection.create({ 
+    const conn = await Connection.create({
       authInfo: fromStub(testAuthInfo),
-      connectionOptions: { version: '50.0' }
-     });
+      connectionOptions: { version: '50.0' },
+    });
     expect(conn.getApiVersion()).to.equal('50.0');
   });
 
   it('create() should create a connection with the cached API version', async () => {
     testAuthInfo.getFields.returns({
       instanceApiVersionLastRetrieved: Date.now() - Duration.hours(10).milliseconds,
-      instanceApiVersion: '51.0'
+      instanceApiVersion: '51.0',
     });
     const conn = await Connection.create({ authInfo: fromStub(testAuthInfo) });
     expect(conn.getApiVersion()).to.equal('51.0');
@@ -103,7 +103,7 @@ describe('Connection', () => {
   it('create() should create a connection with the cached API version updated with latest', async () => {
     testAuthInfo.getFields.returns({
       instanceApiVersionLastRetrieved: 123,
-      instanceApiVersion: '40.0'
+      instanceApiVersion: '40.0',
     });
 
     const conn = await Connection.create({ authInfo: fromStub(testAuthInfo) });

--- a/test/unit/connectionTest.ts
+++ b/test/unit/connectionTest.ts
@@ -93,7 +93,7 @@ describe('Connection', () => {
 
   it('create() should create a connection with the cached API version', async () => {
     testAuthInfo.getFields.returns({
-      instanceApiVersionLastRetrieved: Date.now() - Duration.hours(10).milliseconds,
+      instanceApiVersionLastRetrieved: new Date(Date.now() - Duration.hours(10).milliseconds).toLocaleString(),
       instanceApiVersion: '51.0',
     });
     const conn = await Connection.create({ authInfo: fromStub(testAuthInfo) });


### PR DESCRIPTION
Currently, every connection instantiation will call out and get a list of API versions. This is a waste of time considering Salesforce servers only change API versions every few months. We want to pick up quickly when the server is updated so this sets a 24 hour cache. The call is quick so this seems appropriate. 

It also introduces the environment variable `SFDX_IGNORE_API_VERSION_CACHE` to disable this cache to return to old behavior.

This also fixes an old bug auth info files where the username is an access token write to disk.

Setting `DEBUG=*connection*` you will see something like the following:

No Cache:
```
sfdx:connection DEBUG Using the latest because lastChecked=undefined and SFDX_IGNORE_API_VERSION_CACHE=false +0ms
sfdx:connection DEBUG request: {"method":"GET","url":"https://adcxgs0hub.my.salesforce.com/services/data","headers":{"content-type":"application/json","user-agent":"sfdx toolbelt:"}} +157ms
sfdx:connection DEBUG response for org versions: 20.0,21.0,22.0,23.0,24.0,25.0,26.0,27.0,28.0,29.0,30.0,31.0,32.0,33.0,34.0,35.0,36.0,37.0,38.0,39.0,40.0,41.0,42.0,43.0,44.0,45.0,46.0,47.0,48.0,49.0,50.0,51.0 +395ms
sfdx:connection DEBUG Loaded latest apiVersion 51.0 +1ms
sfdx:connection DEBUG Using apiVersion 51.0 +1ms
```

Cached:
```
sfdx:connection DEBUG Last checked on 1613683877813 (now is 1613684745568) - not getting latest +0ms
sfdx:connection DEBUG Loaded latest apiVersion 51.0 +1ms
sfdx:connection DEBUG Using apiVersion 51.0 +0ms
```

Invalid Cache:
```
sfdx:connection DEBUG Last checked on 161683877813 (now is 1613684784405) - getting latest +0ms
sfdx:connection DEBUG request: {"method":"GET","url":"https://adcxgs0hub.my.salesforce.com/services/data","headers":{"content-type":"application/json","user-agent":"sfdx toolbelt:"}} +83ms
sfdx:connection DEBUG response for org versions: 20.0,21.0,22.0,23.0,24.0,25.0,26.0,27.0,28.0,29.0,30.0,31.0,32.0,33.0,34.0,35.0,36.0,37.0,38.0,39.0,40.0,41.0,42.0,43.0,44.0,45.0,46.0,47.0,48.0,49.0,50.0,51.0 +344ms
sfdx:connection DEBUG Loaded latest apiVersion 51.0 +2ms
sfdx:connection DEBUG Using apiVersion 51.0 +0ms
```

Disable Cache:
```
sfdx:connection DEBUG Using the latest because lastChecked=1613684784833 and SFDX_IGNORE_API_VERSION_CACHE=true +0ms
sfdx:connection DEBUG request: {"method":"GET","url":"https://adcxgs0hub.my.salesforce.com/services/data","headers":{"content-type":"application/json","user-agent":"sfdx toolbelt:"}} +298ms
sfdx:connection DEBUG response for org versions: 20.0,21.0,22.0,23.0,24.0,25.0,26.0,27.0,28.0,29.0,30.0,31.0,32.0,33.0,34.0,35.0,36.0,37.0,38.0,39.0,40.0,41.0,42.0,43.0,44.0,45.0,46.0,47.0,48.0,49.0,50.0,51.0 +361ms
sfdx:connection DEBUG Loaded latest apiVersion 51.0 +2ms
sfdx:connection DEBUG Using apiVersion 51.0 +0ms
```

@W-8856053@