### PR TITLE
deployRecentValidation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postcompile": "tsc -p test; tsc -p typedocExamples",
     "prepack": "sf-build",
     "pretest": "sf-compile-test",
-    "test": "sf-test --require ts-node/register"
+    "test": "sf-test"
   },
   "keywords": [
     "force",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -214,15 +214,12 @@ export class Connection extends JSForceConnection {
   /**
    * Will deploy a recently validated deploy request
    *
-   * @param options.id = the id of the deploy to quickly validate
+   * @param options.id = the deploy ID that's been validated already from a previous checkOnly deploy request
    * @param options.rest = a boolean whether or not to use the REST API
    */
   public async deployRecentValidation(options: recentValidationOptions): Promise<JsonCollection> {
     if (options.rest) {
-      const url = `${this.instanceUrl.replace(
-        /\/$/,
-        ''
-      )}/services/data/v${this.getApiVersion()}/metadata/deployRequest`;
+      const url = `${this.baseUrl()}/metadata/deployRequest`;
       const messageBody = JSON.stringify({
         validatedDeployRequestId: options.id,
       });
@@ -234,6 +231,7 @@ export class Connection extends JSForceConnection {
       const requestOptions = { headers: 'json' };
       return this.request(requestInfo, requestOptions);
     } else {
+      // the _invoke is private in jsforce, we can call the SOAP deployRecentValidation like this
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
       // @ts-ignore
       return this.metadata['_invoke']('deployRecentValidation', {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -221,7 +221,9 @@ export class Connection extends JSForceConnection {
    * @param options.rest = a boolean whether or not to use the REST API
    */
   public async deployRecentValidation(options: recentValidationOptions): Promise<JsonCollection> {
-    if (options.rest) {
+    const rest = options.rest;
+    delete options.rest;
+    if (rest) {
       const url = `${this.baseUrl()}/metadata/deployRequest`;
       const messageBody = JSON.stringify({
         validatedDeployRequestId: options.id,

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -211,6 +211,12 @@ export class Connection extends JSForceConnection {
     return super._baseUrl();
   }
 
+  /**
+   * Will deploy a recently validated deploy request
+   *
+   * @param options.id = the id of the deploy to quickly validate
+   * @param options.rest = a boolean whether or not to use the REST API
+   */
   public async deployRecentValidation(options: recentValidationOptions): Promise<JsonCollection> {
     if (options.rest) {
       const url = `${this.instanceUrl.replace(

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -212,6 +212,9 @@ export class Connection extends JSForceConnection {
   }
 
   /**
+   * TODO: This should be moved into JSForce V2 once ready
+   * this is only a temporary solution to support both REST and SOAP APIs
+   *
    * Will deploy a recently validated deploy request
    *
    * @param options.id = the deploy ID that's been validated already from a previous checkOnly deploy request

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -49,6 +49,7 @@ export const SFDX_HTTP_HEADERS = {
 };
 
 export const DNS_ERROR_NAME = 'Domain Not Found';
+type recentValidationOptions = { id: string; rest?: boolean };
 
 // This interface is so we can add the autoFetchQuery method to both the Connection
 // and Tooling classes and get nice typing info for it within editors.  JSForce is
@@ -210,6 +211,30 @@ export class Connection extends JSForceConnection {
     return super._baseUrl();
   }
 
+  public async deployRecentValidation(options: recentValidationOptions): Promise<JsonCollection> {
+    if (options.rest) {
+      const url = `${this.instanceUrl.replace(
+        /\/$/,
+        ''
+      )}/services/data/v${this.getApiVersion()}/metadata/deployRequest`;
+      const messageBody = JSON.stringify({
+        validatedDeployRequestId: options.id,
+      });
+      const requestInfo = {
+        method: 'POST',
+        url,
+        body: messageBody,
+      };
+      const requestOptions = { headers: 'json' };
+      return this.request(requestInfo, requestOptions);
+    } else {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+      // @ts-ignore
+      return this.metadata['_invoke']('deployRecentValidation', {
+        validationId: options.id,
+      }) as JsonCollection;
+    }
+  }
   /**
    * Retrieves the highest api version that is supported by the target server instance.
    */

--- a/src/keyChainImpl.ts
+++ b/src/keyChainImpl.ts
@@ -165,7 +165,7 @@ export class KeychainAccess implements PasswordStore {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    credManager.on('close', async (code) => {
+    credManager.on('close', async (code: number) => {
       try {
         return await this.osImpl.onGetCommandClose(code, stdout, stderr, opts, fn);
       } catch (e) {

--- a/test/unit/connectionTest.ts
+++ b/test/unit/connectionTest.ts
@@ -273,6 +273,25 @@ describe('Connection', () => {
     }
   });
 
+  describe('deployRecentValidation', () => {
+    it('deployRecentValidation() should call into jsforce for SOAP', async () => {
+      // @ts-ignore
+      const jsforceSpy = $$.SANDBOX.stub(jsforce.Metadata.prototype, 'deployRecentValidation');
+      const res = Connection.prototype.deployRecentValidation({ id: '1234567890', rest: false });
+      expect(jsforceSpy.callCount).to.equal(1);
+      expect(res).to.equal({});
+    });
+
+    it('deployRecentValidation() should call request directly for REST', async () => {
+      const conn = await Connection.create({ authInfo: fromStub(testAuthInfo) });
+      conn.instanceUrl = 'myNewInstance@salesforce.com';
+      const requestStub = $$.SANDBOX.stub(conn, 'request');
+
+      await conn.deployRecentValidation({ id: '0Afxx00000000lWCAQ', rest: true });
+      expect(requestStub.callCount).to.equal(1);
+    });
+  });
+
   it('singleRecordQuery returns single-record result properly', async () => {
     const mockSingleRecord = {
       id: '123',

--- a/test/unit/connectionTest.ts
+++ b/test/unit/connectionTest.ts
@@ -282,6 +282,17 @@ describe('Connection', () => {
       await conn.deployRecentValidation({ id: '0Afxx00000000lWCAQ', rest: true });
       expect(requestStub.callCount).to.equal(1);
     });
+
+    it('deployRecentValidation() should call jsforce for SOAP', async () => {
+      const conn = await Connection.create({ authInfo: fromStub(testAuthInfo) });
+      conn.instanceUrl = 'myNewInstance@salesforce.com';
+      // @ts-ignore private method
+      const requestStub = $$.SANDBOX.stub(conn.metadata, '_invoke');
+
+      await conn.deployRecentValidation({ id: '0Afxx00000000lWCAQ' });
+      expect(requestStub.callCount).to.equal(1);
+      expect(requestStub.args[0][0]).to.equal('deployRecentValidation');
+    });
   });
 
   it('singleRecordQuery returns single-record result properly', async () => {

--- a/test/unit/connectionTest.ts
+++ b/test/unit/connectionTest.ts
@@ -274,14 +274,6 @@ describe('Connection', () => {
   });
 
   describe('deployRecentValidation', () => {
-    it('deployRecentValidation() should call into jsforce for SOAP', async () => {
-      // @ts-ignore
-      const jsforceSpy = $$.SANDBOX.stub(jsforce.Metadata.prototype, 'deployRecentValidation');
-      const res = Connection.prototype.deployRecentValidation({ id: '1234567890', rest: false });
-      expect(jsforceSpy.callCount).to.equal(1);
-      expect(res).to.equal({});
-    });
-
     it('deployRecentValidation() should call request directly for REST', async () => {
       const conn = await Connection.create({ authInfo: fromStub(testAuthInfo) });
       conn.instanceUrl = 'myNewInstance@salesforce.com';


### PR DESCRIPTION
@W-9014822@ 

adds the `deployRecentValidation` method to do a quick deploy with REST or SOAP

compare with https://github.com/salesforcecli/toolbelt/blob/main/src/lib/mdapi/mdApiUtil.ts#L36
and https://github.com/salesforcecli/toolbelt/blob/main/src/lib/mdapi/mdApiUtil.ts#L51