### PR TITLE
fix: force new release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,6 @@ workflows:
               external_project_git_url:
                 [
                   'https://github.com/salesforcecli/plugin-user',
-                  'https://github.com/salesforcecli/plugin-config',
                   'https://github.com/salesforcecli/plugin-alias',
                   'https://github.com/salesforcecli/plugin-limits',
                   'https://github.com/salesforcecli/plugin-auth',
@@ -131,6 +130,7 @@ workflows:
                   'https://github.com/salesforcecli/plugin-telemetry',
                 ]
                 # TODO
+                # re-enable: https://github.com/salesforcecli/plugin-config
                 # data (unlernafied)
                 # toolbelt (git auth because private)
       - release-management/release-package:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/core",
-  "version": "2.28.2",
+  "version": "2.28.3",
   "description": "Core libraries to interact with SFDX projects, orgs, and APIs.",
   "main": "lib/exported",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Force `v2.28.3` release.

This PR disables `plugin-config` failing NUTs that are blocking `release-package`. Re-enable after these are fixed in the plugin.