### PR TITLE
chore: re-enable plugin-config NUTs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,7 @@ workflows:
               external_project_git_url:
                 [
                   'https://github.com/salesforcecli/plugin-user',
+                  'https://github.com/salesforcecli/plugin-config',
                   'https://github.com/salesforcecli/plugin-alias',
                   'https://github.com/salesforcecli/plugin-limits',
                   'https://github.com/salesforcecli/plugin-auth',
@@ -130,7 +131,6 @@ workflows:
                   'https://github.com/salesforcecli/plugin-telemetry',
                 ]
                 # TODO
-                # re-enable: https://github.com/salesforcecli/plugin-config
                 # data (unlernafied)
                 # toolbelt (git auth because private)
       - release-management/release-package:


### PR DESCRIPTION
Re-enable plugin-config NUTs, these were temporary removed in this PR: https://github.com/forcedotcom/sfdx-core/pull/492 to unblock a new sfdx-core release.