### PR TITLE
feat: exported function checkLightningDomain()

### DIFF
--- a/src/util/checkLightningDomain.ts
+++ b/src/util/checkLightningDomain.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { URL } from 'url';
+import { Env, Duration } from '@salesforce/kit';
+import { MyDomainResolver } from '../status/myDomainResolver';
+import { sfdc } from './sfdc';
+
+export default async function checkLightningDomain(url: string): Promise<boolean> {
+  const domain = `https://${/https?:\/\/([^.]*)/.exec(url)?.slice(1, 2).pop()}.lightning.force.com`;
+  const quantity = new Env().getNumber('SFDX_DOMAIN_RETRY', 240) ?? 0;
+  const timeout = new Duration(quantity, Duration.Unit.SECONDS);
+
+  if (sfdc.isInternalUrl(url) || timeout.seconds === 0) {
+    return true;
+  }
+
+  const resolver = await MyDomainResolver.create({
+    url: new URL(domain),
+    timeout,
+    frequency: new Duration(1, Duration.Unit.SECONDS),
+  });
+
+  await resolver.resolve();
+  return true;
+}

--- a/test/unit/util/checkLightningDomainTest.ts
+++ b/test/unit/util/checkLightningDomainTest.ts
@@ -12,11 +12,13 @@ import checkLightningDomain from '../../../src/util/checkLightningDomain';
 const $$ = testSetup();
 const TEST_IP = '1.1.1.1';
 
-describe('Connection', () => {
+describe('checkLightningDomain', () => {
   beforeEach(() => {
-    $$.SANDBOXES.CONNECTION.restore();
-    $$.SANDBOX.stub(process, 'emitWarning');
     $$.SANDBOX.stub(MyDomainResolver.prototype, 'resolve').resolves(TEST_IP);
+  });
+
+  afterEach(() => {
+    $$.SANDBOX.restore();
   });
 
   it('return true for internal urls', async () => {

--- a/test/unit/util/checkLightningDomainTest.ts
+++ b/test/unit/util/checkLightningDomainTest.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from 'chai';
+import { shouldThrow, testSetup } from '../../../src/testSetup';
+import { MyDomainResolver } from '../../../src/status/myDomainResolver';
+import checkLightningDomain from '../../../src/util/checkLightningDomain';
+
+const $$ = testSetup();
+const TEST_IP = '1.1.1.1';
+
+describe('Connection', () => {
+  beforeEach(() => {
+    $$.SANDBOXES.CONNECTION.restore();
+    $$.SANDBOX.stub(process, 'emitWarning');
+    $$.SANDBOX.stub(MyDomainResolver.prototype, 'resolve').resolves(TEST_IP);
+  });
+
+  it('return true for internal urls', async () => {
+    const url = 'http://my-domain.stm.salesforce.com';
+    const response = await checkLightningDomain(url);
+    expect(response).to.be.true;
+  });
+
+  it('return true for urls that dns can resolve', async () => {
+    const url = 'http://login.salesforce.com';
+    const respose = await checkLightningDomain(url);
+    expect(respose).to.be.true;
+  });
+
+  it('throws on domain resolution failure', async () => {
+    $$.SANDBOX.restore();
+    $$.SANDBOX.stub(MyDomainResolver.prototype, 'resolve').rejects();
+    const url = 'http://login.salesforce.com';
+    try {
+      await shouldThrow(checkLightningDomain(url));
+    } catch (e) {
+      expect(e.name).to.equal('Error');
+    }
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Exports a function `checkLightningDomain` to check if an org domain is ready DNS-wise.

### What issues does this PR fix or reference?
@W-9236226@
