### PR TITLE
feat: modify authInfo to return username for access token auth

### DIFF
--- a/messages/core.json
+++ b/messages/core.json
@@ -4,7 +4,7 @@
   "AuthInfoOverwriteError": "Cannot create an AuthInfo instance that will overwrite existing auth data.",
   "AuthInfoOverwriteErrorAction": "Create the AuthInfo instance using existing auth data by just passing the username.  E.g., AuthInfo.create({ username: 'my@user.org' });",
   "AuthCodeExchangeError": "Error authenticating with auth code due to: %s",
-  "AuthCodeUsernameRetrievalError": "Could not retrieve the username after successful auth code exchange in org: %s.\nDue to: %s",
+  "AuthCodeUsernameRetrievalError": "Could not retrieve the username after successful auth code exchange.\nDue to: %s",
   "JWTAuthError": "Error authenticating with JWT config due to: %s",
   "RefreshTokenAuthError": "Error authenticating with the refresh token due to: %s",
   "OrgDataNotAvailableError": "An attempt to refresh the authentication token failed with a 'Data Not Found Error'. The org identified by username %s does not appear to exist. Likely cause is that the org was deleted by another user or has expired.",

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -841,7 +841,7 @@ export class AuthInfo extends AsyncCreatable<AuthInfo.Options> {
         authConfig = options;
         const userInfo = await this.retrieveUsername(
           ensureString(options.instanceUrl),
-          ensureString(options.instanceUrl)
+          ensureString(options.accessToken)
         );
         this.fields.username = userInfo?.preferred_username;
         this.fields.orgId = userInfo?.organization_id;

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -1101,14 +1101,7 @@ export class AuthInfo extends AsyncCreatable<AuthInfo.Options> {
     };
   }
 
-  private async retrieveUsername(
-    instanceUrl: string,
-    accessToken: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    orgIdToRemove?: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    userId?: string
-  ): Promise<Optional<UserInfo>> {
+  private async retrieveUsername(instanceUrl: string, accessToken: string): Promise<Optional<UserInfo>> {
     // Make a REST call for the username directly.  Normally this is done via a connection
     // but we don't want to create circular dependencies or lots of snowflakes
     // within this file to support it.

--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -839,7 +839,7 @@ export class AuthInfo extends AsyncCreatable<AuthInfo.Options> {
 
       if (this.isTokenOptions(options)) {
         authConfig = options;
-        const userInfo = await this.retrieveUsername(
+        const userInfo = await this.retrieveUserInfo(
           ensureString(options.instanceUrl),
           ensureString(options.accessToken)
         );
@@ -1035,7 +1035,7 @@ export class AuthInfo extends AsyncCreatable<AuthInfo.Options> {
     if (!username) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
       // @ts-ignore
-      const userInfo = await this.retrieveUsername(authFieldsBuilder.instance_url, authFieldsBuilder.access_token);
+      const userInfo = await this.retrieveUserInfo(authFieldsBuilder.instance_url, authFieldsBuilder.access_token);
       username = userInfo?.preferred_username;
     }
     return {
@@ -1081,7 +1081,7 @@ export class AuthInfo extends AsyncCreatable<AuthInfo.Options> {
     if (!username) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
       // @ts-ignore
-      const userInfo = await this.retrieveUsername(authFields.instance_url, authFields.access_token);
+      const userInfo = await this.retrieveUserInfo(authFields.instance_url, authFields.access_token);
       username = userInfo?.preferred_username;
     }
 
@@ -1101,14 +1101,13 @@ export class AuthInfo extends AsyncCreatable<AuthInfo.Options> {
     };
   }
 
-  private async retrieveUsername(instanceUrl: string, accessToken: string): Promise<Optional<UserInfo>> {
+  private async retrieveUserInfo(instanceUrl: string, accessToken: string): Promise<Optional<UserInfo>> {
     // Make a REST call for the username directly.  Normally this is done via a connection
     // but we don't want to create circular dependencies or lots of snowflakes
     // within this file to support it.
     const instance = ensure(instanceUrl);
     const url = `${instance}/services/oauth2/userinfo`;
     const headers = Object.assign({ Authorization: `Bearer ${accessToken}` }, SFDX_HTTP_HEADERS);
-    let orgId;
     try {
       this.logger.info(`Sending request for Username after successful auth code exchange to URL: ${url}`);
       const response = await new Transport().httpRequest({ url, headers });
@@ -1116,14 +1115,10 @@ export class AuthInfo extends AsyncCreatable<AuthInfo.Options> {
         this.throwUserGetException(response);
       } else {
         const json = parseJsonMap(response.body) as UserInfo;
-        orgId = asString(json.organization_id);
         return json;
       }
     } catch (err) {
-      throw SfdxError.create('@salesforce/core', 'core', 'AuthCodeUsernameRetrievalError', [
-        orgId || 'unknown',
-        err.message,
-      ]);
+      throw SfdxError.create('@salesforce/core', 'core', 'AuthCodeUsernameRetrievalError', [err.message]);
     }
   }
 

--- a/test/unit/authInfoTest.ts
+++ b/test/unit/authInfoTest.ts
@@ -26,7 +26,6 @@ import { Crypto } from '../../src/crypto';
 import { SfdxError } from '../../src/sfdxError';
 import { testSetup } from '../../src/testSetup';
 import { fs } from '../../src/util/fs';
-
 const TEST_KEY = {
   service: 'sfdx',
   account: 'local',
@@ -294,7 +293,7 @@ describe('AuthInfo', () => {
       // Stub the http requests (OAuth2.requestToken() and the request for the username)
       _postParmsStub.returns(Promise.resolve(authResponse));
       const responseBody = {
-        body: JSON.stringify({ Username: testMetadata.username }),
+        body: JSON.stringify({ preferred_username: testMetadata.username, organization_id: testMetadata.orgId }),
       };
       stubMethod($$.SANDBOX, Transport.prototype, 'httpRequest').returns(Promise.resolve(responseBody));
       authInfo = await AuthInfo.create({ oauth2Options: authCodeConfig });
@@ -480,6 +479,10 @@ describe('AuthInfo', () => {
     });
 
     it('should return an AuthInfo instance when passed an access token and instanceUrl for the access token flow', async () => {
+      const responseBody = {
+        body: JSON.stringify({ preferred_username: testMetadata.username, organization_id: testMetadata.orgId }),
+      };
+      stubMethod($$.SANDBOX, Transport.prototype, 'httpRequest').returns(Promise.resolve(responseBody));
       stubMethod($$.SANDBOX, ConfigAggregator.prototype, 'loadProperties').callsFake(async () => {});
       stubMethod($$.SANDBOX, ConfigAggregator.prototype, 'getPropertyValue').returns(testMetadata.instanceUrl);
 
@@ -1016,7 +1019,9 @@ describe('AuthInfo', () => {
 
       // Stub the http requests (OAuth2.requestToken() and the request for the username)
       _postParmsStub.returns(Promise.resolve(authResponse));
-      const responseBody = { body: JSON.stringify({ Username: username }) };
+      const responseBody = {
+        body: JSON.stringify({ preferred_username: username, organization_id: testMetadata.orgId }),
+      };
       stubMethod($$.SANDBOX, Transport.prototype, 'httpRequest').returns(Promise.resolve(responseBody));
 
       // Create the refresh token AuthInfo instance


### PR DESCRIPTION
@W-8066452@

When creating an authInfo with `AuthInfo.create({ accessTokenOptions: { accessToken, instanceUrl, loginUrl: instanceUrl } });`  the new authInfo instance will contain the username/orgId.