### PR TITLE
sm/external-nuts-from-orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,6 @@ jobs:
         description: "Path to sfdx executable to be used by NUTs, defaults to ''"
         default: ''
         type: string
-      dependency_to_replace:
-        description: 'The fully qualified npm module name, i.e. @salesforce/core, that will be replaced in the external NUTs.  Should match this project'
-        type: string
-        default: ''
       external_project_git_url:
         description: 'The url that will be cloned.  This contains the NUTs you want to run.  Ex: https://github.com/salesforcecli/plugin-user'
         type: string
@@ -90,14 +86,14 @@ jobs:
           command: yarn
       - run:
           name: swap dependencies
-          command: yarn remove <<parameters.dependency_to_replace>> && yarn add $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME#$CIRCLE_SHA1
+          command: yarn remove @salesforce/core && yarn add $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME#$CIRCLE_SHA1
       # install and build in the core module
       - run:
           name: install/build core
           command: |
             yarn install
             yarn build
-          working_directory: node_modules/<<parameters.dependency_to_replace>>
+          working_directory: node_modules/@salesforce/core
       - run:
           name: remove command/core
           # deletes command/core to prevent ts conflicts
@@ -134,12 +130,15 @@ workflows:
           sfdx_version: latest
           os: linux
           node_version: lts
-          dependency_to_replace: '@salesforce/core'
           matrix:
             parameters:
               os: [linux]
               external_project_git_url:
-                ['https://github.com/salesforcecli/plugin-user']
+                [
+                  'https://github.com/salesforcecli/plugin-user',
+                  'https://github.com/salesforcecli/plugin-config',
+                  'https://github.com/salesforcecli/plugin-alias',
+                ]
       # - - release-management/test-nut:
       #     name: nuts-on-windows
       #     os: windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,6 @@ jobs:
         description: 'The url that will be cloned.  This contains the NUTs you want to run.  Ex: https://github.com/salesforcecli/plugin-user'
         type: string
         default: ''
-      # repo_tag:
-      #   description: "The tag of the module repo to checkout, '' defaults to branch/PR"
-      #   default: ''
-      #   type: string
       size:
         type: enum
         description: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,10 +100,10 @@ jobs:
           working_directory: node_modules/<<parameters.dependency_to_replace>>
       - run:
           name: remove command/core
+          # deletes command/core to prevent ts conflicts
           command: rm -rf node_modules/\@salesforce/command/node_modules/\@salesforce/core
       - run:
           name: Build
-          # deletes command/core to prevent ts conflicts
           command: |
             yarn build
       - release-management/verify-installed-plugin
@@ -135,7 +135,11 @@ workflows:
           os: linux
           node_version: lts
           dependency_to_replace: '@salesforce/core'
-          external_project_git_url: 'https://github.com/salesforcecli/plugin-user'
+          matrix:
+            parameters:
+              os: [linux]
+              external_project_git_url:
+                ['https://github.com/salesforcecli/plugin-user']
       # - - release-management/test-nut:
       #     name: nuts-on-windows
       #     os: windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,12 +104,13 @@ workflows:
   test-and-release:
     jobs:
       - external-nut:
+          requires:
+            - release-management/test-package
           sfdx_version: latest
-          os: linux
-          node_version: lts
           matrix:
             parameters:
               os: [linux]
