### PR TITLE
Feat: export getJwtAudienceUrl

### DIFF
--- a/src/authInfo.ts
+++ b/src/authInfo.ts
@@ -230,7 +230,7 @@ async function resolvesToSandbox(options: OAuth2Options & { createdOrgInstance?:
   return cnames.some((cname) => isSandboxUrl({ ...options, loginUrl: cname }));
 }
 
-async function getJwtAudienceUrl(options: OAuth2Options & { createdOrgInstance?: string }) {
+export async function getJwtAudienceUrl(options: OAuth2Options & { createdOrgInstance?: string }) {
   // environment variable is used as an override
   if (process.env.SFDX_AUDIENCE_URL) {
     return process.env.SFDX_AUDIENCE_URL;

--- a/src/exported.ts
+++ b/src/exported.ts
@@ -28,7 +28,7 @@ export { ConfigPropertyMeta, ConfigPropertyMetaInput, Config } from './config/co
 
 export { ConfigInfo, ConfigAggregator } from './config/configAggregator';
 
-export { Authorization, AuthFields, AuthInfo, OAuth2WithVerifier, SfdcUrl } from './authInfo';
+export { Authorization, AuthFields, AuthInfo, OAuth2WithVerifier, SfdcUrl, getJwtAudienceUrl } from './authInfo';
 
 export { AuthConfigs, AuthRemover } from './authRemover';
 


### PR DESCRIPTION
### What does this PR do?
exports the function `getJwtAudienceUrl` so that it can be consumed by other libraries in this WI it's going to replace `jwtAudienceUrl` from toolbelt

### What issues does this PR fix or reference?
@W-9271200@