### PR TITLE
fix: remove any types and match getter/setter type

### DIFF
--- a/src/sfdxError.ts
+++ b/src/sfdxError.ts
@@ -168,8 +168,7 @@ export class SfdxError extends NamedError {
    * The message string. Error.message
    */
   public message!: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public name: any;
+  public name!: string;
 
   /**
    * Action messages. Hints to the users regarding what can be done to fix related issues.
@@ -269,8 +268,7 @@ export class SfdxError extends NamedError {
     return sfdxError;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public get code(): string | undefined | any {
+  public get code(): string {
     return this._code || this.name;
   }
 


### PR DESCRIPTION
The different types for the getter/setter on SfdxError was causing tsc errors like this in consuming libraries:

```
node_modules/@salesforce/core/lib/sfdxError.d.ts:152:9 - error TS2380: 'get' and 'set' accessor must have the same type.

152     get code(): string | undefined | any;
            ~~~~

node_modules/@salesforce/core/lib/sfdxError.d.ts:153:9 - error TS2380: 'get' and 'set' accessor must have the same type.

153     set code(code: string);
```

@W-0@