+              node_version: [lts]
               external_project_git_url:
                 [
                   'https://github.com/salesforcecli/plugin-user',

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,29 +58,6 @@ jobs:
           version: <<parameters.sfdx_version>>
           os: <<parameters.os>>
       - run: git clone <<parameters.external_project_git_url>> $(pwd)
-      # - when:
-      #     condition:
-      #       and:
-      #         - equal: ['windows', <<parameters.os>>]
-      #         - <<parameters.repo_tag>>
-      #     steps:
-      #       - run:
-      #           name: Switch to tag v<<parameters.repo_tag>> or <<parameters.npm_module_name>>@<<parameters.repo_tag>>
-      #           command: |
-      #             git checkout "v<<parameters.repo_tag>>"
-      #             if (!$?)
-      #             {
-      #               git checkout "<<parameters.npm_module_name>>@<<parameters.repo_tag>>"
-      #             }
-      # - when:
-      #     condition:
-      #       and:
-      #         - equal: ['linux', <<parameters.os>>]
-      #         - <<parameters.repo_tag>>
-      #     steps:
-      #       - run:
-      #           name: Switch to tag v<<parameters.repo_tag>> or <<parameters.npm_module_name>>@<<parameters.repo_tag>>
-      #           command: git checkout v<<parameters.repo_tag>> || git checkout <<parameters.npm_module_name>>@<<parameters.repo_tag>>
       - run:
           name: Install dependencies
           command: yarn
@@ -138,7 +115,13 @@ workflows:
                   'https://github.com/salesforcecli/plugin-user',
                   'https://github.com/salesforcecli/plugin-config',
                   'https://github.com/salesforcecli/plugin-alias',
+                  'https://github.com/salesforcecli/plugin-limits',
+                  'https://github.com/salesforcecli/plugin-auth',
+                  'https://github.com/salesforcecli/plugin-schema',
+                  'https://github.com/salesforcecli/plugin-telemetry',
+                  'https://github.com/salesforcecli/toolbelt',
                 ]
+                # TODO: data (unlernafied)
       # - - release-management/test-nut:
       #     name: nuts-on-windows
       #     os: windows
@@ -167,3 +150,4 @@ workflows:
       #       branches:
       #         only: main
       #     context: CLI_CTC
+# TODO: data (unlernafied)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,19 @@ workflows:
   version: 2
   test-and-release:
     jobs:
+      - release-management/validate-pr:
+          filters:
+            branches:
+              ignore: main
+      - release-management/test-package:
+          matrix:
+            parameters:
+              os:
+                - linux
+              node_version:
+                - latest
+                - lts
+                - maintenance
       - external-nut:
           requires:
             - release-management/test-package
@@ -123,32 +136,14 @@ workflows:
                   'https://github.com/salesforcecli/toolbelt',
                 ]
                 # TODO: data (unlernafied)
-      # - - release-management/test-nut:
-      #     name: nuts-on-windows
-      #     os: windows
-      #     requires:
-      #       - release-management/test-package
-      # - release-management/validate-pr:
-      #     filters:
-      #       branches:
-      #         ignore: main
-      # - release-management/test-package:
-      #     matrix:
-      #       parameters:
-      #         os:
-      #           - linux
-      #         node_version:
-      #           - latest
-      #           - lts
-      #           - maintenance
-      # - release-management/release-package:
-      #     github-release: true
-      #     post-job-steps:
-      #       - run: yarn ci-docs
-      #     requires:
-      #       - release-management/test-package
-      #     filters:
-      #       branches:
-      #         only: main
-      #     context: CLI_CTC
-# TODO: data (unlernafied)
+      - release-management/release-package:
+          github-release: true
+          post-job-steps:
+            - run: yarn ci-docs
+          requires:
+            - release-management/test-package
+            - external-nut
+          filters:
+            branches:
+              only: main
+          context: CLI_CTC

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,41 @@
 version: 2.1
 orbs:
-  release-management: salesforce/npm-release-management@4
+  release-management: salesforce/npm-release-management@dev:80f2a12
 
 workflows:
   version: 2
   test-and-release:
     jobs:
-      - release-management/validate-pr:
-          filters:
-            branches:
-              ignore: main
-      - release-management/test-package:
-          matrix:
-            parameters:
-              os:
-                - linux
-              node_version:
-                - latest
-                - lts
-                - maintenance
-      - release-management/release-package:
-          github-release: true
-          post-job-steps:
-            - run: yarn ci-docs
-          requires:
-            - release-management/test-package
-          filters:
-            branches:
-              only: main
-          context: CLI_CTC
+      - release-management/test-external-nut:
+          sfdx_version: latest
+          os: linux
+          dependency_to_replace: '@salesforce/core'
+          external_project_git_url: 'https://github.com/salesforcecli/plugin-user'
+      # - - release-management/test-nut:
+      #     name: nuts-on-windows
+      #     os: windows
+      #     requires:
+      #       - release-management/test-package
+      # - release-management/validate-pr:
+      #     filters:
+      #       branches:
+      #         ignore: main
+      # - release-management/test-package:
+      #     matrix:
+      #       parameters:
+      #         os:
+      #           - linux
+      #         node_version:
+      #           - latest
+      #           - lts
+      #           - maintenance
+      # - release-management/release-package:
+      #     github-release: true
+      #     post-job-steps:
+      #       - run: yarn ci-docs
+      #     requires:
+      #       - release-management/test-package
+      #     filters:
+      #       branches:
+      #         only: main
+      #     context: CLI_CTC

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ workflows:
       - release-management/test-external-nut:
           sfdx_version: latest
           os: linux
