### PR TITLE
Allow port in loginUrl

### DIFF
--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -516,7 +516,7 @@ export class AuthInfo extends AsyncCreatable<AuthInfo.Options> {
    */
   public static parseSfdxAuthUrl(sfdxAuthUrl: string) {
     const match = sfdxAuthUrl.match(
-      /^force:\/\/([a-zA-Z0-9._-]+):([a-zA-Z0-9._-]*):([a-zA-Z0-9._-]+)@([a-zA-Z0-9._-]+)/
+      /^force:\/\/([a-zA-Z0-9._-]+):([a-zA-Z0-9._-]*):([a-zA-Z0-9._-]+)@([a-zA-Z0-9:._-]+)/
     );
 
     if (!match) {


### PR DESCRIPTION
The regex does not allow the : in the match for loginUrl, this prevents a port from being included in the loginUrl.

fails with this sfdxAuthUrl before the change and succeeds after change
```
force://PlatformCLI::<refreshToken>@devhub.my.localhost.sfdcdev.salesforce.com:6101
```