### PR TITLE
fix: prefer instanceUrl for loginUrl on user:create

### DIFF
--- a/src/user.ts
+++ b/src/user.ts
@@ -379,7 +379,8 @@ export class User extends AsyncCreatable<User.Options> {
 
     // Setup oauth options for the new user
     const oauthOptions = {
-      loginUrl: adminUserAuthFields.loginUrl,
+      // Communities users require the instance for auth
+      loginUrl: adminUserAuthFields.instanceUrl ?? adminUserAuthFields.loginUrl,
       refreshToken: refreshTokenSecret.buffer.value((buffer: Buffer): string => buffer.toString('utf8')),
       clientId: adminUserAuthFields.clientId,
       clientSecret: adminUserAuthFields.clientSecret,


### PR DESCRIPTION
improve post-user creation auth by using instanceUrl over loginUrl (see gh issue for testing repro).

has been confirmed by customer that the fix works (see gh issue)

note about the note on the issue:
I did try deleting the org using plugin-org linked to this version of core, with no issues.

Testing notes--this only causes problem for community user create **with jwt** and **on Summer22** orgs

@W-10494033@
https://github.com/forcedotcom/cli/issues/1365

