### PR TITLE
fix: dont fail when trying to unset sf config keys

### DIFF
--- a/src/authRemover.ts
+++ b/src/authRemover.ts
@@ -220,8 +220,11 @@ export class AuthRemover extends AsyncOptionalCreatable {
           .reduce((x, y) => x.concat(y), []);
         const allKeys = keysWithUsername.concat(keysWithAlias);
         this.logger.debug(`Found these config keys to remove: ${allKeys}`);
-        allKeys.forEach((key) => config.unset(key));
-        await config.write();
+        try {
+          allKeys.forEach((key) => config.unset(key));
+        } finally {
+          await config.write();
+        }
       }
     }
   }


### PR DESCRIPTION
Gracefully fail when trying to unset `sf` config keys. Doing so fixes the scenario where a user has authorized with `sf` and is logging out with `sfdx`

[skip-validate-pr]