+          node_version: lts
           dependency_to_replace: '@salesforce/core'
           external_project_git_url: 'https://github.com/salesforcecli/plugin-user'
       # - - release-management/test-nut:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,11 +94,18 @@ jobs:
       # install and build in the core module
       - run:
           name: install/build core
-          command: yarn install && rm -rf node_modules/\@salesforce/command/node_modules/\@salesforce/core yarn build
+          command: |
+            yarn install
+            yarn build
           working_directory: node_modules/<<parameters.dependency_to_replace>>
       - run:
+          name: remove command/core
+          command: rm -rf node_modules/\@salesforce/command/node_modules/\@salesforce/core
+      - run:
           name: Build
-          command: yarn build
+          # deletes command/core to prevent ts conflicts
+          command: |
+            yarn build
       - release-management/verify-installed-plugin
       - run:
           name: set TESTKIT_ENABLE_ZIP for artifacts on linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,129 @@
 version: 2.1
 orbs:
-  release-management: salesforce/npm-release-management@dev:alpha
+  release-management: salesforce/npm-release-management@4
+
+jobs:
+  external-nut:
+    description: Runs NUTs from other (external) repos by cloning them.  Substitutes a dependency for the current pull request.  For example, you're testing a PR to a library and want to test a plugin in another repo that uses the library.
+
+    parameters:
+      node_version:
+        description: version of node to run tests against
+        type: string
+        default: 'latest'
+      os:
+        description: operating system to run tests on
+        type: enum
+        enum: ['linux', 'windows']
+        default: 'linux'
+      sfdx_version:
+        description: 'By default, the latest version of the standalone CLI will be installed. To install via npm, supply a version tag such as "latest" or "6".'
+        default: ''
+        type: string
+      sfdx_executable_path:
+        description: "Path to sfdx executable to be used by NUTs, defaults to ''"
+        default: ''
+        type: string
+      dependency_to_replace:
+        description: 'The fully qualified npm module name, i.e. @salesforce/core, that will be replaced in the external NUTs.  Should match this project'
+        type: string
+        default: ''
+      external_project_git_url:
+        description: 'The url that will be cloned.  This contains the NUTs you want to run.  Ex: https://github.com/salesforcecli/plugin-user'
+        type: string
+        default: ''
+      # repo_tag:
+      #   description: "The tag of the module repo to checkout, '' defaults to branch/PR"
+      #   default: ''
+      #   type: string
+      size:
+        type: enum
+        description: |
+          The size of machine resource to use. Defaults to medium.
+        default: medium
+        enum:
+          - medium
+          - large
+          - xlarge
+          - 2xlarge
+
+    executor:
+      name: << parameters.os >>
+      size: << parameters.size >>
+
+    environment:
+      TESTKIT_EXECUTABLE_PATH: <<parameters.sfdx_executable_path>>
+
+    steps:
+      - install-node:
+          version: <<parameters.node_version>>
+          os: <<parameters.os>>
+      - install-sfdx:
+          version: <<parameters.sfdx_version>>
+          os: <<parameters.os>>
+      - run: git clone <<parameters.external_project_git_url>> $(pwd)
+      # - when:
+      #     condition:
+      #       and:
+      #         - equal: ['windows', <<parameters.os>>]
+      #         - <<parameters.repo_tag>>
+      #     steps:
+      #       - run:
+      #           name: Switch to tag v<<parameters.repo_tag>> or <<parameters.npm_module_name>>@<<parameters.repo_tag>>
+      #           command: |
+      #             git checkout "v<<parameters.repo_tag>>"
+      #             if (!$?)
+      #             {
+      #               git checkout "<<parameters.npm_module_name>>@<<parameters.repo_tag>>"
+      #             }
+      # - when:
+      #     condition:
+      #       and:
+      #         - equal: ['linux', <<parameters.os>>]
+      #         - <<parameters.repo_tag>>
+      #     steps:
+      #       - run:
+      #           name: Switch to tag v<<parameters.repo_tag>> or <<parameters.npm_module_name>>@<<parameters.repo_tag>>
+      #           command: git checkout v<<parameters.repo_tag>> || git checkout <<parameters.npm_module_name>>@<<parameters.repo_tag>>
+      - run:
+          name: Install dependencies
+          command: yarn
+      - run:
+          name: swap dependencies
+          command: yarn remove <<parameters.dependency_to_replace>> && yarn add $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME#$CIRCLE_SHA1
+      # install and build in the core module
+      - run:
+          name: install/build core
+          command: yarn install && rm -rf node_modules/\@salesforce/command/node_modules/\@salesforce/core yarn build
+          working_directory: node_modules/<<parameters.dependency_to_replace>>
+      - run:
+          name: Build
+          command: yarn build
+      - verify-installed-plugin
+      - run:
+          name: set TESTKIT_ENABLE_ZIP for artifacts on linux
+          command: |
+            echo "export TESTKIT_ENABLE_ZIP=true" >> $BASH_ENV
+      - run:
+          name: Create artifact dir
+          command: |
+            mkdir artifacts
+      - run:
+          name: Nuts
+          command: |
+            echo "Using node: $(node --version)"
+            echo "Environment Variables:"
+            env
+            yarn test:nuts
+          # this is in the command instead of the circle project environment to prevent it from happening on windows
+      - store_artifacts:
+          path: artifacts
 
 workflows:
   version: 2
   test-and-release:
     jobs:
