### PR TITLE
fix: improve time to build auths for many orgs @W-9914839@

### DIFF
--- a/src/crypto/crypto.ts
+++ b/src/crypto/crypto.ts
@@ -41,6 +41,12 @@ interface CredType {
   password: string;
 }
 
+const makeSecureBuffer = (password: string | undefined): SecureBuffer<string> => {
+  const newSb = new SecureBuffer<string>();
+  newSb.consume(Buffer.from(ensure(password), 'utf8'));
+  return newSb;
+};
+
 /**
  * osxKeyChain promise wrapper.
  */
@@ -58,17 +64,13 @@ const keychainPromises = {
       return new Promise((resolve, reject): {} => {
         return _keychain.getPassword({ service, account }, (err: Nullable<Error>, password?: string) => {
           if (err) return reject(err);
-          const newSb = new SecureBuffer<string>();
-          newSb.consume(Buffer.from(ensure(password), 'utf8'));
-          Cache.set(`${service}:${account}`, newSb);
+          Cache.set(`${service}:${account}`, makeSecureBuffer(password));
           return resolve({ username: account, password: ensure(password) });
         });
       });
     } else {
       const pw = sb.value((buffer) => buffer.toString('utf8'));
-      const newSb = new SecureBuffer<string>();
-      newSb.consume(Buffer.from(ensure(pw), 'utf8'));
-      Cache.set(`${service}:${account}`, newSb);
+      Cache.set(`${service}:${account}`, makeSecureBuffer(pw));
       return new Promise((resolve): void => {
         return resolve({ username: account, password: ensure(pw) });
       });

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -8,6 +8,7 @@ export class Cache extends Map {
   private static _instance: Cache;
   private _hits = 0;
   private _lookups = 0;
+  private _enabled = true;
 
   public static instance(): Cache {
     if (!Cache._instance) {
@@ -17,13 +18,26 @@ export class Cache extends Map {
   }
 
   public static set<V>(key: string, value: V) {
-    Cache.instance().set(key, value);
+    if (Cache.instance()._enabled) {
+      Cache.instance().set(key, value);
+    }
   }
 
   public static get<V>(key: string): V {
+    if (Cache.instance()._enabled) {
+      return undefined as unknown as V;
+    }
     Cache.instance()._lookups++;
     Cache.instance()._hits += Cache.instance().has(key) ? 1 : 0;
     return Cache._instance.get(key) as V;
+  }
+
+  public static disable(): void {
+    Cache.instance()._enabled = false;
+  }
+
+  public static enable(): void {
+    Cache.instance()._enabled = true;
   }
 
   public get hits(): number {

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -26,7 +26,7 @@ export class Cache extends Map {
   }
 
   public static get<V>(key: string): V {
-    if (Cache.instance().#enabled) {
+    if (!Cache.instance().#enabled) {
       return undefined as unknown as V;
     }
     Cache.instance().#lookups++;

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -27,7 +27,6 @@ export class Cache extends Map {
   }
 
   public static set<V>(key: string, value: V) {
-    Cache.instance();
     if (Cache.#enabled) {
       Cache.instance().set(key, value);
     }

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+export class Cache extends Map {
+  private static _instance: Cache;
+  private _hits = 0;
+  private _lookups = 0;
+
+  public static instance(): Cache {
+    if (!Cache._instance) {
+      Cache._instance = new Cache();
+    }
+    return Cache._instance;
+  }
+
+  public static set<V>(key: string, value: V) {
+    Cache.instance().set(key, value);
+  }
+
+  public static get<V>(key: string): V {
+    Cache.instance()._lookups++;
+    Cache.instance()._hits += Cache.instance().has(key) ? 1 : 0;
+    return Cache._instance.get(key) as V;
+  }
+
+  public get hits(): number {
+    return Cache.instance()._hits;
+  }
+  public get lookups(): number {
+    return Cache.instance()._lookups;
+  }
+}

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -5,45 +5,47 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 export class Cache extends Map {
-  private static _instance: Cache;
-  private _hits = 0;
-  private _lookups = 0;
-  private _enabled = true;
+  /* eslint-disable @typescript-eslint/explicit-member-accessibility */
+  static #instance: Cache;
+  #hits = 0;
+  #lookups = 0;
+  #enabled = true;
+  /* eslint-enable @typescript-eslint/explicit-member-accessibility */
 
   public static instance(): Cache {
-    if (!Cache._instance) {
-      Cache._instance = new Cache();
+    if (!Cache.#instance) {
+      Cache.#instance = new Cache();
     }
-    return Cache._instance;
+    return Cache.#instance;
   }
 
   public static set<V>(key: string, value: V) {
-    if (Cache.instance()._enabled) {
+    if (Cache.instance().#enabled) {
       Cache.instance().set(key, value);
     }
   }
 
   public static get<V>(key: string): V {
-    if (Cache.instance()._enabled) {
+    if (Cache.instance().#enabled) {
       return undefined as unknown as V;
     }
-    Cache.instance()._lookups++;
-    Cache.instance()._hits += Cache.instance().has(key) ? 1 : 0;
-    return Cache._instance.get(key) as V;
+    Cache.instance().#lookups++;
+    Cache.instance().#hits += Cache.instance().has(key) ? 1 : 0;
+    return Cache.#instance.get(key) as V;
   }
 
   public static disable(): void {
-    Cache.instance()._enabled = false;
+    Cache.instance().#enabled = false;
   }
 
   public static enable(): void {
-    Cache.instance()._enabled = true;
+    Cache.instance().#enabled = true;
   }
 
   public get hits(): number {
-    return Cache.instance()._hits;
+    return Cache.instance().#hits;
   }
   public get lookups(): number {
-    return Cache.instance()._lookups;
+    return Cache.instance().#lookups;
   }
 }

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -7,27 +7,34 @@
 export class Cache extends Map {
   /* eslint-disable @typescript-eslint/explicit-member-accessibility */
   static #instance: Cache;
-  #hits = 0;
-  #lookups = 0;
-  #enabled = true;
+  static #enabled: boolean;
+  #hits: number;
+  #lookups: number;
   /* eslint-enable @typescript-eslint/explicit-member-accessibility */
+
+  private constructor() {
+    super();
+    this.#hits = 0;
+    this.#lookups = 0;
+  }
 
   public static instance(): Cache {
     if (!Cache.#instance) {
+      Cache.#enabled = true;
       Cache.#instance = new Cache();
     }
     return Cache.#instance;
   }
 
   public static set<V>(key: string, value: V) {
-    if (Cache.instance().#enabled) {
+    if (Cache.#enabled) {
       Cache.instance().set(key, value);
     }
   }
 
-  public static get<V>(key: string): V {
-    if (!Cache.instance().#enabled) {
-      return undefined as unknown as V;
+  public static get<V>(key: string): V | undefined {
+    if (!Cache.#enabled) {
+      return undefined;
     }
     Cache.instance().#lookups++;
     Cache.instance().#hits += Cache.instance().has(key) ? 1 : 0;
@@ -35,17 +42,17 @@ export class Cache extends Map {
   }
 
   public static disable(): void {
-    Cache.instance().#enabled = false;
+    Cache.#enabled = false;
   }
 
   public static enable(): void {
-    Cache.instance().#enabled = true;
+    Cache.#enabled = true;
   }
 
-  public get hits(): number {
+  public static get hits(): number {
     return Cache.instance().#hits;
   }
-  public get lookups(): number {
+  public static get lookups(): number {
     return Cache.instance().#lookups;
   }
 }

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -7,7 +7,7 @@
 export class Cache extends Map {
   /* eslint-disable @typescript-eslint/explicit-member-accessibility */
   static #instance: Cache;
-  static #enabled: boolean;
+  static #enabled = true;
   #hits: number;
   #lookups: number;
   /* eslint-enable @typescript-eslint/explicit-member-accessibility */
@@ -27,6 +27,7 @@ export class Cache extends Map {
   }
 
   public static set<V>(key: string, value: V) {
+    Cache.instance();
     if (Cache.#enabled) {
       Cache.instance().set(key, value);
     }

--- a/test/unit/config/configAggregatorTest.ts
+++ b/test/unit/config/configAggregatorTest.ts
@@ -11,6 +11,7 @@ import { ConfigFile } from '../../../src/config/configFile';
 import { OrgConfigProperties } from '../../../src/exported';
 import { testSetup } from '../../../src/testSetup';
 import { fs } from '../../../src/util/fs';
+import { Cache } from '../../../lib/util/cache';
 
 // Setup the test environment.
 const $$ = testSetup();
@@ -18,6 +19,7 @@ const $$ = testSetup();
 describe('ConfigAggregator', () => {
   let id: string;
   beforeEach(() => {
+    Cache.instance().clear();
     // Testing config functionality, so restore global stubs.
     $$.SANDBOXES.CONFIG.restore();
 

--- a/test/unit/crypto/cryptoKeyFailuresTest.ts
+++ b/test/unit/crypto/cryptoKeyFailuresTest.ts
@@ -11,6 +11,7 @@ import { AnyJson } from '@salesforce/ts-types';
 import { assert, expect } from 'chai';
 import { Crypto } from '../../../src/crypto/crypto';
 import { testSetup } from '../../../src/testSetup';
+import { Cache } from '../../../lib/util/cache';
 
 // Setup the test environment.
 const $$ = testSetup();
@@ -40,10 +41,12 @@ if (os.platform() === 'darwin') {
 
     before(() => {
       process.env.SFDX_USE_GENERIC_UNIX_KEYCHAIN = 'false';
+      Cache.disable();
     });
 
     after(() => {
       process.env.SFDX_USE_GENERIC_UNIX_KEYCHAIN = OLD_GENERIC_VAL || '';
+      Cache.enable();
     });
 
     beforeEach(() => {

--- a/test/unit/crypto/cryptoKeyFailuresTest.ts
+++ b/test/unit/crypto/cryptoKeyFailuresTest.ts
@@ -11,7 +11,7 @@ import { AnyJson } from '@salesforce/ts-types';
 import { assert, expect } from 'chai';
 import { Crypto } from '../../../src/crypto/crypto';
 import { testSetup } from '../../../src/testSetup';
-import { Cache } from '../../../lib/util/cache';
+import { Cache } from '../../../src/util/cache';
 
 // Setup the test environment.
 const $$ = testSetup();
@@ -41,7 +41,6 @@ if (os.platform() === 'darwin') {
 
     before(() => {
       process.env.SFDX_USE_GENERIC_UNIX_KEYCHAIN = 'false';
-      Cache.disable();
     });
 
     after(() => {
@@ -52,6 +51,7 @@ if (os.platform() === 'darwin') {
     beforeEach(() => {
       // Testing crypto functionality, so restore global stubs.
       $$.SANDBOXES.CRYPTO.restore();
+      Cache.disable();
     });
 
     it('should throw SetCredentialError when unable to get/set a keychain password', async () => {

--- a/test/unit/util/cacheTest.ts
+++ b/test/unit/util/cacheTest.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import { Cache } from '../../../src/util/cache';
+
+describe('cache', () => {
+  before(() => {
+    Cache.enable();
+  });
+  afterEach(() => {
+    Cache.enable();
+  });
+  it('should store a key and string value', () => {
+    Cache.set('key', 'a value');
+    const value = Cache.get('key');
+    expect(typeof value).to.be.equal('string');
+    expect(value).to.be.equal('a value');
+  });
+  it('should store a key and number value', () => {
+    Cache.set('key', 42);
+    const value = Cache.get('key');
+    expect(typeof value).to.be.equal('number');
+    expect(value).to.be.equal(42);
+  });
+  it('should return undefined for key not in cache', () => {
+    const value = Cache.get('somotherkey');
+    expect(value).to.not.be.ok;
+  });
+  it('should record cache hits', () => {
+    Cache.set('key', 'a value');
+    Cache.get('key');
+    expect(Cache.hits).to.be.greaterThan(0);
+  });
+  it('number of lookups should be greater than hits', () => {
+    Cache.set('key', 'a value');
+    Cache.get('key');
+    expect(Cache.lookups).to.be.greaterThan(Cache.hits);
+  });
+  it('should disable cache', () => {
+    Cache.set('key', 'a value');
+    expect(Cache.get('key')).to.be.ok;
+    Cache.disable();
+    expect(Cache.get('key')).to.not.be.ok;
+  });
+});


### PR DESCRIPTION
I have been looking at perf around keychain access and found that the keychain program is invoked many times during commands like org list/env list. Each org has a new auth info constructed, which requires the keychain be accessed to fetch the crypto key used for encrypt/decrypt. I found this inefficient and this PR proposes a solution for this.

My experiments were on my local box where I have 32 orgs. When running sf env list w/o this change I see times in the ~3 second range and with this change the time is reduced to ~1.2 seconds.