### PR TITLE
fix: add predicate function to list all auths

### DIFF
--- a/src/exported.ts
+++ b/src/exported.ts
@@ -24,7 +24,7 @@ export { ConfigPropertyMeta, ConfigPropertyMetaInput, Config, SfdxPropertyKeys }
 
 export { ConfigInfo, ConfigAggregator } from './config/configAggregator';
 
-export { AuthFields, AuthInfo, OAuth2WithVerifier, OrgAuthorization } from './org/authInfo';
+export { AuthFields, AuthInfo, OAuth2WithVerifier, OrgAuthorization, OrgAuthorizationFilter } from './org/authInfo';
 
 export { AuthRemover } from './org/authRemover';
 

--- a/src/exported.ts
+++ b/src/exported.ts
@@ -24,7 +24,7 @@ export { ConfigPropertyMeta, ConfigPropertyMetaInput, Config, SfdxPropertyKeys }
 
 export { ConfigInfo, ConfigAggregator } from './config/configAggregator';
 
-export { AuthFields, AuthInfo, OAuth2WithVerifier, OrgAuthorization, OrgAuthorizationFilter } from './org/authInfo';
+export { AuthFields, AuthInfo, OAuth2WithVerifier, OrgAuthorization } from './org/authInfo';
 
 export { AuthRemover } from './org/authRemover';
 

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -98,7 +98,7 @@ export type OrgAuthorization = {
   instanceUrl?: string;
   accessToken?: string;
   error?: string;
-  isExpired: boolean;
+  isExpired: boolean | unknown;
 };
 
 /**
@@ -332,7 +332,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
 
   /**
    * Get a list of all authorizations based on auth files stored in the global directory.
-   * One can supply a filter (see @param orgAuthFilter) and calling this function withoyt
+   * One can supply a filter (see @param orgAuthFilter) and calling this function without
    * a filter will return all authorizations.
    *
    * @param orgAuthFilter a boolean value or a predicate function that filters authorizations
@@ -373,7 +373,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
           isExpired:
             Boolean(devHubUsername) && expirationDate
               ? new Date(ensureString(expirationDate)).getTime() < new Date().getTime()
-              : false,
+              : undefined,
         });
       } catch (err) {
         final.push({

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -94,9 +94,11 @@ export type OrgAuthorization = {
   aliases: Nullable<string[]>;
   configs: Nullable<string[]>;
   isScratchOrg?: boolean;
+  isDevHub?: boolean;
   instanceUrl?: string;
   accessToken?: string;
   error?: string;
+  isExpired: boolean;
 };
 
 /**
@@ -292,6 +294,10 @@ function base64UrlEscape(base64Encoded: string): string {
  * const connection = await Connection.create({ authInfo });
  * ```
  */
+
+const defaultOrgAuthFilter = (orgAuth: OrgAuthorization): boolean => !!orgAuth;
+export type OrgAuthorizationFilter = boolean | typeof defaultOrgAuthFilter;
+
 export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
   // Possibly overridden in create
   private usingAccessToken = false;
@@ -326,16 +332,25 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
 
   /**
    * Get a list of all authorizations based on auth files stored in the global directory.
+   * One can supply a filter (see @param orgAuthFilter) and calling this function withoyt
+   * a filter will return all authorizations.
+   *
+   * @param orgAuthFilter a boolean value or a predicate function that filters authorizations
+   *        For boolean value of true, return active org authorizations, false returns inactive
+   *        org authorizations. For a predicate function as (orgAuthorization: {OrgAuthorization}): boolean return
+   *        true for those org authorizations that are to be retained.
    *
    * @returns {Promise<OrgAuthorization[]>}
    */