-      - release-management/test-external-nut:
+      - external-nut:
           sfdx_version: latest
           os: linux
           node_version: lts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,9 +133,10 @@ workflows:
                   'https://github.com/salesforcecli/plugin-auth',
                   'https://github.com/salesforcecli/plugin-schema',
                   'https://github.com/salesforcecli/plugin-telemetry',
-                  'https://github.com/salesforcecli/toolbelt',
                 ]
-                # TODO: data (unlernafied)
+                # TODO
+                # data (unlernafied)
+                # toolbelt (git auth because private)
       - release-management/release-package:
           github-release: true
           post-job-steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  release-management: salesforce/npm-release-management@dev:80f2a12
+  release-management: salesforce/npm-release-management@dev:alpha
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,17 +48,17 @@ jobs:
           - 2xlarge
 
     executor:
-      name: << parameters.os >>
+      name: release-management/<< parameters.os >>
       size: << parameters.size >>
 
     environment:
       TESTKIT_EXECUTABLE_PATH: <<parameters.sfdx_executable_path>>
 
     steps:
-      - install-node:
+      - release-management/install-node:
           version: <<parameters.node_version>>
           os: <<parameters.os>>
-      - install-sfdx:
+      - release-management/install-sfdx:
           version: <<parameters.sfdx_version>>
           os: <<parameters.os>>
       - run: git clone <<parameters.external_project_git_url>> $(pwd)
@@ -99,7 +99,7 @@ jobs:
       - run:
           name: Build
           command: yarn build
-      - verify-installed-plugin
+      - release-management/verify-installed-plugin
       - run:
           name: set TESTKIT_ENABLE_ZIP for artifacts on linux
           command: |


### PR DESCRIPTION
runs plugin nuts from sfdx-core branches @W-9330701@
I decided not to put this in the orb because fixing the core dependencies (deleting from command node module) got very specific to sfdx-core.

known gaps:
this will fix the plugin-config error: https://github.com/salesforcecli/plugin-config/pull/181

this will fix the plugin-auth compile error: https://github.com/salesforcecli/cli-plugins-testkit/pull/172

toolbelt is omitted becuase it would require ssh key setup since that's a private repo