### PR TITLE
Sm/delete deletes alias

### DIFF
--- a/src/org.ts
+++ b/src/org.ts
@@ -799,43 +799,40 @@ export class Org extends AsyncCreatable<Org.Options> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private async removeUsers(throwWhenRemoveFails: boolean): Promise<void> {
     this.logger.debug(`Removing users associate with org: ${this.getOrgId()}`);
-    const config = await this.retrieveOrgUsersConfig();
+    const [config, authInfos, aliases] = await Promise.all([
+      this.retrieveOrgUsersConfig(),
+      this.readUserAuthFiles(),
+      Aliases.create(Aliases.getDefaultOptions()),
+    ]);
     this.logger.debug(`using path for org users: ${config.getPath()}`);
-    if (await config.exists()) {
-      const authInfos: AuthInfo[] = await this.readUserAuthFiles();
-      const aliases: Aliases = await Aliases.create(Aliases.getDefaultOptions());
-      this.logger.info(`Cleaning up usernames in org: ${this.getOrgId()}`);
+    this.logger.info(`Cleaning up usernames in org: ${this.getOrgId()}`);
 
-      for (const auth of authInfos) {
-        const username = auth.getFields().username;
+    for (const auth of authInfos) {
+      const username = auth.getFields().username;
+      const aliasKeys = (username && aliases.getKeysByValue(username)) || [];
+      aliases.unsetAll(aliasKeys);
 
-        const aliasKeys = (username && aliases.getKeysByValue(username)) || [];
-        aliases.unsetAll(aliasKeys);
+      const orgForUser =
+        username === this.getUsername()
+          ? this
+          : await Org.create({
+              connection: await Connection.create({ authInfo: await AuthInfo.create({ username }) }),
+            });
 
-        let orgForUser;
-        if (username === this.getUsername()) {
-          orgForUser = this;
-        } else {
-          const info = await AuthInfo.create({ username });
-          const connection: Connection = await Connection.create({ authInfo: info });
-          orgForUser = await Org.create({ connection });
-        }
+      const orgType = this.isDevHubOrg() ? Config.DEFAULT_DEV_HUB_USERNAME : Config.DEFAULT_USERNAME;
 
-        const orgType = this.isDevHubOrg() ? Config.DEFAULT_DEV_HUB_USERNAME : Config.DEFAULT_USERNAME;
+      const configInfo: ConfigInfo = orgForUser.configAggregator.getInfo(orgType);
 
-        const configInfo: ConfigInfo = orgForUser.configAggregator.getInfo(orgType);
-
-        if (
-          (configInfo.value === username || aliasKeys.includes(configInfo.value as string)) &&
-          (configInfo.isGlobal() || configInfo.isLocal())
-        ) {
-          await Config.update(configInfo.isGlobal(), orgType, undefined);
-        }
-        await orgForUser.removeAuth();
+      if (
+        (configInfo.value === username || aliasKeys.includes(configInfo.value as string)) &&
+        (configInfo.isGlobal() || configInfo.isLocal())
+      ) {
+        await Config.update(configInfo.isGlobal(), orgType, undefined);
       }
-
-      await aliases.write();
+      await orgForUser.removeAuth();
     }
+
+    await aliases.write();
   }
 
   /**

--- a/test/unit/orgTest.ts
+++ b/test/unit/orgTest.ts
@@ -1014,9 +1014,10 @@ describe('Org Tests', () => {
       });
 
       // Stub to track the deleted paths.
-      const deletedPaths: string[] = [];
+      const deletedPaths = new Set<string>();
+
       stubMethod($$.SANDBOX, ConfigFile.prototype, 'unlink').callsFake(function (this: ConfigFile<ConfigFile.Options>) {
-        deletedPaths.push(this.getPath());
+        deletedPaths.add(this.getPath());
         return Promise.resolve({});
       });
 
@@ -1029,8 +1030,8 @@ describe('Org Tests', () => {
       // Remove the org
       await org.remove();
 
-      // Expect there are only two files.
-      expect(deletedPaths).to.have.length(2);
+      // Expect there are only two files deleted
+      expect(deletedPaths.size).to.equal(2);
       // Expect the sandbox config is deleted.
       expect(deletedPaths).includes(
         pathJoin(await $$.globalPathRetriever($$.id), Global.STATE_FOLDER, `${testData.orgId}.sandbox.json`)


### PR DESCRIPTION
removes what seems to be an unnecessary check for config.Exists() around removing auth infos.  This was affecting both sandboxes and scratch orgs from what I can see.

That prevents both the defaultusername (config) and aliases from being deleted.

QA notes: 
I would definitely create a sandbox and `org:delete` it.  All of the deletes of config files seemed to be protected with their own `exists` check.

I think there are org:delete sandbox NUTs so you should run those, too.

[@W-10717340@](https://gus.lightning.force.com/a07EE00000pSWdtYAG)