### PR TITLE
fix: optionally throw error when reading deprecated config key

### DIFF
--- a/src/config/configAggregator.ts
+++ b/src/config/configAggregator.ts
@@ -194,6 +194,7 @@ export class ConfigAggregator extends AsyncOptionalCreatable<JsonMap> {
    * Get a resolved config property.
    *
    * @param key The key of the property.
+   * @param throwOnDeprecation True, if you want an error throw when reading a deprecated config
    */
   public getInfo(key: string, throwOnDeprecation = false): ConfigInfo {
     const meta = this.getPropertyMeta(key);

--- a/src/config/configAggregator.ts
+++ b/src/config/configAggregator.ts
@@ -195,9 +195,9 @@ export class ConfigAggregator extends AsyncOptionalCreatable<JsonMap> {
    *
    * @param key The key of the property.
    */
-  public getInfo(key: string): ConfigInfo {
+  public getInfo(key: string, throwOnDeprecation = false): ConfigInfo {
     const meta = this.getPropertyMeta(key);
-    if (meta.deprecated && meta.newKey) {
+    if (throwOnDeprecation && meta.deprecated && meta.newKey) {
       throw messages.createError('deprecatedConfigKey', [key, meta.newKey]);
     }
     const location = this.getLocation(key);


### PR DESCRIPTION
By default, do not throw an error when reading a deprecated config key.

[skip-validate-pr]