### PR TITLE
force:org:open force:org:open --urlonly display bug fix 

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -897,18 +897,7 @@ const _filter = (...args: unknown[]): unknown => {
         _arg = _arg.replace(keyRegex, `$1${hiddenAttrMessage}`);
       });
 
-      // This is a jsforce message we are masking. This can be removed after the following pull request is committed
-      // and pushed to a jsforce release.
-      //
-      // Looking  For: "Refreshed access token = ..."
-      // Related Jsforce pull requests:
-      //  https://github.com/jsforce/jsforce/pull/598
-      //  https://github.com/jsforce/jsforce/pull/608
-      //  https://github.com/jsforce/jsforce/pull/609
-      const jsForceTokenRefreshRegEx = new RegExp('Refreshed(.*)access(.*)token(.*)=\\s*[^\'"\\s*]*');
-      _arg = _arg.replace(jsForceTokenRefreshRegEx, `<refresh_token - ${HIDDEN}>`);
-
-      _arg = _arg.replace(/sid=(.*)/, `sid=<${HIDDEN}>`);
+      _arg = _arg.replace(/(00D\w{12,15})![.\w]*/, `<${HIDDEN}>`);
 
       // return an object if an object was logged; otherwise return the filtered string.
       return isObject(arg) ? parseJson(_arg) : _arg;

--- a/test/unit/loggerTest.ts
+++ b/test/unit/loggerTest.ts
@@ -217,13 +217,12 @@ describe('Logger', () => {
   });
 
   describe('filters', () => {
-    const sid = 'SIDHERE!';
+    const sid = '00D55000000M2qA!AQ0AQHg3LnYDOyobmH07';
     const simpleString = `sid=${sid}`;
     const stringWithObject = ` The rain in Spain: ${JSON.stringify({
       // eslint-disable-next-line camelcase
       access_token: sid,
     })}`;
-    const jsforceStringWithToken = `Connection refresh completed. Refreshed access token = ${sid}`;
     const obj1 = { accessToken: `${sid}`, refreshToken: `${sid}` };
     const obj2 = { key: 'Access Token', value: `${sid}` };
     const arr1 = [
@@ -236,7 +235,7 @@ describe('Logger', () => {
       { key: ' refresh  _TOKEn ', value: ` ${sid} ` },
       { key: ' SfdX__AuthUrl  ', value: ` ${sid} ` },
     ];
-    const testLogEntries = [simpleString, stringWithObject, jsforceStringWithToken, obj1, obj2, arr1, arr2];
+    const testLogEntries = [simpleString, stringWithObject, obj1, obj2, arr1, arr2];
 
     async function runTest(logLevel: [string, number]) {
       const logger = (await Logger.child('testLogger')).useMemoryLogging().setLevel(0);


### PR DESCRIPTION
What does this PR do?
Modifies access token regex in logger which replaces the access token to hidden while logging the information. 
It fixes the following issue: https://github.com/forcedotcom/sfdx-core/issues/153

Testing Notes:
Try to reproduce the issue before. Test that functionality with the current branch. Test force:org:open --urlonly command with 
different tags by enabling and disabling SFDX_LOG_LEVEL

What issues does this PR fix or reference?
@W-6336711@