### PR TITLE
fix: await the call to authInfo.save

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -411,7 +411,7 @@ export class Connection extends JSForceConnection {
       // verifies DNS
       await this.useLatestApiVersion();
       version = this.getApiVersion();
-      this.options.authInfo.save({
+      await this.options.authInfo.save({
         instanceApiVersion: version,
         // This will get messed up if the user changes their local time on their machine.
         // Not a big deal since it will just get updated sooner/later.


### PR DESCRIPTION
When loading the instance API version we need to await the call to authInfo save.
@W-8927294@