### PR TITLE
fix: remove redundant warnings about no listerners on warnings

### DIFF
--- a/src/lifecycleEvents.ts
+++ b/src/lifecycleEvents.ts
@@ -193,7 +193,7 @@ export class Lifecycle {
    */
   public async emit<T = AnyJson>(eventName: string, data: T): Promise<void> {
     const listeners = this.getListeners(eventName);
-    if (listeners.length === 0) {
+    if (listeners.length === 0 && eventName !== Lifecycle.warningEventName) {
       this.debug(
         `A lifecycle event with the name ${eventName} does not exist. An event must be registered before it can be emitted.`
       );


### PR DESCRIPTION
Found as part of the work for @W-5657753@ but it's not required for the SDR PR to go forward.