### PR TITLE
fix: debugEnabled should be public

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -220,11 +220,15 @@ export class Logger {
   // The sfdx root logger singleton
   private static rootLogger?: Logger;
 
+  /**
+   * Whether debug is enabled for this Logger.
+   */
+  public debugEnabled = false;
+
   // The actual Bunyan logger
   private bunyan: Bunyan;
 
   private readonly format: LoggerFormat;
-  private debugEnabled = false;
 
   /**
    * Constructs a new `Logger`.

--- a/test/unit/loggerTest.ts
+++ b/test/unit/loggerTest.ts
@@ -40,7 +40,7 @@ describe('Logger', () => {
       const logger1 = new Logger('testLogger');
       expect(logger1).to.be.instanceof(Logger);
       expect(logger1.getName()).to.equal('testLogger');
-      const logger2 = Logger.root();
+      const logger2 = await Logger.root();
       expect(logger2).to.not.equal(logger1);
     });
   });
@@ -346,6 +346,7 @@ describe('Logger', () => {
         return (output += error);
       });
       const logger = await Logger.root();
+      expect(logger.debugEnabled).to.equal(true);
       logger.warn('warn');
       out.restore();
       err.restore();


### PR DESCRIPTION
Core's logger uses the Debug library. That library has a public field so that you can check if debug is enabled and if so, do some specific logic for debugging that could potentially degrade performance. To avoid this when debug is not enabled we need to expose this property on the Logger and have @salesforce/command library use it so that it's available for plugins.

@W-9092712@