-  public static async listAllAuthorizations(): Promise<OrgAuthorization[]> {
+  public static async listAllAuthorizations(
+    orgAuthFilter: OrgAuthorizationFilter = defaultOrgAuthFilter
+  ): Promise<OrgAuthorization[]> {
     const globalInfo = await GlobalInfo.getInstance();
     const config = (await ConfigAggregator.create()).getConfigInfo();
-    const auths = Object.values(globalInfo.orgs.getAll());
+    const orgs = Object.values(globalInfo.orgs.getAll());
     const final: OrgAuthorization[] = [];
-    for (const auth of auths) {
-      const username = ensureString(auth.username);
+    for (const org of orgs) {
+      const username = ensureString(org.username);
       const aliases = globalInfo.aliases.getAll(username) ?? undefined;
       // Get a list of configuration values that are set to either the username or one
       // of the aliases
@@ -344,32 +359,50 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
         .map((c) => c.key);
       try {
         const authInfo = await AuthInfo.create({ username });
-        const { orgId, instanceUrl, devHubUsername } = authInfo.getFields();
+        const { orgId, instanceUrl, devHubUsername, expirationDate, isDevHub } = authInfo.getFields();
         final.push({
           aliases,
           configs,
           username,
           instanceUrl,
-          isScratchOrg: Boolean(devHubUsername),
+          isScratchOrg: Boolean(devHubUsername) ?? false,
+          isDevHub: isDevHub || false,
           orgId: orgId as string,
           accessToken: authInfo.getConnectionOptions().accessToken,
           oauthMethod: authInfo.isJwt() ? 'jwt' : authInfo.isOauth() ? 'web' : 'token',
+          isExpired:
+            Boolean(devHubUsername) && expirationDate
+              ? new Date(ensureString(expirationDate)).getTime() < new Date().getTime()
+              : false,
         });
       } catch (err) {
         final.push({
           aliases,
           configs,
           username,
-          orgId: auth.orgId,
-          instanceUrl: auth.instanceUrl,
+          orgId: org.orgId,
+          instanceUrl: org.instanceUrl,
           accessToken: undefined,
           oauthMethod: 'unknown',
           error: err.message,
+          isExpired: false,
         });
       }
     }
 
-    return final;
+    const applyThisFilter =
+      typeof orgAuthFilter !== 'boolean'
+        ? orgAuthFilter
+        : (orgAuth: OrgAuthorization): boolean => {
+            if (!orgAuthFilter) {
+              // inactive
+              return !orgAuth.isExpired;
+            } else {
+              return !orgAuth.error && !orgAuth.isExpired;
+            }
+          };
+
+    return final.filter(applyThisFilter);
   }
 
   /**

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -98,7 +98,7 @@ export type OrgAuthorization = {
   instanceUrl?: string;
   accessToken?: string;
   error?: string;
-  isExpired: boolean | unknown;
+  isExpired: boolean | 'unknown';
 };
 
 /**
@@ -373,7 +373,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
           isExpired:
             Boolean(devHubUsername) && expirationDate
               ? new Date(ensureString(expirationDate)).getTime() < new Date().getTime()
-              : undefined,
+              : 'unknown',
         });
       } catch (err) {
         final.push({
@@ -385,7 +385,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
           accessToken: undefined,
           oauthMethod: 'unknown',
           error: err.message,
-          isExpired: false,
+          isExpired: 'unknown',
         });
       }
     }
@@ -394,9 +394,13 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
       typeof orgAuthFilter !== 'boolean'
         ? orgAuthFilter
         : (orgAuth: OrgAuthorization): boolean => {
+            // handle 'unknown' expiry - always treat as active
+            if (typeof orgAuth.isExpired === 'string') {
+              return true;
+            }
             if (!orgAuthFilter) {
               // inactive
-              return !orgAuth.isExpired;
+              return orgAuth.isExpired;
             } else {
               return !orgAuth.error && !orgAuth.isExpired;
             }

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -365,7 +365,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
           configs,
           username,
           instanceUrl,
-          isScratchOrg: Boolean(devHubUsername) ?? false,
+          isScratchOrg: Boolean(devHubUsername),
           isDevHub: isDevHub || false,
           orgId: orgId as string,
           accessToken: authInfo.getConnectionOptions().accessToken,

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -332,10 +332,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
    * One can supply a filter (see @param orgAuthFilter) and calling this function without
    * a filter will return all authorizations.
    *
-   * @param orgAuthFilter a boolean value or a predicate function that filters authorizations
-   *        For boolean value of true, return active org authorizations, false returns inactive
-   *        org authorizations. For a predicate function as (orgAuthorization: {OrgAuthorization}): boolean return
-   *        true for those org authorizations that are to be retained.
+   * @param orgAuthFilter A predicate function that returns true for those org authorizations that are to be retained.
    *
    * @returns {Promise<OrgAuthorization[]>}
    */

--- a/test/unit/org/authInfoTest.ts
+++ b/test/unit/org/authInfoTest.ts
@@ -1803,7 +1803,7 @@ describe('AuthInfo', () => {
   describe('listAllAuthorizations', () => {
     describe('with no AuthInfo.create errors', () => {
       const username = 'espresso@coffee.com';
-
+      let authInfo;
       beforeEach(async () => {
         stubMethod($$.SANDBOX, ConfigAggregator.prototype, 'loadProperties').callsFake(async () => {});
         stubMethod($$.SANDBOX, ConfigAggregator.prototype, 'getPropertyValue').returns(testMetadata.instanceUrl);
@@ -1830,7 +1830,7 @@ describe('AuthInfo', () => {
         set(jwtData, 'username', username);
         testMetadata.fetchConfigInfo = () => jwtData;
 
-        const authInfo = await AuthInfo.create({
+        authInfo = await AuthInfo.create({
           username,
           oauth2Options: {
             clientId: testMetadata.clientId,
@@ -1857,7 +1857,7 @@ describe('AuthInfo', () => {
             accessToken: 'authInfoTest_access_token',
             oauthMethod: 'web',
             isDevHub: false,
-            isExpired: false,
+            isExpired: undefined,
           },
         ]);
       });
@@ -1876,7 +1876,7 @@ describe('AuthInfo', () => {
             accessToken: 'authInfoTest_access_token',
             oauthMethod: 'jwt',
             isDevHub: false,
-            isExpired: false,
+            isExpired: undefined,
           },
         ]);
       });
@@ -1896,7 +1896,7 @@ describe('AuthInfo', () => {
             accessToken: 'authInfoTest_access_token',
             oauthMethod: 'token',
             isDevHub: false,
-            isExpired: false,
+            isExpired: undefined,
           },
         ]);
       });
@@ -1917,7 +1917,7 @@ describe('AuthInfo', () => {
             accessToken: 'authInfoTest_access_token',
             oauthMethod: 'web',
             isDevHub: false,
-            isExpired: false,
+            isExpired: undefined,
           },
         ]);
       });
@@ -1942,6 +1942,27 @@ describe('AuthInfo', () => {
             aliases: ['MyAlias'],
             configs: [OrgConfigProperties.TARGET_ORG, OrgConfigProperties.TARGET_DEV_HUB],
             isScratchOrg: false,
+            username: 'espresso@coffee.com',
+            orgId: '00DAuthInfoTest_orgId',
+            instanceUrl: 'https://mydevhub.localhost.internal.salesforce.com:6109',
+            accessToken: 'authInfoTest_access_token',
+            oauthMethod: 'web',
+            isDevHub: false,
+            isExpired: undefined,
+          },
+        ]);
+      });
+      it('should return list of authorizations devhub username', async () => {
+        authInfo.getFields().devHubUsername = 'foobarusername';
+        const expiryDate = new Date(Date.now());
+        expiryDate.setFullYear(expiryDate.getFullYear() + 1);
+        authInfo.getFields().expirationDate = expiryDate.toISOString();
+        const auths = await AuthInfo.listAllAuthorizations();
+        expect(auths).to.deep.equal([
+          {
+            aliases: [],
+            configs: [],
+            isScratchOrg: true,
             username: 'espresso@coffee.com',
             orgId: '00DAuthInfoTest_orgId',
             instanceUrl: 'https://mydevhub.localhost.internal.salesforce.com:6109',

--- a/test/unit/org/authInfoTest.ts
+++ b/test/unit/org/authInfoTest.ts
@@ -1864,7 +1864,7 @@ describe('AuthInfo', () => {
 
       it('should return list of authorizations with jwt oauthMethod', async () => {
         stubMethod($$.SANDBOX, AuthInfo.prototype, 'isJwt').returns(true);
-        const auths = await AuthInfo.listAllAuthorizations(false);
+        const auths = await AuthInfo.listAllAuthorizations();
         const expiryDate = new Date(Date.now());
         expiryDate.setFullYear(expiryDate.getFullYear() - 1);
         authInfo.getFields().expirationDate = expiryDate.toISOString();

--- a/test/unit/org/authInfoTest.ts
+++ b/test/unit/org/authInfoTest.ts
@@ -1843,7 +1843,9 @@ describe('AuthInfo', () => {
       });
 
       it('should return list of authorizations with web oauthMethod', async () => {
-        const auths = await AuthInfo.listAllAuthorizations();
+        const auths = await AuthInfo.listAllAuthorizations(
+          (orgAuth) => orgAuth.oauthMethod !== 'jwt' && !orgAuth.isScratchOrg
+        );
         expect(auths).to.deep.equal([
           {
             aliases: [],
@@ -1854,13 +1856,15 @@ describe('AuthInfo', () => {
             instanceUrl: 'https://mydevhub.localhost.internal.salesforce.com:6109',
             accessToken: 'authInfoTest_access_token',
             oauthMethod: 'web',
+            isDevHub: false,
+            isExpired: false,
           },
         ]);
       });
 
       it('should return list of authorizations with jwt oauthMethod', async () => {
         stubMethod($$.SANDBOX, AuthInfo.prototype, 'isJwt').returns(true);
-        const auths = await AuthInfo.listAllAuthorizations();
+        const auths = await AuthInfo.listAllAuthorizations(false);
         expect(auths).to.deep.equal([
           {
             aliases: [],
@@ -1871,6 +1875,8 @@ describe('AuthInfo', () => {
             instanceUrl: 'https://mydevhub.localhost.internal.salesforce.com:6109',
             accessToken: 'authInfoTest_access_token',
             oauthMethod: 'jwt',
+            isDevHub: false,
+            isExpired: false,
           },
         ]);
       });
@@ -1889,13 +1895,17 @@ describe('AuthInfo', () => {
             instanceUrl: 'https://mydevhub.localhost.internal.salesforce.com:6109',
             accessToken: 'authInfoTest_access_token',
             oauthMethod: 'token',
+            isDevHub: false,
+            isExpired: false,
           },
         ]);
       });
 
       it('should return list of authorizations with aliases', async () => {
         stubMethod($$.SANDBOX, AliasAccessor.prototype, 'getAll').returns(['MyAlias']);
-        const auths = await AuthInfo.listAllAuthorizations();
+        const auths = await AuthInfo.listAllAuthorizations(
+          (orgAuth) => orgAuth.aliases.length === 1 && orgAuth.aliases.includes('MyAlias')
+        );
         expect(auths).to.deep.equal([
           {
             aliases: ['MyAlias'],
@@ -1906,6 +1916,8 @@ describe('AuthInfo', () => {
             instanceUrl: 'https://mydevhub.localhost.internal.salesforce.com:6109',
             accessToken: 'authInfoTest_access_token',
             oauthMethod: 'web',
+            isDevHub: false,
+            isExpired: false,
           },
         ]);
       });
@@ -1922,7 +1934,9 @@ describe('AuthInfo', () => {
             key: OrgConfigProperties.TARGET_DEV_HUB,
           },
         ]);
-        const auths = await AuthInfo.listAllAuthorizations();
+        const auths = await AuthInfo.listAllAuthorizations((orgAuth) =>
+          orgAuth.configs.includes(OrgConfigProperties.TARGET_ORG)
+        );
         expect(auths).to.deep.equal([
           {
             aliases: ['MyAlias'],
@@ -1933,6 +1947,8 @@ describe('AuthInfo', () => {
             instanceUrl: 'https://mydevhub.localhost.internal.salesforce.com:6109',
             accessToken: 'authInfoTest_access_token',
             oauthMethod: 'web',
+            isDevHub: false,
+            isExpired: false,
           },
         ]);
       });
@@ -1957,7 +1973,7 @@ describe('AuthInfo', () => {
       });
 
       it('should return list of authorizations with unknown oauthMethod', async () => {
-        const auths = await AuthInfo.listAllAuthorizations();
+        const auths = await AuthInfo.listAllAuthorizations((orgAuth) => orgAuth.error === 'FAIL!');
         expect(auths).to.deep.equal([
           {
             aliases: [],
@@ -1965,6 +1981,7 @@ describe('AuthInfo', () => {
             username: 'espresso@coffee.com',
             orgId: '00DAuthInfoTest_orgId',
             instanceUrl: 'https://mydevhub.localhost.internal.salesforce.com:6109',
+            isExpired: false,
             accessToken: undefined,
             oauthMethod: 'unknown',
             error: 'FAIL!',
@@ -1982,6 +1999,7 @@ describe('AuthInfo', () => {
             username: 'espresso@coffee.com',
             orgId: '00DAuthInfoTest_orgId',
             instanceUrl: 'https://mydevhub.localhost.internal.salesforce.com:6109',
+            isExpired: false,
             accessToken: undefined,
             oauthMethod: 'unknown',
             error: 'FAIL!',

--- a/test/unit/org/authInfoTest.ts
+++ b/test/unit/org/authInfoTest.ts
@@ -1857,7 +1857,7 @@ describe('AuthInfo', () => {
             accessToken: 'authInfoTest_access_token',
             oauthMethod: 'web',
             isDevHub: false,
-            isExpired: undefined,
+            isExpired: 'unknown',
           },
         ]);
       });
@@ -1865,6 +1865,9 @@ describe('AuthInfo', () => {
       it('should return list of authorizations with jwt oauthMethod', async () => {
         stubMethod($$.SANDBOX, AuthInfo.prototype, 'isJwt').returns(true);
         const auths = await AuthInfo.listAllAuthorizations(false);
+        const expiryDate = new Date(Date.now());
+        expiryDate.setFullYear(expiryDate.getFullYear() - 1);
+        authInfo.getFields().expirationDate = expiryDate.toISOString();
         expect(auths).to.deep.equal([
           {
             aliases: [],
@@ -1876,7 +1879,7 @@ describe('AuthInfo', () => {
             accessToken: 'authInfoTest_access_token',
             oauthMethod: 'jwt',
             isDevHub: false,
-            isExpired: undefined,
+            isExpired: 'unknown',
           },
         ]);
       });
@@ -1896,7 +1899,7 @@ describe('AuthInfo', () => {
             accessToken: 'authInfoTest_access_token',
             oauthMethod: 'token',
             isDevHub: false,
-            isExpired: undefined,
+            isExpired: 'unknown',
           },
         ]);
       });
@@ -1917,7 +1920,7 @@ describe('AuthInfo', () => {
             accessToken: 'authInfoTest_access_token',
             oauthMethod: 'web',
             isDevHub: false,
-            isExpired: undefined,
+            isExpired: 'unknown',
           },
         ]);
       });
@@ -1948,7 +1951,7 @@ describe('AuthInfo', () => {
             accessToken: 'authInfoTest_access_token',
             oauthMethod: 'web',
             isDevHub: false,
-            isExpired: undefined,
+            isExpired: 'unknown',
           },
         ]);
       });
@@ -2002,7 +2005,7 @@ describe('AuthInfo', () => {
             username: 'espresso@coffee.com',
             orgId: '00DAuthInfoTest_orgId',
             instanceUrl: 'https://mydevhub.localhost.internal.salesforce.com:6109',
-            isExpired: false,
+            isExpired: 'unknown',
             accessToken: undefined,
             oauthMethod: 'unknown',
             error: 'FAIL!',
@@ -2020,7 +2023,7 @@ describe('AuthInfo', () => {
             username: 'espresso@coffee.com',
             orgId: '00DAuthInfoTest_orgId',
             instanceUrl: 'https://mydevhub.localhost.internal.salesforce.com:6109',
-            isExpired: false,
+            isExpired: 'unknown',
             accessToken: undefined,
             oauthMethod: 'unknown',
             error: 'FAIL!',


### PR DESCRIPTION
@W-9670267@ Modify listAllAuthorizations function that allows caller to filter results
Default for filter is to return all authorizations to protect backward compatibility.