### PR TITLE
fix(auth): Allow for parsing sfdxAuthUrls from json files

### DIFF
--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -515,9 +515,12 @@ export class AuthInfo extends AsyncCreatable<AuthInfo.Options> {
    * @param sfdxAuthUrl
    */
   public static parseSfdxAuthUrl(sfdxAuthUrl: string) {
-    const match = sfdxAuthUrl.match(
-      /^force:\/\/([a-zA-Z0-9._-]+):([a-zA-Z0-9._-]*):([a-zA-Z0-9._-]+)@([a-zA-Z0-9._-]+)/
-    );
+    let url;
+    try {
+      url = JSON.parse(sfdxAuthUrl).sfdxAuthUrl;
+    } catch (error) {
+      url = sfdxAuthUrl;
+    }
 
     if (!match) {
       throw new SfdxError(

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -521,7 +521,9 @@ export class AuthInfo extends AsyncCreatable<AuthInfo.Options> {
     } catch (error) {
       url = sfdxAuthUrl;
     }
-
+    
+    const match = url.match(/^force:\/\/([a-zA-Z0-9._-]+):([a-zA-Z0-9._-]*):([a-zA-Z0-9._-]+)@([a-zA-Z0-9._-]+)/);
+    
     if (!match) {
       throw new SfdxError(
         'Invalid sfdx auth url. Must be in the format `force://<clientId>:<clientSecret>:<refreshToken>@<loginUrl>`. The instanceUrl must not have the protocol set.',

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -521,9 +521,9 @@ export class AuthInfo extends AsyncCreatable<AuthInfo.Options> {
     } catch (error) {
       url = sfdxAuthUrl;
     }
-    
+
     const match = url.match(/^force:\/\/([a-zA-Z0-9._-]+):([a-zA-Z0-9._-]*):([a-zA-Z0-9._-]+)@([a-zA-Z0-9._-]+)/);
-    
+
     if (!match) {
       throw new SfdxError(
         'Invalid sfdx auth url. Must be in the format `force://<clientId>:<clientSecret>:<refreshToken>@<loginUrl>`. The instanceUrl must not have the protocol set.',

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -2014,6 +2014,19 @@ describe('AuthInfo', () => {
       expect(options.loginUrl).to.equal('https://test.my.salesforce.com');
     });
 
+    it('should parse the correct url when passed in as json', () => {
+      const options = AuthInfo.parseSfdxAuthUrl(
+        '{"sfdxAuthUrl": "force://PlatformCLI::5Aep861_OKMvio5gy8xCNsXxybPdupY9fVEZyeVOvb4kpOZx5Z1QLB7k7n5flEqEWKcwUQEX1I.O5DCFwjlYUB.@test.my.salesforce.com"}'
+      );
+
+      expect(options.refreshToken).to.equal(
+        '5Aep861_OKMvio5gy8xCNsXxybPdupY9fVEZyeVOvb4kpOZx5Z1QLB7k7n5flEqEWKcwUQEX1I.O5DCFwjlYUB.'
+      );
+      expect(options.clientId).to.equal('PlatformCLI');
+      expect(options.clientSecret).to.equal('');
+      expect(options.loginUrl).to.equal('https://test.my.salesforce.com');
+    });
+
     it('should throw with incorrect url', () => {
       try {
         AuthInfo.parseSfdxAuthUrl(


### PR DESCRIPTION
Allows for getting sfdxAuthUrls from json files like stated in the [documentation for `auth:sfdxurl:store`](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_auth_sfdxurl.htm#cli_reference_auth_sfdxurl_store).

@W-8993725@

