### PR TITLE
Rename SfdxProject to SfProject and SfdxError to SfError

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,6 @@ workflows:
                   'https://github.com/salesforcecli/plugin-env',
                   'https://github.com/salesforcecli/plugin-login',
                   'https://github.com/salesforcecli/plugin-deploy-retrieve',
-                  'https://github.com/salesforcecli/plugin-deploy-retrieve-metadata',
                 ]
       - release-management/release-package:
           # TODO: add these back when we're ready to GA v3

--- a/EXPORTED.md
+++ b/EXPORTED.md
@@ -41,7 +41,7 @@ Represents a Salesforce DX project, defined by the file `sfdx-project.json`.
 
 All logging in `sfdx-core` is accomplished through this logging class. Anyone can also use the logger to log their own log lines to the `sfdx.log` file or to any other log file or stream by utilizing the log level flags and envars set by the CLI or framework.
 
-## [SfdxError]{@link SfdxError}
+## [SfError]{@link SfError}
 
 An error class that is always thrown from `sfdx-core`, providing useful formatting and contextual data.
 

--- a/EXPORTED.md
+++ b/EXPORTED.md
@@ -27,13 +27,13 @@ Represents a config file at either a local or global path. The config file exten
 - {@link Aliases}
 - {@link OrgUsersConfig}
 - {@link Config}
-- {@link SfdxProjectJson}
+- {@link SfProjectJson}
 
 ## {@link ConfigAggregator}
 
 Aggregates local, global, and environment config values using {@link Config} and environment variables.
 
-## {@link SfdxProject}
+## {@link SfProject}
 
 Represents a Salesforce DX project, defined by the file `sfdx-project.json`.
 

--- a/MIGRATING_V2-V3.md
+++ b/MIGRATING_V2-V3.md
@@ -188,10 +188,11 @@ Quite often, customers would get the error `Missing message <bundle>:<key> for l
 
 We created the method `load` to really highlight the change and require the type key param. Making it optional on `loadMessages` could lead to mistakes as well. Plus, the word messages there is redundant. We did not rename `getMessages` to reduce the amount of code changes.
 
-## SfError (formerley SfdxError)
+## SfError (formerly SfdxError)
 
 ### What?
 
+- Renamed: `SfdxError` to `SfError`
 - Removed: `SfdxErrorConfig`
 - Removed: `SfdxError.create`
 
@@ -251,3 +252,14 @@ While standardizing on our message files, we realized that there were a lot of i
 | MissingGroupNameError                        | MissingGroupNameError                        |
 | ValidationSchemaFieldErrors                  | ValidationSchemaFieldError                   |
 | ValidationSchemaUnknown                      | ValidationSchemaUnknownError                 |
+
+## SfdxProject
+
+### What?
+
+- Renamed `SfdxProject` to `SfProject`
+- Renamed `SfdxProjectJson` to `SfProjectJson`
+
+### Why?
+
+As we move to supporting the new `sf` executable, we want the naming to be consistent.

--- a/MIGRATING_V2-V3.md
+++ b/MIGRATING_V2-V3.md
@@ -188,12 +188,12 @@ Quite often, customers would get the error `Missing message <bundle>:<key> for l
 
 We created the method `load` to really highlight the change and require the type key param. Making it optional on `loadMessages` could lead to mistakes as well. Plus, the word messages there is redundant. We did not rename `getMessages` to reduce the amount of code changes.
 
-## SfdxError
+## SfError (formerley SfdxError)
 
 ### What?
 
 - Removed: `SfdxErrorConfig`
-- Removed: `Sfdx.create`
+- Removed: `SfdxError.create`
 
 **v2:**
 
@@ -210,7 +210,7 @@ const messages = Messages.load('<package>', '<bundle>', ['myKey', 'actionKey']);
 const errName = 'myKey';
 const errMessage = messages.getMessage(errName, ['tokens']);
 const errActions = messages.getMessages('actionsKey', ['actionTokens']);
-throw new SfdxError(errMessage, errName, errActions);
+throw new SfError(errMessage, errName, errActions);
 ```
 
 ### Why?

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ describe('Mocking Auth data', () => {
 After having a valid AuthInfo object you can then create fake connections to a Salesforce.com scratch org. This allows for writing tests that can validate result responses for SOQL queries and REST endpoints.
 
 ```typescript
-import { AuthInfo, Connection, SfdxError } from '@salesforce/core';
+import { AuthInfo, Connection, SfError } from '@salesforce/core';
 import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
 import { AnyJson, ensureJsonMap, JsonMap } from '@salesforce/ts-types';
 import { ensureString } from '@salesforce/ts-types';
@@ -77,7 +77,7 @@ describe('Mocking a force server call', () => {
       if (request && ensureString(_request.url).includes('Account')) {
         return Promise.resolve(records);
       } else {
-        return Promise.reject(new SfdxError(`Unexpected request: ${_request.url}`));
+        return Promise.reject(new SfError(`Unexpected request: ${_request.url}`));
       }
     };
     const connection: Connection = await Connection.create({
@@ -117,13 +117,13 @@ describe('Using the built in Sinon sandbox.', () => {
 It's important to have negative tests that ensure proper error handling. With `shouldThrow` it's easy to test for expected async rejections.
 
 ```typescript
-import { SfdxError } from '@salesforce/core';
+import { SfError } from '@salesforce/core';
 import { shouldThrow } from '@salesforce/core/lib/testSetup';
 import { strictEqual } from 'assert';
 
 class TestObject {
   public static async method() {
-    throw new SfdxError('Error', 'ExpectedError');
+    throw new SfError('Error', 'ExpectedError');
   }
 }
 

--- a/examples/examples/test/unit/MockServerRequest.ts
+++ b/examples/examples/test/unit/MockServerRequest.ts
@@ -1,4 +1,4 @@
-import { AuthInfo, Connection, SfdxError } from '@salesforce/core';
+import { AuthInfo, Connection, SfError } from '@salesforce/core';
 import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
 import { AnyJson, ensureJsonMap, JsonMap } from '@salesforce/ts-types';
 import { ensureString } from '@salesforce/ts-types';
@@ -23,7 +23,7 @@ describe('Mocking a force server call', () => {
       if (request && ensureString(_request.url).includes('Account')) {
         return Promise.resolve(records);
       } else {
-        return Promise.reject(new SfdxError(`Unexpected request: ${_request.url}`));
+        return Promise.reject(new SfError(`Unexpected request: ${_request.url}`));
       }
     };
     const connection: Connection = await Connection.create({

--- a/examples/examples/test/unit/TestExpectedError.ts
+++ b/examples/examples/test/unit/TestExpectedError.ts
@@ -1,10 +1,10 @@
-import { SfdxError } from '@salesforce/core';
+import { SfError } from '@salesforce/core';
 import { shouldThrow } from '@salesforce/core/lib/testSetup';
 import { strictEqual } from 'assert';
 
 class TestObject {
   public static async method() {
-    throw new SfdxError('Error', 'ExpectedError');
+    throw new SfError('Error', 'ExpectedError');
   }
 }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -414,7 +414,7 @@ export class Config extends ConfigFile<ConfigFile.Options, ConfigProperties> {
    * DO NOT CALL - The config file needs to encrypt values which can only be done asynchronously.
    * Call {@link SfdxConfig.write} instead.
    *
-   * **Throws** *{@link SfdxError}{ name: 'InvalidWriteError' }* Always.
+   * **Throws** *{@link SfError}{ name: 'InvalidWriteError' }* Always.
    *
    * @param newContents Contents to write
    */
@@ -426,8 +426,8 @@ export class Config extends ConfigFile<ConfigFile.Options, ConfigProperties> {
   /**
    * Sets a value for a property.
    *
-   * **Throws** *{@link SfdxError}{ name: 'UnknownConfigKeyError' }* An attempt to get a property that's not supported.
-   * **Throws** *{@link SfdxError}{ name: 'InvalidConfigValueError' }* If the input validator fails.
+   * **Throws** *{@link SfError}{ name: 'UnknownConfigKeyError' }* An attempt to get a property that's not supported.
+   * **Throws** *{@link SfError}{ name: 'InvalidConfigValueError' }* If the input validator fails.
    *
    * @param key The property to set.
    * @param value The value of the property.
@@ -463,7 +463,7 @@ export class Config extends ConfigFile<ConfigFile.Options, ConfigProperties> {
   /**
    * Unsets a value for a property.
    *
-   * **Throws** *{@link SfdxError}{ name: 'UnknownConfigKeyError' }* If the input validator fails.
+   * **Throws** *{@link SfError}{ name: 'UnknownConfigKeyError' }* If the input validator fails.
    *
    * @param key The property to unset.
    */
@@ -484,7 +484,7 @@ export class Config extends ConfigFile<ConfigFile.Options, ConfigProperties> {
   /**
    * Get an individual property config.
    *
-   * **Throws** *{@link SfdxError}{ name: 'UnknownConfigKeyError' }* An attempt to get a property that's not supported.
+   * **Throws** *{@link SfError}{ name: 'UnknownConfigKeyError' }* An attempt to get a property that's not supported.
    *
    * @param propertyName The name of the property.
    */

--- a/src/config/configAggregator.ts
+++ b/src/config/configAggregator.ts
@@ -165,7 +165,7 @@ export class ConfigAggregator extends AsyncOptionalCreatable<JsonMap> {
   /**
    * Get a resolved config property.
    *
-   * **Throws** *{@link SfdxError}{ name: 'UnknownConfigKeyError' }* An attempt to get a property that's not supported.
+   * **Throws** *{@link SfError}{ name: 'UnknownConfigKeyError' }* An attempt to get a property that's not supported.
    *
    * @param key The key of the property.
    */
@@ -180,7 +180,7 @@ export class ConfigAggregator extends AsyncOptionalCreatable<JsonMap> {
   /**
    * Get a resolved config property meta.
    *
-   * **Throws** *{@link SfdxError}{ name: 'UnknownConfigKeyError' }* An attempt to get a property that's not supported.
+   * **Throws** *{@link SfError}{ name: 'UnknownConfigKeyError' }* An attempt to get a property that's not supported.
    *
    * @param key The key of the property.
    */

--- a/src/config/configFile.ts
+++ b/src/config/configFile.ts
@@ -11,7 +11,7 @@ import { dirname as pathDirname, join as pathJoin } from 'path';
 import { isBoolean, isPlainObject } from '@salesforce/ts-types';
 import { Global } from '../global';
 import { Logger } from '../logger';
-import { SfdxError } from '../sfdxError';
+import { SfError } from '../sfError';
 import { fs } from '../util/fs';
 import { resolveProjectPath, resolveProjectPathSync } from '../util/internal';
 import { BaseConfigStore, ConfigContents } from './configStore';
@@ -75,7 +75,7 @@ export class ConfigFile<
    */
   public static getFileName(): string {
     // Can not have abstract static methods, so throw a runtime error.
-    throw new SfdxError('Unknown filename for config file.');
+    throw new SfError('Unknown filename for config file.');
   }
 
   /**
@@ -149,7 +149,7 @@ export class ConfigFile<
    * Read the config file and set the config contents. Returns the config contents of the config file. As an
    * optimization, files are only read once per process and updated in memory and via `write()`. To force
    * a read from the filesystem pass `force=true`.
-   * **Throws** *{@link SfdxError}{ name: 'UnexpectedJsonFileFormat' }* There was a problem reading or parsing the file.
+   * **Throws** *{@link SfError}{ name: 'UnexpectedJsonFileFormat' }* There was a problem reading or parsing the file.
    *
    * @param [throwOnNotFound = false] Optionally indicate if a throw should occur on file read.
    * @param [force = false] Optionally force the file to be read from disk even when already read within the process.
@@ -165,7 +165,7 @@ export class ConfigFile<
       }
       return this.getContents();
     } catch (err) {
-      if ((err as SfdxError).code === 'ENOENT') {
+      if ((err as SfError).code === 'ENOENT') {
         if (!throwOnNotFound) {
           this.setContents();
           return this.getContents();
@@ -183,7 +183,7 @@ export class ConfigFile<
    * Read the config file and set the config contents. Returns the config contents of the config file. As an
    * optimization, files are only read once per process and updated in memory and via `write()`. To force
    * a read from the filesystem pass `force=true`.
-   * **Throws** *{@link SfdxError}{ name: 'UnexpectedJsonFileFormat' }* There was a problem reading or parsing the file.
+   * **Throws** *{@link SfError}{ name: 'UnexpectedJsonFileFormat' }* There was a problem reading or parsing the file.
    *
    * @param [throwOnNotFound = false] Optionally indicate if a throw should occur on file read.
    * @param [force = false] Optionally force the file to be read from disk even when already read within the process.
@@ -199,7 +199,7 @@ export class ConfigFile<
       }
       return this.getContents();
     } catch (err) {
-      if ((err as SfdxError).code === 'ENOENT') {
+      if ((err as SfError).code === 'ENOENT') {
         if (!throwOnNotFound) {
           this.setContents();
           return this.getContents();
@@ -294,7 +294,7 @@ export class ConfigFile<
     if (exists) {
       return await fs.unlink(this.getPath());
     }
-    throw new SfdxError(`Target file doesn't exist. path: ${this.getPath()}`, 'TargetFileNotFound');
+    throw new SfError(`Target file doesn't exist. path: ${this.getPath()}`, 'TargetFileNotFound');
   }
 
   /**
@@ -308,7 +308,7 @@ export class ConfigFile<
     if (exists) {
       return fs.unlinkSync(this.getPath());
     }
-    throw new SfdxError(`Target file doesn't exist. path: ${this.getPath()}`, 'TargetFileNotFound');
+    throw new SfError(`Target file doesn't exist. path: ${this.getPath()}`, 'TargetFileNotFound');
   }
 
   /**
@@ -321,7 +321,7 @@ export class ConfigFile<
   public getPath(): string {
     if (!this.path) {
       if (!this.options.filename) {
-        throw new SfdxError('The ConfigOptions filename parameter is invalid.', 'InvalidParameter');
+        throw new SfError('The ConfigOptions filename parameter is invalid.', 'InvalidParameter');
       }
 
       const _isGlobal: boolean = isBoolean(this.options.isGlobal) && this.options.isGlobal;

--- a/src/config/configStore.ts
+++ b/src/config/configStore.ts
@@ -19,7 +19,7 @@ import {
   Optional,
 } from '@salesforce/ts-types';
 import { Crypto } from '../crypto/crypto';
-import { SfdxError } from '../sfdxError';
+import { SfError } from '../sfError';
 
 /**
  * The allowed types stored in a config store.
@@ -403,17 +403,17 @@ export abstract class BaseConfigStore<
 
   protected encrypt(value: unknown): Optional<string> {
     if (!value) return;
-    if (!this.crypto) throw new SfdxError('crypto is not initialized', 'CryptoNotInitializedError');
+    if (!this.crypto) throw new SfError('crypto is not initialized', 'CryptoNotInitializedError');
     if (!isString(value))
-      throw new SfdxError(`can only encrypt strings but found: ${typeof value} : ${value}`, 'InvalidCryptoValueError');
+      throw new SfError(`can only encrypt strings but found: ${typeof value} : ${value}`, 'InvalidCryptoValueError');
     return this.crypto.isEncrypted(value) ? value : this.crypto.encrypt(value);
   }
 
   protected decrypt(value: unknown): Optional<string> {
     if (!value) return;
-    if (!this.crypto) throw new SfdxError('crypto is not initialized', 'CryptoNotInitializedError');
+    if (!this.crypto) throw new SfError('crypto is not initialized', 'CryptoNotInitializedError');
     if (!isString(value))
-      throw new SfdxError(`can only encrypt strings but found: ${typeof value} : ${value}`, 'InvalidCryptoValueError');
+      throw new SfError(`can only encrypt strings but found: ${typeof value} : ${value}`, 'InvalidCryptoValueError');
     return this.crypto.isEncrypted(value) ? this.crypto.decrypt(value) : value;
   }
 

--- a/src/crypto/keyChainImpl.ts
+++ b/src/crypto/keyChainImpl.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import { homedir } from 'os';
 import { asString, ensureString, Nullable } from '@salesforce/ts-types';
 import { Global } from '../global';
-import { SfdxError } from '../sfdxError';
+import { SfError } from '../sfError';
 import { fs } from '../util/fs';
 import { Messages } from '../messages';
 
@@ -67,9 +67,9 @@ const _isExe = (mode: number, gid: number, uid: number) => {
 /**
  * Private helper to validate that a program exists on the file system and is executable.
  *
- * **Throws** *{@link SfdxError}{ name: 'MissingCredentialProgramError' }* When the OS credential program isn't found.
+ * **Throws** *{@link SfError}{ name: 'MissingCredentialProgramError' }* When the OS credential program isn't found.
  *
- * **Throws** *{@link SfdxError}{ name: 'CredentialProgramAccessError' }* When the OS credential program isn't accessible.
+ * **Throws** *{@link SfError}{ name: 'CredentialProgramAccessError' }* When the OS credential program isn't accessible.
  *
  * @param programPath The absolute path of the program.
  * @param fsIfc The file system interface.
@@ -371,7 +371,7 @@ const _darwinImpl: OsImpl = {
   },
 
   async onGetCommandClose(code, stdout, stderr, opts, fn) {
-    let err: SfdxError;
+    let err: SfError;
 
     if (code !== 0) {
       switch (code) {

--- a/src/deviceOauthService.ts
+++ b/src/deviceOauthService.ts
@@ -15,7 +15,7 @@ import { HttpRequest } from 'jsforce';
 import { Nullable, ensureString, JsonMap } from '@salesforce/ts-types';
 import { Logger } from './logger';
 import { AuthInfo, DEFAULT_CONNECTED_APP_INFO } from './org/authInfo';
-import { SfdxError } from './sfdxError';
+import { SfError } from './sfError';
 import { SFDX_HTTP_HEADERS } from './org/connection';
 import { Messages } from './messages';
 
@@ -50,7 +50,7 @@ async function makeRequest<T extends JsonMap>(options: HttpRequest): Promise<T> 
   const rawResponse = await new Transport().httpRequest(options);
   const response = parseJsonMap<T>(rawResponse.body);
   if (response.error) {
-    const err = new SfdxError('Request Failed.');
+    const err = new SfError('Request Failed.');
     err.data = Object.assign(response, { status: rawResponse.statusCode });
     throw err;
   } else {
@@ -177,7 +177,7 @@ export class DeviceOauthService extends AsyncCreatable<OAuth2Config> {
       return await makeRequest<DeviceCodePollingResponse>(httpRequest);
     } catch (e) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const err: any = (e as SfdxError).data;
+      const err: any = (e as SfError).data;
       if (err.error && err.status === 400 && err.error === 'authorization_pending') {
         // do nothing because we're still waiting
       } else {

--- a/src/exported.ts
+++ b/src/exported.ts
@@ -76,7 +76,15 @@ export {
 
 export { OrgConfigProperties, ORG_CONFIG_ALLOWED_PROPERTIES } from './org/orgConfigProperties';
 
-export { PackageDir, NamedPackageDir, PackageDirDependency, SfdxProject, SfdxProjectJson } from './sfdxProject';
+export {
+  PackageDir,
+  NamedPackageDir,
+  PackageDirDependency,
+  SfProject,
+  SfProjectJson,
+  SfdxProject,
+  SfdxProjectJson,
+} from './sfProject';
 
 export { SchemaPrinter } from './schema/printer';
 

--- a/src/exported.ts
+++ b/src/exported.ts
@@ -82,7 +82,7 @@ export { SchemaPrinter } from './schema/printer';
 
 export { SchemaValidator } from './schema/validator';
 
-export { SfdxError } from './sfdxError';
+export { SfError, SfdxError } from './sfError';
 
 export { PollingClient } from './status/pollingClient';
 

--- a/src/globalInfo/accessors/aliasAccessor.ts
+++ b/src/globalInfo/accessors/aliasAccessor.ts
@@ -6,7 +6,7 @@
  */
 
 import { Nullable } from '@salesforce/ts-types';
-import { SfdxError } from '../../sfdxError';
+import { SfError } from '../../sfError';
 import { GlobalInfo } from '../globalInfoConfig';
 import { SfAliases, SfOrg, SfInfoKeys, SfToken } from '../types';
 
@@ -135,7 +135,7 @@ export class AliasAccessor {
     if (typeof entity === 'string') return entity;
     const aliaseeName = entity.username ?? entity.user;
     if (!aliaseeName) {
-      throw new SfdxError(`Invalid aliasee, it must contain a user or username property: ${JSON.stringify(entity)}`);
+      throw new SfError(`Invalid aliasee, it must contain a user or username property: ${JSON.stringify(entity)}`);
     }
     return aliaseeName as string;
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -26,7 +26,7 @@ import {
 } from '@salesforce/ts-types';
 import * as Debug from 'debug';
 import { Global, Mode } from './global';
-import { SfdxError } from './sfdxError';
+import { SfError } from './sfError';
 import { fs } from './util/fs';
 
 /**
@@ -234,7 +234,7 @@ export class Logger {
    *
    * @param optionsOrName A set of `LoggerOptions` or name to use with the default options.
    *
-   * **Throws** *{@link SfdxError}{ name: 'RedundantRootLoggerError' }* More than one attempt is made to construct the root
+   * **Throws** *{@link SfError}{ name: 'RedundantRootLoggerError' }* More than one attempt is made to construct the root
    * `Logger`.
    */
   public constructor(optionsOrName: LoggerOptions | string) {
@@ -250,7 +250,7 @@ export class Logger {
     }
 
     if (Logger.rootLogger && options.name === Logger.ROOT_NAME) {
-      throw new SfdxError('Can not create another root logger.', 'RedundantRootLoggerError');
+      throw new SfError('Can not create another root logger.', 'RedundantRootLoggerError');
     }
 
     // Inspect format to know what logging format to use then delete from options to
@@ -363,13 +363,13 @@ export class Logger {
    *
    * @param {string} levelName The level name to convert to a `LoggerLevel` enum value.
    *
-   * **Throws** *{@link SfdxError}{ name: 'UnrecognizedLoggerLevelNameError' }* The level name was not case-insensitively recognized as a valid `LoggerLevel` value.
+   * **Throws** *{@link SfError}{ name: 'UnrecognizedLoggerLevelNameError' }* The level name was not case-insensitively recognized as a valid `LoggerLevel` value.
    * @see {@Link LoggerLevel}
    */
   public static getLevelByName(levelName: string): LoggerLevelValue {
     levelName = levelName.toUpperCase();
     if (!isKeyOf(LoggerLevel, levelName)) {
-      throw new SfdxError(`Invalid log level "${levelName}".`, 'UnrecognizedLoggerLevelNameError');
+      throw new SfError(`Invalid log level "${levelName}".`, 'UnrecognizedLoggerLevelNameError');
     }
     return LoggerLevel[levelName];
   }
@@ -407,7 +407,7 @@ export class Logger {
       try {
         await fs.writeFile(logFile, '', { mode: fs.DEFAULT_USER_FILE_MODE });
       } catch (err3) {
-        throw SfdxError.wrap(err3 as string | Error);
+        throw SfError.wrap(err3 as string | Error);
       }
     }
 
@@ -449,7 +449,7 @@ export class Logger {
       try {
         fs.writeFileSync(logFile, '', { mode: fs.DEFAULT_USER_FILE_MODE });
       } catch (err3) {
-        throw SfdxError.wrap(err3 as string | Error);
+        throw SfError.wrap(err3 as string | Error);
       }
     }
 
@@ -492,7 +492,7 @@ export class Logger {
    *
    * @param {LoggerLevelValue} [level] The logger level.
    *
-   * **Throws** *{@link SfdxError}{ name: 'UnrecognizedLoggerLevelNameError' }* A value of `level` read from `SFDX_LOG_LEVEL`
+   * **Throws** *{@link SfError}{ name: 'UnrecognizedLoggerLevelNameError' }* A value of `level` read from `SFDX_LOG_LEVEL`
    * was invalid.
    *
    * ```
@@ -631,7 +631,7 @@ export class Logger {
    */
   public child(name: string, fields: Fields = {}): Logger {
     if (!name) {
-      throw new SfdxError('LoggerNameRequired');
+      throw new SfError('LoggerNameRequired');
     }
     fields.log = name;
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -20,7 +20,7 @@ import {
   Optional,
 } from '@salesforce/ts-types';
 import { NamedError, upperFirst } from '@salesforce/kit';
-import { SfdxError } from './sfdxError';
+import { SfError } from './sfError';
 
 export type Tokens = Array<string | boolean | number | null | undefined>;
 
@@ -85,7 +85,7 @@ const markdownLoader: FileParser = (filePath: string, fileContents: string): Sto
         map.set(key, rest);
       }
     } else {
-      // use error instead of SfdxError because messages.js should have no internal dependencies.
+      // use error instead of SfError because messages.js should have no internal dependencies.
       throw new Error(
         `Invalid markdown message file: ${filePath}\nThe line "# <key>" must be immediately followed by the message on a new line.`
       );
@@ -285,7 +285,7 @@ export class Messages<T extends string> {
       if (!fileContents || fileContents.trim().length === 0) {
         // messages.js should have no internal dependencies.
         const error = new Error(`Invalid message file: ${filePath}. No content.`);
-        error.name = 'SfdxError';
+        error.name = 'SfError';
         throw error;
       }
 
@@ -343,7 +343,7 @@ export class Messages<T extends string> {
         fs.statSync(path.join(projectRoot, 'package.json'));
         break;
       } catch (err) {
-        if ((err as SfdxError).code !== 'ENOENT') throw err;
+        if ((err as SfError).code !== 'ENOENT') throw err;
         projectRoot = projectRoot.substring(0, projectRoot.lastIndexOf(path.sep));
       }
     }
@@ -542,7 +542,7 @@ export class Messages<T extends string> {
     actionTokens: Tokens = [],
     exitCodeOrCause?: number | Error,
     cause?: Error
-  ): SfdxError {
+  ): SfError {
     // Convert key to name:
     //     'myMessage' -> `MyMessageError`
     //     'myMessageError' -> `MyMessageError`
@@ -556,7 +556,7 @@ export class Messages<T extends string> {
     } catch (e) {
       /* just ignore if actions aren't found */
     }
-    return new SfdxError(errMessage, errName, errActions, exitCodeOrCause, cause);
+    return new SfError(errMessage, errName, errActions, exitCodeOrCause, cause);
   }
 
   private getMessageWithMap(key: string, tokens: Tokens = [], map: StoredMessageMap): string[] {

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -28,7 +28,7 @@ import * as jwt from 'jsonwebtoken';
 import { Config } from '../config/config';
 import { ConfigAggregator } from '../config/configAggregator';
 import { Logger } from '../logger';
-import { SfdxError } from '../sfdxError';
+import { SfError } from '../sfError';
 import { fs } from '../util/fs';
 import { sfdc } from '../util/sfdc';
 import { SfOrg, GlobalInfo } from '../globalInfo';
@@ -330,7 +330,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
       const auths = (await GlobalInfo.getInstance()).orgs.getAll();
       return !isEmpty(auths);
     } catch (err) {
-      const error = err as SfdxError;
+      const error = err as SfError;
       if (error.name === 'OrgDataNotAvailableError' || error.code === 'ENOENT') {
         return false;
       }
@@ -377,7 +377,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     );
 
     if (!match) {
-      throw new SfdxError(
+      throw new SfError(
         'Invalid SFDX auth URL. Must be in the format "force://<clientId>:<clientSecret>:<refreshToken>@<instanceUrl>".  Note that the SFDX auth URL uses the "force" protocol, and not "http" or "https".  Also note that the "instanceUrl" inside the SFDX auth URL doesn\'t include the protocol ("https://").',
         'INVALID_SFDX_AUTH_URL'
       );
@@ -668,7 +668,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
    *
    * @param options Options to be used for creating an OAuth2 instance.
    *
-   * **Throws** *{@link SfdxError}{ name: 'NamedOrgNotFoundError' }* Org information does not exist.
+   * **Throws** *{@link SfError}{ name: 'NamedOrgNotFoundError' }* Org information does not exist.
    * @returns {Promise<AuthInfo>}
    */
   private async initAuthOptions(options?: OAuth2Config | AccessTokenOptions): Promise<AuthInfo> {
@@ -757,7 +757,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
   // both for a JWT connection and an OAuth connection.
   private async refreshFn(
     conn: Connection,
-    callback: (err: Nullable<Error | SfdxError>, accessToken?: string, res?: Record<string, unknown>) => Promise<void>
+    callback: (err: Nullable<Error | SfError>, accessToken?: string, res?: Record<string, unknown>) => Promise<void>
   ): Promise<void> {
     this.logger.info('Access token has expired. Updating...');
 
@@ -975,7 +975,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     } catch (err) {
       errorMsg = `${bodyAsString}`;
     }
-    throw new SfdxError(errorMsg);
+    throw new SfError(errorMsg);
   }
 }
 

--- a/src/org/authRemover.ts
+++ b/src/org/authRemover.ts
@@ -72,8 +72,8 @@ export class AuthRemover extends AsyncOptionalCreatable {
 
   /**
    * Finds authorization files for username/alias in the global .sfdx folder
-   * **Throws** *{@link SfdxError}{ name: 'TargetOrgNotSetError' }* if no target-org
-   * **Throws** *{@link SfdxError}{ name: 'NamedOrgNotFoundError' }* if specified user is not found
+   * **Throws** *{@link SfError}{ name: 'TargetOrgNotSetError' }* if no target-org
+   * **Throws** *{@link SfError}{ name: 'NamedOrgNotFoundError' }* if specified user is not found
    *
    * @param usernameOrAlias username or alias of the auth you want to find, defaults to the configured target-org
    * @returns {Promise<SfOrg>}

--- a/src/org/connection.ts
+++ b/src/org/connection.ts
@@ -36,7 +36,7 @@ import { StreamPromise } from 'jsforce/lib/util/promise';
 import { MyDomainResolver } from '../status/myDomainResolver';
 import { ConfigAggregator } from '../config/configAggregator';
 import { Logger } from '../logger';
-import { SfdxError } from '../sfdxError';
+import { SfError } from '../sfError';
 import { sfdc } from '../util/sfdc';
 import { Messages } from '../messages';
 import { Lifecycle } from '../lifecycleEvents';
@@ -352,7 +352,7 @@ export class Connection<S extends Schema = Schema> extends JSForceConnection<S> 
   /**
    * Set the API version for all connection requests.
    *
-   * **Throws** *{@link SfdxError}{ name: 'IncorrectAPIVersionError' }* Incorrect API version.
+   * **Throws** *{@link SfError}{ name: 'IncorrectAPIVersionError' }* Incorrect API version.
    *
    * @param version The API version.
    */
@@ -459,10 +459,10 @@ export class Connection<S extends Schema = Schema> extends JSForceConnection<S> 
   ): Promise<T> {
     const result = options.tooling ? await this.tooling.query<T>(soql) : await this.query<T>(soql);
     if (result.totalSize === 0) {
-      throw new SfdxError(`No record found for ${soql}`, SingleRecordQueryErrors.NoRecords);
+      throw new SfError(`No record found for ${soql}`, SingleRecordQueryErrors.NoRecords);
     }
     if (result.totalSize > 1) {
-      throw new SfdxError(
+      throw new SfError(
         options.returnChoicesOnMultiple
           ? `Multiple records found. ${result.records.map((item) => item[options.choiceField as keyof T]).join(',')}`
           : 'The query returned more than 1 record',

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -30,7 +30,7 @@ import { SandboxOrgConfig } from '../config/sandboxOrgConfig';
 import { Global } from '../global';
 import { Lifecycle } from '../lifecycleEvents';
 import { Logger } from '../logger';
-import { SfdxError } from '../sfdxError';
+import { SfError } from '../sfError';
 import { fs } from '../util/fs';
 import { sfdc } from '../util/sfdc';
 import { WebOAuthServer } from '../webOAuthServer';
@@ -295,9 +295,9 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
   /**
    * Check that this org is a scratch org by asking the dev hub if it knows about it.
    *
-   * **Throws** *{@link SfdxError}{ name: 'NotADevHubError' }* Not a Dev Hub.
+   * **Throws** *{@link SfError}{ name: 'NotADevHubError' }* Not a Dev Hub.
    *
-   * **Throws** *{@link SfdxError}{ name: 'NoResultsError' }* No results.
+   * **Throws** *{@link SfError}{ name: 'NoResultsError' }* No results.
    *
    * @param devHubUsernameOrAlias The username or alias of the dev hub org.
    */
@@ -318,7 +318,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
     try {
       const results = await devHubConnection.query(DEV_HUB_SOQL);
       if (getNumber(results, 'records.length') !== 1) {
-        throw new SfdxError('No results', 'NoResultsError');
+        throw new SfError('No results', 'NoResultsError');
       }
     } catch (err) {
       if (err instanceof Error && err.name === 'INVALID_TYPE') {
@@ -567,7 +567,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
    */
   public async addUsername(auth: AuthInfo | string): Promise<Org> {
     if (!auth) {
-      throw new SfdxError('Missing auth info', 'MissingAuthInfo');
+      throw new SfError('Missing auth info', 'MissingAuthInfo');
     }
 
     const authInfo = isString(auth) ? await AuthInfo.create({ username: auth }) : auth;
@@ -581,7 +581,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
     const usernames = contents.usernames || [];
 
     if (!isArray(usernames)) {
-      throw new SfdxError('Usernames is not an array', 'UnexpectedDataFormat');
+      throw new SfError('Usernames is not an array', 'UnexpectedDataFormat');
     }
 
     let shouldUpdate = false;
@@ -609,13 +609,13 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
   /**
    * Removes a username from the user config for this object. For convenience `this` object is returned.
    *
-   * **Throws** *{@link SfdxError}{ name: 'MissingAuthInfoError' }* Auth info is missing.
+   * **Throws** *{@link SfError}{ name: 'MissingAuthInfoError' }* Auth info is missing.
    *
    * @param {AuthInfo | string} auth The AuthInfo containing the username to remove.
    */
   public async removeUsername(auth: AuthInfo | string): Promise<Org> {
     if (!auth) {
-      throw new SfdxError('Missing auth info', 'MissingAuthInfoError');
+      throw new SfError('Missing auth info', 'MissingAuthInfoError');
     }
 
     const authInfo: AuthInfo = isString(auth) ? await AuthInfo.create({ username: auth }) : auth;
@@ -742,7 +742,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
         throw messages.createError('noUsernameFound');
       }
       this.connection = await Connection.create({
-        // If no username is provided or resolvable from an alias, AuthInfo will throw an SfdxError.
+        // If no username is provided or resolvable from an alias, AuthInfo will throw an SfError.
         authInfo: await AuthInfo.create({ username, isDevHub: this.options.isDevHub }),
       });
     } else {
@@ -752,10 +752,10 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
   }
 
   /**
-   * **Throws** *{@link SfdxError}{ name: 'NotSupportedError' }* Throws an unsupported error.
+   * **Throws** *{@link SfError}{ name: 'NotSupportedError' }* Throws an unsupported error.
    */
   protected getDefaultOptions(): Org.Options {
-    throw new SfdxError('Not Supported', 'NotSupportedError');
+    throw new SfError('Not Supported', 'NotSupportedError');
   }
 
   private async queryProduction(org: Org, field: string, value: string): Promise<{ SandboxInfoId: string }> {
@@ -1058,7 +1058,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
         if (error?.name === 'JWTAuthError' && error?.stack?.includes("user hasn't approved")) {
           waitingOnAuth = true;
         } else {
-          throw SfdxError.wrap(error);
+          throw SfError.wrap(error);
         }
       }
     }
@@ -1161,7 +1161,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
         this.logger.debug('Error while authenticating the user %s', error?.toString());
       } else {
         // If it fails for any unexpected reason, just pass that through
-        throw SfdxError.wrap(error);
+        throw SfError.wrap(error);
       }
     }
   }

--- a/src/org/permissionSetAssignment.ts
+++ b/src/org/permissionSetAssignment.ts
@@ -11,7 +11,7 @@ import { getString, hasArray, Optional } from '@salesforce/ts-types';
 import { QueryResult, Record } from 'jsforce';
 import { Logger } from '../logger';
 import { Messages } from '../messages';
-import { SfdxError } from '../sfdxError';
+import { SfError } from '../sfError';
 import { Org } from './org';
 
 Messages.importMessagesDirectory(__dirname);
@@ -111,7 +111,7 @@ export class PermissionSetAssignment {
         errors.forEach((_message) => {
           message = `${message}${_message}${EOL}`;
         });
-        throw new SfdxError(message, 'errorsEncounteredCreatingAssignment');
+        throw new SfError(message, 'errorsEncounteredCreatingAssignment');
       } else {
         throw messages.createError('notSuccessfulButNoErrorsReported');
       }

--- a/src/org/scratchOrgCreate.ts
+++ b/src/org/scratchOrgCreate.ts
@@ -9,8 +9,8 @@ import { ensureString, getString } from '@salesforce/ts-types';
 import { Messages } from '../messages';
 import { Logger } from '../logger';
 import { ConfigAggregator } from '../config/configAggregator';
-import { SfdxProject } from '../sfdxProject';
-import { SfdxError } from '../sfdxError';
+import { SfProject } from '../sfProject';
+import { SfError } from '../sfError';
 import { Org } from './org';
 import {
   authorizeScratchOrg,
@@ -201,7 +201,7 @@ export const scratchOrgCreate = async (options: ScratchOrgCreateOptions): Promis
 
 const getSignupTargetLoginUrl = async (): Promise<string | undefined> => {
   try {
-    const project = await SfdxProject.resolve();
+    const project = await SfProject.resolve();
     const projectJson = await project.resolveProjectConfig();
     return projectJson.signupTargetLoginUrl as string;
   } catch {
@@ -221,6 +221,6 @@ const updateRevisionCounterToZero = async (scratchOrg: Org): Promise<void> => {
       scratchOrg.getOrgId(),
       scratchOrg.getUsername(),
     ]);
-    throw new SfdxError(message, 'SourceStatusResetFailure');
+    throw new SfError(message, 'SourceStatusResetFailure');
   }
 };

--- a/src/org/scratchOrgErrorCodes.ts
+++ b/src/org/scratchOrgErrorCodes.ts
@@ -7,7 +7,7 @@
 
 import { Optional } from '@salesforce/ts-types';
 import { Messages } from '../messages';
-import { SfdxError } from '../sfdxError';
+import { SfError } from '../sfError';
 import { Logger } from '../logger';
 import { ScratchOrgInfo } from './scratchOrgInfoApi';
 
@@ -44,7 +44,7 @@ export const checkScratchOrgInfoForErrors = (
   logger: Logger
 ): ScratchOrgInfo => {
   if (!orgInfo) {
-    throw new SfdxError('No scratch org info found.', 'ScratchOrgInfoNotFound');
+    throw new SfError('No scratch org info found.', 'ScratchOrgInfoNotFound');
   }
   if (orgInfo.Status === 'Active') {
     return orgInfo;
@@ -52,20 +52,20 @@ export const checkScratchOrgInfoForErrors = (
   if (orgInfo.Status === 'Error' && orgInfo.ErrorCode) {
     const message = optionalErrorCodeMessage(orgInfo.ErrorCode, [WORKSPACE_CONFIG_FILENAME]);
     if (message) {
-      throw new SfdxError(message, 'RemoteOrgSignupFailed', [
+      throw new SfError(message, 'RemoteOrgSignupFailed', [
         namedMessages.getMessage('SignupFailedActionError', [orgInfo.ErrorCode]),
       ]);
     }
-    throw new SfdxError(namedMessages.getMessage('SignupFailedError', [orgInfo.ErrorCode]));
+    throw new SfError(namedMessages.getMessage('SignupFailedError', [orgInfo.ErrorCode]));
   }
   if (orgInfo.Status === 'Error') {
     // Maybe the request object can help the user somehow
     logger.error('No error code on signup error! Logging request.');
     logger.error(orgInfo);
-    throw new SfdxError(
+    throw new SfError(
       namedMessages.getMessage('SignupFailedUnknownError', [orgInfo.Id, hubUsername]),
       'signupFailedUnknown'
     );
   }
-  throw new SfdxError(namedMessages.getMessage('SignupUnexpectedError'), 'UnexpectedSignupStatus');
+  throw new SfError(namedMessages.getMessage('SignupUnexpectedError'), 'UnexpectedSignupStatus');
 };

--- a/src/org/scratchOrgSettingsGenerator.ts
+++ b/src/org/scratchOrgSettingsGenerator.ts
@@ -10,7 +10,7 @@ import { isEmpty, env, upperFirst, Duration } from '@salesforce/kit';
 import { ensureObject, getObject, JsonMap, Optional } from '@salesforce/ts-types';
 import * as js2xmlparser from 'js2xmlparser';
 import { Logger } from '../logger';
-import { SfdxError } from '../sfdxError';
+import { SfError } from '../sfError';
 import { JsonAsXml } from '../util/jsonXmlTools';
 import { ZipWriter } from '../util/zipWriter';
 import { StatusResult } from '../status/types';
@@ -149,7 +149,7 @@ export default class SettingsGenerator {
       const failures = (Array.isArray(componentFailures) ? componentFailures : [componentFailures])
         .map((failure) => failure.problem)
         .join('\n');
-      const error = new SfdxError(
+      const error = new SfError(
         `A scratch org was created with username ${username}, but the settings failed to deploy due to: \n${failures}`,
         'ProblemDeployingSettings'
       );

--- a/src/org/user.ts
+++ b/src/org/user.ts
@@ -23,7 +23,7 @@ import type { HttpRequest, HttpResponse, Schema, SObjectUpdateRecord } from 'jsf
 import { Logger } from '../logger';
 import { Messages } from '../messages';
 import { SecureBuffer } from '../crypto/secureBuffer';
-import { SfdxError } from '../sfdxError';
+import { SfError } from '../sfError';
 import { sfdc } from '../util/sfdc';
 import { Connection } from './connection';
 import { PermissionSetAssignment } from './permissionSetAssignment';
@@ -255,11 +255,11 @@ export class User extends AsyncCreatable<User.Options> {
   ): SecureBuffer<void> {
     if (!PASSWORD_COMPLEXITY[passwordCondition.complexity]) {
       const msg = messages.getMessage('complexityOutOfBound');
-      throw new SfdxError(msg, 'complexityOutOfBound');
+      throw new SfError(msg, 'complexityOutOfBound');
     }
     if (passwordCondition.length < 8 || passwordCondition.length > 1000) {
       const msg = messages.getMessage('lengthOutOfBound');
-      throw new SfdxError(msg, 'lengthOutOfBound');
+      throw new SfError(msg, 'lengthOutOfBound');
     }
 
     let password: string[] = [];
@@ -515,7 +515,7 @@ export class User extends AsyncCreatable<User.Options> {
         }
       }
       this.logger.debug(message);
-      throw new SfdxError(message, 'UserCreateHttpError');
+      throw new SfError(message, 'UserCreateHttpError');
     }
 
     fields.id = ensureString(responseBody.id);

--- a/src/schema/printer.ts
+++ b/src/schema/printer.ts
@@ -16,7 +16,7 @@ import {
   Optional,
 } from '@salesforce/ts-types';
 import { Logger } from '../logger';
-import { SfdxError } from '../sfdxError';
+import { SfError } from '../sfError';
 
 /**
  * Renders schema properties.  By default, this is simply an identity transform.  Subclasses may provide more
@@ -95,7 +95,7 @@ export class SchemaPrinter {
       // No need to add to messages, since this should never happen. In fact,
       // this will cause a test failure if there is a command that uses a schema
       // with no properties defined.
-      throw new SfdxError('There is no purpose to print a schema with no properties or items');
+      throw new SfError('There is no purpose to print a schema with no properties or items');
     }
 
     const startLevel = 0;

--- a/src/schema/validator.ts
+++ b/src/schema/validator.ts
@@ -22,7 +22,7 @@ import {
 import * as validator from 'jsen';
 import { JsenValidateError } from 'jsen';
 import { Logger } from '../logger';
-import { SfdxError } from '../sfdxError';
+import { SfError } from '../sfError';
 import { fs } from '../util/fs';
 
 /**
@@ -71,8 +71,8 @@ export class SchemaValidator {
    * Performs validation of JSON data against the schema located at the `schemaPath` value provided
    * at instantiation.
    *
-   * **Throws** *{@link SfdxError}{ name: 'ValidationSchemaFieldError' }* If there are known validations errors.
-   * **Throws** *{@link SfdxError}{ name: 'ValidationSchemaUnknownError' }* If there are unknown validations errors.
+   * **Throws** *{@link SfError}{ name: 'ValidationSchemaFieldError' }* If there are known validations errors.
+   * **Throws** *{@link SfError}{ name: 'ValidationSchemaUnknownError' }* If there are unknown validations errors.
    *
    * @param json A JSON value to validate against this instance's target schema.
    * @returns The validated JSON data.
@@ -86,8 +86,8 @@ export class SchemaValidator {
    * Performs validation of JSON data against the schema located at the `schemaPath` value provided
    * at instantiation.
    *
-   * **Throws** *{@link SfdxError}{ name: 'ValidationSchemaFieldError' }* If there are known validations errors.
-   * **Throws** *{@link SfdxError}{ name: 'ValidationSchemaUnknownError' }* If there are unknown validations errors.
+   * **Throws** *{@link SfError}{ name: 'ValidationSchemaFieldError' }* If there are known validations errors.
+   * **Throws** *{@link SfError}{ name: 'ValidationSchemaUnknownError' }* If there are unknown validations errors.
    *
    * @param json A JSON value to validate against this instance's target schema.
    * @returns The validated JSON data.
@@ -107,9 +107,9 @@ export class SchemaValidator {
     if (!validate(json)) {
       if (validate.errors) {
         const errors = this.getErrorsText(validate.errors, schema);
-        throw new SfdxError(`Validation errors:\n${errors}`, 'ValidationSchemaFieldError');
+        throw new SfError(`Validation errors:\n${errors}`, 'ValidationSchemaFieldError');
       } else {
-        throw new SfdxError('Unknown schema validation error', 'ValidationSchemaUnknownError');
+        throw new SfError('Unknown schema validation error', 'ValidationSchemaUnknownError');
       }
     }
 
@@ -134,7 +134,7 @@ export class SchemaValidator {
       if (isString(externalSchema.id)) {
         externalSchemas[externalSchema.id] = externalSchema;
       } else {
-        throw new SfdxError(
+        throw new SfError(
           `Unexpected external schema id type: ${typeof externalSchema.id}`,
           'ValidationSchemaTypeError'
         );
@@ -153,8 +153,8 @@ export class SchemaValidator {
     try {
       return fs.readJsonMapSync(schemaPath);
     } catch (err) {
-      if ((err as SfdxError).code === 'ENOENT') {
-        throw new SfdxError(`Schema not found: ${schemaPath}`, 'ValidationSchemaNotFound');
+      if ((err as SfError).code === 'ENOENT') {
+        throw new SfError(`Schema not found: ${schemaPath}`, 'ValidationSchemaNotFound');
       }
       throw err;
     }

--- a/src/sfError.ts
+++ b/src/sfError.ts
@@ -21,10 +21,10 @@ import { hasString, isString, JsonMap } from '@salesforce/ts-types';
  * const messages = Messages.load('myPackageName', 'myBundleName');
  *
  * // To throw a non-bundle based error:
- * throw new SfdxError(message.getMessage('myError'), 'MyErrorName');
+ * throw new SfError(message.getMessage('myError'), 'MyErrorName');
  * ```
  */
-export class SfdxError extends NamedError {
+export class SfError extends NamedError {
   /**
    * Action messages. Hints to the users regarding what can be done to fix related issues.
    */
@@ -49,10 +49,10 @@ export class SfdxError extends NamedError {
   private _code?: string;
 
   /**
-   * Create an SfdxError.
+   * Create an SfError.
    *
    * @param message The error message.
-   * @param name The error name. Defaults to 'SfdxError'.
+   * @param name The error name. Defaults to 'SfError'.
    * @param actions The action message(s).
    * @param exitCodeOrCause The exit code which will be used by SfdxCommand or he underlying error that caused this error to be raised.
    * @param cause The underlying error that caused this error to be raised.
@@ -65,7 +65,7 @@ export class SfdxError extends NamedError {
     cause?: Error
   ) {
     cause = exitCodeOrCause instanceof Error ? exitCodeOrCause : cause;
-    super(name || 'SfdxError', message || name, cause);
+    super(name || 'SfError', message || name, cause);
     this.actions = actions;
     if (typeof exitCodeOrCause === 'number') {
       this.exitCode = exitCodeOrCause;
@@ -75,26 +75,26 @@ export class SfdxError extends NamedError {
   }
 
   /**
-   * Convert an Error to an SfdxError.
+   * Convert an Error to an SfError.
    *
    * @param err The error to convert.
    */
-  public static wrap(err: Error | string): SfdxError {
+  public static wrap(err: Error | string): SfError {
     if (isString(err)) {
-      return new SfdxError(err);
+      return new SfError(err);
     }
 
-    if (err instanceof SfdxError) {
+    if (err instanceof SfError) {
       return err;
     }
 
-    const sfdxError = new SfdxError(err.message, err.name, undefined, err);
+    const sfError = new SfError(err.message, err.name, undefined, err);
 
     // If the original error has a code, use that instead of name.
     if (hasString(err, 'code')) {
-      sfdxError.code = err.code;
+      sfError.code = err.code;
     }
-    return sfdxError;
+    return sfError;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -111,7 +111,7 @@ export class SfdxError extends NamedError {
    *
    * @param context The command name.
    */
-  public setContext(context: string): SfdxError {
+  public setContext(context: string): SfError {
     this.context = context;
     return this;
   }
@@ -121,13 +121,13 @@ export class SfdxError extends NamedError {
    *
    * @param data The payload data.
    */
-  public setData(data: unknown): SfdxError {
+  public setData(data: unknown): SfError {
     this.data = data;
     return this;
   }
 
   /**
-   * Convert an {@link SfdxError} state to an object. Returns a plain object representing the state of this error.
+   * Convert an {@link SfError} state to an object. Returns a plain object representing the state of this error.
    */
   public toObject(): JsonMap {
     const obj: JsonMap = {
@@ -157,3 +157,8 @@ export class SfdxError extends NamedError {
     /** Do nothing. */
   }
 }
+
+/**
+ * @deprecated use SfError instead
+ */
+export class SfdxError extends SfError {}

--- a/src/sfProject.ts
+++ b/src/sfProject.ts
@@ -358,7 +358,7 @@ export class SfProject {
    *
    * @ignore
    */
-  private constructor(private path: string) {}
+  protected constructor(private path: string) {}
 
   /**
    * Get a Project from a given path or from the working directory.
@@ -659,7 +659,6 @@ export class SfProject {
 /**
  * @deprecated use SfProject instead
  */
-// @ts-expect-error
 export class SfdxProject extends SfProject {}
 
 /**

--- a/src/sfProject.ts
+++ b/src/sfProject.ts
@@ -85,7 +85,7 @@ export type ProjectJson = ConfigContents & {
  * be in a top level property that represents your project or plugin.
  *
  * ```
- * const project = await SfdxProject.resolve();
+ * const project = await SfProject.resolve();
  * const projectJson = await project.resolveProjectConfig();
  * const myPluginProperties = projectJson.get('myplugin') || {};
  * myPluginProperties.myprop = 'someValue';
@@ -95,7 +95,7 @@ export type ProjectJson = ConfigContents & {
  *
  * **See** [force:project:create](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_ws_create_new.htm)
  */
-export class SfdxProjectJson extends ConfigFile {
+export class SfProjectJson extends ConfigFile {
   public static BLOCKLIST = ['packageAliases'];
 
   public static getFileName(): string {
@@ -103,7 +103,7 @@ export class SfdxProjectJson extends ConfigFile {
   }
 
   public static getDefaultOptions(isGlobal = false): ConfigFile.Options {
-    const options = ConfigFile.getDefaultOptions(isGlobal, SfdxProjectJson.getFileName());
+    const options = ConfigFile.getDefaultOptions(isGlobal, SfProjectJson.getFileName());
     options.isState = false;
     return options;
   }
@@ -296,7 +296,7 @@ export class SfdxProjectJson extends ConfigFile {
   }
 
   /**
-   * Get a list of the unique package names from within sfdx-project.json. Use {@link SfdxProject.getUniquePackageDirectories}
+   * Get a list of the unique package names from within sfdx-project.json. Use {@link SfProject.getUniquePackageDirectories}
    * for data other than the names.
    */
   public getUniquePackageNames(): string[] {
@@ -323,7 +323,7 @@ export class SfdxProjectJson extends ConfigFile {
 
   private validateKeys(): void {
     // Verify that the configObject does not have upper case keys; throw if it does.  Must be heads down camel case.
-    const upperCaseKey = sfdc.findUpperCaseKeys(this.toObject(), SfdxProjectJson.BLOCKLIST);
+    const upperCaseKey = sfdc.findUpperCaseKeys(this.toObject(), SfProjectJson.BLOCKLIST);
     if (upperCaseKey) {
       throw coreMessages.createError('invalidJsonCasing', [upperCaseKey, this.getPath()]);
     }
@@ -331,30 +331,30 @@ export class SfdxProjectJson extends ConfigFile {
 }
 
 /**
- * Represents an SFDX project directory. This directory contains a {@link SfdxProjectJson} config file as well as
+ * Represents an SFDX project directory. This directory contains a {@link SfProjectJson} config file as well as
  * a hidden .sfdx folder that contains all the other local project config files.
  *
  * ```
- * const project = await SfdxProject.resolve();
+ * const project = await SfProject.resolve();
  * const projectJson = await project.resolveProjectConfig();
  * console.log(projectJson.sfdcLoginUrl);
  * ```
  */
-export class SfdxProject {
-  // Cache of SfdxProject instances per path.
-  private static instances = new Map<string, SfdxProject>();
+export class SfProject {
+  // Cache of SfProject instances per path.
+  private static instances = new Map<string, SfProject>();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private projectConfig: any;
 
-  // Dynamically referenced in retrieveSfdxProjectJson
-  private sfdxProjectJson!: SfdxProjectJson;
-  private sfdxProjectJsonGlobal!: SfdxProjectJson;
+  // Dynamically referenced in retrieveSfProjectJson
+  private sfProjectJson!: SfProjectJson;
+  private sfProjectJsonGlobal!: SfProjectJson;
 
   private packageDirectories?: NamedPackageDir[];
   private activePackage: Nullable<NamedPackageDir>;
 
   /**
-   * Do not directly construct instances of this class -- use {@link SfdxProject.resolve} instead.
+   * Do not directly construct instances of this class -- use {@link SfProject.resolve} instead.
    *
    * @ignore
    */
@@ -367,13 +367,13 @@ export class SfdxProject {
    *
    * **Throws** *{@link SfError}{ name: 'InvalidProjectWorkspaceError' }* If the current folder is not located in a workspace.
    */
-  public static async resolve(path?: string): Promise<SfdxProject> {
+  public static async resolve(path?: string): Promise<SfProject> {
     path = await this.resolveProjectPath(path || process.cwd());
-    if (!SfdxProject.instances.has(path)) {
-      const project = new SfdxProject(path);
-      SfdxProject.instances.set(path, project);
+    if (!SfProject.instances.has(path)) {
+      const project = new SfProject(path);
+      SfProject.instances.set(path, project);
     }
-    return ensure(SfdxProject.instances.get(path));
+    return ensure(SfProject.instances.get(path));
   }
 
   /**
@@ -383,15 +383,15 @@ export class SfdxProject {
    *
    * **Throws** *{@link SfError}{ name: 'InvalidProjectWorkspaceError' }* If the current folder is not located in a workspace.
    */
-  public static getInstance(path?: string): SfdxProject {
+  public static getInstance(path?: string): SfProject {
     // Store instance based on the path of the actual project.
     path = this.resolveProjectPathSync(path || process.cwd());
 
-    if (!SfdxProject.instances.has(path)) {
-      const project = new SfdxProject(path);
-      SfdxProject.instances.set(path, project);
+    if (!SfProject.instances.has(path)) {
+      const project = new SfProject(path);
+      SfProject.instances.set(path, project);
     }
-    return ensure(SfdxProject.instances.get(path));
+    return ensure(SfProject.instances.get(path));
   }
 
   /**
@@ -435,24 +435,24 @@ export class SfdxProject {
    * Get the sfdx-project.json config. The global sfdx-project.json is used for user defaults
    * that are not checked in to the project specific file.
    *
-   * *Note:* When reading values from {@link SfdxProjectJson}, it is recommended to use
-   * {@link SfdxProject.resolveProjectConfig} instead.
+   * *Note:* When reading values from {@link SfProjectJson}, it is recommended to use
+   * {@link SfProject.resolveProjectConfig} instead.
    *
    * @param isGlobal True to get the global project file, otherwise the local project config.
    */
-  public async retrieveSfdxProjectJson(isGlobal = false): Promise<SfdxProjectJson> {
-    const options = SfdxProjectJson.getDefaultOptions(isGlobal);
+  public async retrieveSfProjectJson(isGlobal = false): Promise<SfProjectJson> {
+    const options = SfProjectJson.getDefaultOptions(isGlobal);
     if (isGlobal) {
-      if (!this.sfdxProjectJsonGlobal) {
-        this.sfdxProjectJsonGlobal = await SfdxProjectJson.create(options);
+      if (!this.sfProjectJsonGlobal) {
+        this.sfProjectJsonGlobal = await SfProjectJson.create(options);
       }
-      return this.sfdxProjectJsonGlobal;
+      return this.sfProjectJsonGlobal;
     } else {
       options.rootFolder = this.getPath();
-      if (!this.sfdxProjectJson) {
-        this.sfdxProjectJson = await SfdxProjectJson.create(options);
+      if (!this.sfProjectJson) {
+        this.sfProjectJson = await SfProjectJson.create(options);
       }
-      return this.sfdxProjectJson;
+      return this.sfProjectJson;
     }
   }
 
@@ -460,28 +460,28 @@ export class SfdxProject {
    * Get the sfdx-project.json config. The global sfdx-project.json is used for user defaults
    * that are not checked in to the project specific file.
    *
-   * *Note:* When reading values from {@link SfdxProjectJson}, it is recommended to use
-   * {@link SfdxProject.resolveProjectConfig} instead.
+   * *Note:* When reading values from {@link SfProjectJson}, it is recommended to use
+   * {@link SfProject.resolveProjectConfig} instead.
    *
-   * This is the sync method of {@link SfdxProject.resolveSfdxProjectJson}
+   * This is the sync method of {@link SfProject.resolveSfProjectJson}
    *
    * @param isGlobal True to get the global project file, otherwise the local project config.
    */
-  public getSfdxProjectJson(isGlobal = false): SfdxProjectJson {
-    const options = SfdxProjectJson.getDefaultOptions(isGlobal);
+  public getSfProjectJson(isGlobal = false): SfProjectJson {
+    const options = SfProjectJson.getDefaultOptions(isGlobal);
     if (isGlobal) {
-      if (!this.sfdxProjectJsonGlobal) {
-        this.sfdxProjectJsonGlobal = new SfdxProjectJson(options);
-        this.sfdxProjectJsonGlobal.readSync();
+      if (!this.sfProjectJsonGlobal) {
+        this.sfProjectJsonGlobal = new SfProjectJson(options);
+        this.sfProjectJsonGlobal.readSync();
       }
-      return this.sfdxProjectJsonGlobal;
+      return this.sfProjectJsonGlobal;
     } else {
       options.rootFolder = this.getPath();
-      if (!this.sfdxProjectJson) {
-        this.sfdxProjectJson = new SfdxProjectJson(options);
-        this.sfdxProjectJson.readSync();
+      if (!this.sfProjectJson) {
+        this.sfProjectJson = new SfProjectJson(options);
+        this.sfProjectJson.readSync();
       }
-      return this.sfdxProjectJson;
+      return this.sfProjectJson;
     }
   }
 
@@ -492,7 +492,7 @@ export class SfdxProject {
    */
   public getPackageDirectories(): NamedPackageDir[] {
     if (!this.packageDirectories) {
-      this.packageDirectories = this.getSfdxProjectJson().getPackageDirectoriesSync();
+      this.packageDirectories = this.getSfProjectJson().getPackageDirectoriesSync();
     }
     return this.packageDirectories;
   }
@@ -508,15 +508,15 @@ export class SfdxProject {
    * for packaging operations that want to do something for each package entry.
    */
   public getUniquePackageDirectories(): NamedPackageDir[] {
-    return this.getSfdxProjectJson().getUniquePackageDirectories();
+    return this.getSfProjectJson().getUniquePackageDirectories();
   }
 
   /**
-   * Get a list of the unique package names from within sfdx-project.json. Use {@link SfdxProject.getUniquePackageDirectories}
+   * Get a list of the unique package names from within sfdx-project.json. Use {@link SfProject.getUniquePackageDirectories}
    * for data other than the names.
    */
   public getUniquePackageNames(): string[] {
-    return this.getSfdxProjectJson().getUniquePackageNames();
+    return this.getSfProjectJson().getUniquePackageNames();
   }
 
   /**
@@ -567,14 +567,14 @@ export class SfdxProject {
    * Has package directories defined in the project.
    */
   public hasPackages(): boolean {
-    return this.getSfdxProjectJson().hasPackages();
+    return this.getSfProjectJson().hasPackages();
   }
 
   /**
    * Has multiple package directories (MPD) defined in the project.
    */
   public hasMultiplePackages(): boolean {
-    return this.getSfdxProjectJson().hasMultiplePackages();
+    return this.getSfProjectJson().hasMultiplePackages();
   }
 
   /**
@@ -612,11 +612,11 @@ export class SfdxProject {
   }
 
   /**
-   * The project config is resolved from local and global {@link SfdxProjectJson},
+   * The project config is resolved from local and global {@link SfProjectJson},
    * {@link ConfigAggregator}, and a set of defaults. It is recommended to use
-   * this when reading values from SfdxProjectJson.
+   * this when reading values from SfProjectJson.
    *
-   * The global {@link SfdxProjectJson} is used to allow the user to provide default values they
+   * The global {@link SfProjectJson} is used to allow the user to provide default values they
    * may not want checked into their project's source.
    *
    * @returns A resolved config object that contains a bunch of different
@@ -626,8 +626,8 @@ export class SfdxProject {
     if (!this.projectConfig) {
       // Do fs operations in parallel
       const [global, local, configAggregator] = await Promise.all([
-        this.retrieveSfdxProjectJson(true),
-        this.retrieveSfdxProjectJson(),
+        this.retrieveSfProjectJson(true),
+        this.retrieveSfProjectJson(),
         ConfigAggregator.create(),
       ]);
       await Promise.all([global.read(), local.read()]);
@@ -655,3 +655,14 @@ export class SfdxProject {
     return this.projectConfig;
   }
 }
+
+/**
+ * @deprecated use SfProject instead
+ */
+// @ts-expect-error
+export class SfdxProject extends SfProject {}
+
+/**
+ * @deprecated use SfProjectJson instead
+ */
+export class SfdxProjectJson extends SfProjectJson {}

--- a/src/sfdxProject.ts
+++ b/src/sfdxProject.ts
@@ -16,7 +16,7 @@ import { SchemaValidator } from './schema/validator';
 import { fs } from './util/fs';
 import { resolveProjectPath, resolveProjectPathSync, SFDX_PROJECT_JSON } from './util/internal';
 
-import { SfdxError } from './sfdxError';
+import { SfError } from './sfError';
 import { sfdc } from './util/sfdc';
 import { Messages } from './messages';
 
@@ -365,7 +365,7 @@ export class SfdxProject {
    *
    * @param path The path of the project.
    *
-   * **Throws** *{@link SfdxError}{ name: 'InvalidProjectWorkspaceError' }* If the current folder is not located in a workspace.
+   * **Throws** *{@link SfError}{ name: 'InvalidProjectWorkspaceError' }* If the current folder is not located in a workspace.
    */
   public static async resolve(path?: string): Promise<SfdxProject> {
     path = await this.resolveProjectPath(path || process.cwd());
@@ -381,7 +381,7 @@ export class SfdxProject {
    *
    * @param path The path of the project.
    *
-   * **Throws** *{@link SfdxError}{ name: 'InvalidProjectWorkspaceError' }* If the current folder is not located in a workspace.
+   * **Throws** *{@link SfError}{ name: 'InvalidProjectWorkspaceError' }* If the current folder is not located in a workspace.
    */
   public static getInstance(path?: string): SfdxProject {
     // Store instance based on the path of the actual project.
@@ -399,7 +399,7 @@ export class SfdxProject {
    *
    * @param dir The directory path to start traversing from.
    *
-   * **Throws** *{@link SfdxError}{ name: 'InvalidProjectWorkspaceError' }* If the current folder is not located in a workspace.
+   * **Throws** *{@link SfError}{ name: 'InvalidProjectWorkspaceError' }* If the current folder is not located in a workspace.
    *
    * **See** {@link traverseForFile}
    *
@@ -414,7 +414,7 @@ export class SfdxProject {
    *
    * @param dir The directory path to start traversing from.
    *
-   * **Throws** *{@link SfdxError}{ name: 'InvalidProjectWorkspaceError' }* If the current folder is not located in a workspace.
+   * **Throws** *{@link SfError}{ name: 'InvalidProjectWorkspaceError' }* If the current folder is not located in a workspace.
    *
    * **See** {@link traverseForFileSync}
    *
@@ -605,7 +605,7 @@ export class SfdxProject {
    */
   public getDefaultPackage(): NamedPackageDir {
     if (!this.hasPackages()) {
-      throw new SfdxError('The sfdx-project.json does not have any packageDirectories defined.');
+      throw new SfError('The sfdx-project.json does not have any packageDirectories defined.');
     }
     const defaultPackage = this.getPackageDirectories().find((packageDir) => packageDir.default === true);
     return defaultPackage || this.getPackageDirectories()[0];

--- a/src/status/pollingClient.ts
+++ b/src/status/pollingClient.ts
@@ -8,7 +8,7 @@ import { AsyncOptionalCreatable, Duration } from '@salesforce/kit';
 import { AnyJson, ensure } from '@salesforce/ts-types';
 import { retryDecorator, NotRetryableError } from 'ts-retry-promise';
 import { Logger } from '../logger';
-import { SfdxError } from '../sfdxError';
+import { SfError } from '../sfError';
 import { Lifecycle } from '../lifecycleEvents';
 import { StatusResult } from './types';
 
@@ -71,7 +71,7 @@ export class PollingClient extends AsyncOptionalCreatable<PollingClient.Options>
         ) {
           this.logger.debug('Network error on the request', err);
           await Lifecycle.getInstance().emitWarning('Network error occurred. Continuing to poll.');
-          throw SfdxError.wrap(err);
+          throw SfError.wrap(err);
         }
         // there was an actual error thrown, so we don't want to keep retrying
         throw new NotRetryableError(err.name);
@@ -94,7 +94,7 @@ export class PollingClient extends AsyncOptionalCreatable<PollingClient.Options>
       }
 
       this.logger.debug('Polling timed out');
-      throw new SfdxError('The client has timed out.', this.options.timeoutErrorName ?? 'PollingClientTimeout');
+      throw new SfError('The client has timed out.', this.options.timeoutErrorName ?? 'PollingClientTimeout');
     }
   }
 }

--- a/src/status/streamingClient.ts
+++ b/src/status/streamingClient.ts
@@ -12,8 +12,8 @@ import { AsyncOptionalCreatable, Duration, Env, env, set } from '@salesforce/kit
 import { AnyFunction, AnyJson, ensure, ensureString, JsonMap } from '@salesforce/ts-types/lib';
 import * as Faye from 'faye';
 import { Logger } from '../logger';
-import { Org } from '../org';
-import { SfdxError } from '../sfdxError';
+import { Org } from '../org/org';
+import { SfError } from '../sfError';
 import { Messages } from '../messages';
 import { CometClient, CometSubscription, Message, StatusResult, StreamingExtension, StreamProcessor } from './types';
 export { CometClient, CometSubscription, Message, StatusResult, StreamingExtension, StreamProcessor };
@@ -187,7 +187,7 @@ export class StreamingClient extends AsyncOptionalCreatable<StreamingClient.Opti
       this.logger.debug(`accessToken: XXXXXX${accessToken.substring(accessToken.length - 5, accessToken.length - 1)}`);
       this.cometClient.setHeader('Authorization', `OAuth ${accessToken}`);
     } else {
-      throw new SfdxError('Missing or invalid access token', 'MissingOrInvalidAccessToken');
+      throw new SfError('Missing or invalid access token', 'MissingOrInvalidAccessToken');
     }
 
     this.log(`Streaming client target url: ${this.targetUrl}`);
@@ -243,7 +243,7 @@ export class StreamingClient extends AsyncOptionalCreatable<StreamingClient.Opti
    * Subscribe to streaming events. When the streaming processor that's set in the options completes execution it
    * returns a payload in the StatusResult object. The payload is just echoed here for convenience.
    *
-   * **Throws** *{@link SfdxError}{ name: '{@link StreamingClient.TimeoutErrorType.SUBSCRIBE}'}* When the subscribe timeout occurs.
+   * **Throws** *{@link SfError}{ name: '{@link StreamingClient.TimeoutErrorType.SUBSCRIBE}'}* When the subscribe timeout occurs.
    *
    * @param streamInit This function should call the platform apis that result in streaming updates on push topics.
    * {@link StatusResult}
@@ -329,7 +329,7 @@ export class StreamingClient extends AsyncOptionalCreatable<StreamingClient.Opti
     cb(message);
   }
 
-  private doTimeout(timeout: NodeJS.Timer, error: SfdxError): SfdxError {
+  private doTimeout(timeout: NodeJS.Timer, error: SfError): SfError {
     this.disconnect();
     clearTimeout(timeout);
     this.log(JSON.stringify(error));
@@ -445,15 +445,15 @@ export namespace StreamingClient {
         logger.warn('envDep is deprecated');
       }
       if (!streamProcessor) {
-        throw new SfdxError('Missing stream processor', 'MissingArg');
+        throw new SfError('Missing stream processor', 'MissingArg');
       }
 
       if (!org) {
-        throw new SfdxError('Missing org', 'MissingArg');
+        throw new SfError('Missing org', 'MissingArg');
       }
 
       if (!channel) {
-        throw new SfdxError('Missing streaming channel', 'MissingArg');
+        throw new SfError('Missing streaming channel', 'MissingArg');
       }
 
       this.org = org;

--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -32,7 +32,7 @@ import { Connection } from './org/connection';
 import { Crypto } from './crypto/crypto';
 import { Logger } from './logger';
 import { Messages } from './messages';
-import { SfdxError } from './sfdxError';
+import { SfError } from './sfError';
 import { SfdxProject, SfdxProjectJson } from './sfdxProject';
 import { CometClient, CometSubscription, Message, StreamingExtension } from './status/streamingClient';
 import { GlobalInfo, SfOrg } from './globalInfo';
@@ -302,10 +302,10 @@ export const instantiateContext = (sinon?: any): TestContext => {
         );
       } else {
         testContext.SANDBOXES.PROJECT.stub(SfdxProject, 'resolveProjectPath').rejects(
-          new SfdxError('', 'InvalidProjectWorkspaceError')
+          new SfError('', 'InvalidProjectWorkspaceError')
         );
         testContext.SANDBOXES.PROJECT.stub(SfdxProject, 'resolveProjectPathSync').throws(
-          new SfdxError('', 'InvalidProjectWorkspaceError')
+          new SfError('', 'InvalidProjectWorkspaceError')
         );
       }
     },
@@ -532,7 +532,7 @@ export const testSetup = once(_testSetup);
  *
  * **See** {@link shouldThrow}
  */
-export const unexpectedResult = new SfdxError('This code was expected to fail', 'UnexpectedResult');
+export const unexpectedResult = new SfError('This code was expected to fail', 'UnexpectedResult');
 
 /**
  * Use for this testing pattern:
@@ -588,7 +588,7 @@ export interface StreamingMockCometSubscriptionOptions {
   /**
    * If it's an error that states what that error should be.
    */
-  subscriptionErrbackError?: SfdxError;
+  subscriptionErrbackError?: SfError;
   /**
    * A list of messages to playback for the client. One message per process tick.
    */

--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -33,7 +33,7 @@ import { Crypto } from './crypto/crypto';
 import { Logger } from './logger';
 import { Messages } from './messages';
 import { SfError } from './sfError';
-import { SfdxProject, SfdxProjectJson } from './sfdxProject';
+import { SfProject, SfProjectJson } from './sfProject';
 import { CometClient, CometSubscription, Message, StreamingExtension } from './status/streamingClient';
 import { GlobalInfo, SfOrg } from './globalInfo';
 import { Global } from './global';
@@ -118,7 +118,7 @@ export interface TestContext {
     [configName: string]: Optional<ConfigStub>;
     GlobalInfo?: ConfigStub;
     Aliases?: ConfigStub;
-    SfdxProjectJson?: ConfigStub;
+    SfProjectJson?: ConfigStub;
     SfdxConfig?: ConfigStub;
   };
   /**
@@ -294,17 +294,17 @@ export const instantiateContext = (sinon?: any): TestContext => {
     inProject(inProject = true) {
       testContext.SANDBOXES.PROJECT.restore();
       if (inProject) {
-        testContext.SANDBOXES.PROJECT.stub(SfdxProject, 'resolveProjectPath').callsFake(() =>
+        testContext.SANDBOXES.PROJECT.stub(SfProject, 'resolveProjectPath').callsFake(() =>
           testContext.localPathRetriever(testContext.id)
         );
-        testContext.SANDBOXES.PROJECT.stub(SfdxProject, 'resolveProjectPathSync').callsFake(() =>
+        testContext.SANDBOXES.PROJECT.stub(SfProject, 'resolveProjectPathSync').callsFake(() =>
           testContext.localPathRetrieverSync(testContext.id)
         );
       } else {
-        testContext.SANDBOXES.PROJECT.stub(SfdxProject, 'resolveProjectPath').rejects(
+        testContext.SANDBOXES.PROJECT.stub(SfProject, 'resolveProjectPath').rejects(
           new SfError('', 'InvalidProjectWorkspaceError')
         );
-        testContext.SANDBOXES.PROJECT.stub(SfdxProject, 'resolveProjectPathSync').throws(
+        testContext.SANDBOXES.PROJECT.stub(SfProject, 'resolveProjectPathSync').throws(
           new SfError('', 'InvalidProjectWorkspaceError')
         );
       }
@@ -355,7 +355,7 @@ export const stubContext = (testContext: TestContext) => {
     testContext.rootPathRetrieverSync(isGlobal, testContext.id)
   );
 
-  stubMethod(testContext.SANDBOXES.PROJECT, SfdxProjectJson.prototype, 'doesPackageExist').callsFake(() => true);
+  stubMethod(testContext.SANDBOXES.PROJECT, SfProjectJson.prototype, 'doesPackageExist').callsFake(() => true);
 
   const initStubForRead = (configFile: ConfigFile<ConfigFile.Options>): ConfigStub => {
     const stub: ConfigStub = testContext.configStubs[configFile.constructor.name] || {};

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -12,7 +12,7 @@ import { parseJson, parseJsonMap } from '@salesforce/kit';
 import { AnyJson, JsonMap, Optional } from '@salesforce/ts-types';
 import * as fsLib from 'graceful-fs';
 import * as mkdirpLib from 'mkdirp';
-import { SfdxError } from '../sfdxError';
+import { SfError } from '../sfError';
 
 type PerformFunction = (filePath: string, file?: string, dir?: string) => Promise<void>;
 type PerformFunctionSync = (filePath: string, file?: string, dir?: string) => void;
@@ -102,12 +102,12 @@ export const fs = Object.assign({}, fsLib, {
    */
   remove: async (dirPath: string): Promise<void> => {
     if (!dirPath) {
-      throw new SfdxError('Path is null or undefined.', 'PathIsNullOrUndefined');
+      throw new SfError('Path is null or undefined.', 'PathIsNullOrUndefined');
     }
     try {
       await fs.access(dirPath, fsLib.constants.R_OK);
     } catch (err) {
-      throw new SfdxError(`The path: ${dirPath} doesn't exist or access is denied.`, 'DirMissingOrNoAccess');
+      throw new SfError(`The path: ${dirPath} doesn't exist or access is denied.`, 'DirMissingOrNoAccess');
     }
     const files = await fs.readdir(dirPath);
     const stats = await Promise.all(files.map((file) => fs.stat(path.join(dirPath, file))));
@@ -128,12 +128,12 @@ export const fs = Object.assign({}, fsLib, {
    */
   removeSync: (dirPath: string): void => {
     if (!dirPath) {
-      throw new SfdxError('Path is null or undefined.', 'PathIsNullOrUndefined');
+      throw new SfError('Path is null or undefined.', 'PathIsNullOrUndefined');
     }
     try {
       fs.accessSync(dirPath, fsLib.constants.R_OK);
     } catch (err) {
-      throw new SfdxError(`The path: ${dirPath} doesn't exist or access is denied.`, 'DirMissingOrNoAccess');
+      throw new SfError(`The path: ${dirPath} doesn't exist or access is denied.`, 'DirMissingOrNoAccess');
     }
     fs.actOnSync(
       dirPath,
@@ -165,7 +165,7 @@ export const fs = Object.assign({}, fsLib, {
       await fs.stat(path.join(dir, file));
       foundProjectDir = dir;
     } catch (err) {
-      if (err && (err as SfdxError).code === 'ENOENT') {
+      if (err && (err as SfError).code === 'ENOENT') {
         const nextDir = path.resolve(dir, '..');
         if (nextDir !== dir) {
           // stop at root
@@ -190,7 +190,7 @@ export const fs = Object.assign({}, fsLib, {
       fs.statSync(path.join(dir, file));
       foundProjectDir = dir;
     } catch (err) {
-      if (err && (err as SfdxError).code === 'ENOENT') {
+      if (err && (err as SfError).code === 'ENOENT') {
         const nextDir = path.resolve(dir, '..');
         if (nextDir !== dir) {
           // stop at root
@@ -377,7 +377,7 @@ export const fs = Object.assign({}, fsLib, {
 
       return fs.getContentHash(contentA) === fs.getContentHash(contentB);
     } catch (err) {
-      throw new SfdxError(
+      throw new SfError(
         `The path: ${(err as { path: string }).path} doesn't exist or access is denied.`,
         'DirMissingOrNoAccess'
       );
@@ -404,7 +404,7 @@ export const fs = Object.assign({}, fsLib, {
 
       return fs.getContentHash(contentA) === fs.getContentHash(contentB);
     } catch (err) {
-      throw new SfdxError(
+      throw new SfError(
         `The path: ${(err as { path: string }).path} doesn't exist or access is denied.`,
         'DirMissingOrNoAccess'
       );

--- a/src/util/internal.ts
+++ b/src/util/internal.ts
@@ -26,7 +26,7 @@ export const SFDX_PROJECT_JSON = 'sfdx-project.json';
  *
  * **See** {@link traverseForFile}
  *
- * **Throws** *{@link SfdxError}{ name: 'InvalidProjectWorkspaceError' }* If the current folder is not located in a workspace.
+ * **Throws** *{@link SfError}{ name: 'InvalidProjectWorkspaceError' }* If the current folder is not located in a workspace.
  *
  * @param dir The directory path to start traversing from.
  * @ignore
@@ -46,7 +46,7 @@ export async function resolveProjectPath(dir: string = process.cwd()): Promise<s
  *
  * **See** {@link traverseForFile}
  *
- * **Throws** *{@link SfdxError}{ name: 'InvalidProjectWorkspaceError' }* If the current folder is not located in a workspace.
+ * **Throws** *{@link SfError}{ name: 'InvalidProjectWorkspaceError' }* If the current folder is not located in a workspace.
  *
  * @param dir The directory path to start traversing from.
  * @ignore

--- a/src/util/sfdcUrl.ts
+++ b/src/util/sfdcUrl.ts
@@ -140,7 +140,7 @@ export class SfdcUrl extends URL {
    * If SFDX_DOMAIN_RETRY environment variable is set (number) it overrides the default timeout duration (240 seconds)
    *
    * @returns {Promise<true | never>} The resolved ip address or never
-   * @throws {@link SfdxError} If can't resolve DNS.
+   * @throws {@link SfError} If can't resolve DNS.
    */
   public async checkLightningDomain(): Promise<true | never> {
     const quantity = ensureNumber(new Env().getNumber('SFDX_DOMAIN_RETRY', 240));
@@ -165,7 +165,7 @@ export class SfdcUrl extends URL {
    * If SFDX_DOMAIN_RETRY environment variable is set (number) it overrides the default timeout duration (240 seconds)
    *
    * @returns the resolved ip address.
-   * @throws {@link SfdxError} If can't resolve DNS.
+   * @throws {@link SfError} If can't resolve DNS.
    */
   public async lookup(): Promise<string> {
     const quantity = ensureNumber(new Env().getNumber('SFDX_DOMAIN_RETRY', 240));

--- a/src/webOAuthServer.ts
+++ b/src/webOAuthServer.ts
@@ -17,7 +17,7 @@ import { Logger } from './logger';
 import { AuthInfo, DEFAULT_CONNECTED_APP_INFO, OAuth2Config } from './org/authInfo';
 import { SfError } from './sfError';
 import { Messages } from './messages';
-import { SfdxProjectJson } from './sfdxProject';
+import { SfProjectJson } from './sfProject';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.load('@salesforce/core', 'auth', [
@@ -65,8 +65,8 @@ export class WebOAuthServer extends AsyncCreatable<WebOAuthServer.Options> {
    */
   public static async determineOauthPort(): Promise<number> {
     try {
-      const sfdxProject = await SfdxProjectJson.create();
-      return (sfdxProject.get('oauthLocalPort') as number) || WebOAuthServer.DEFAULT_PORT;
+      const sfProject = await SfProjectJson.create();
+      return (sfProject.get('oauthLocalPort') as number) || WebOAuthServer.DEFAULT_PORT;
     } catch {
       return WebOAuthServer.DEFAULT_PORT;
     }

--- a/src/webOAuthServer.ts
+++ b/src/webOAuthServer.ts
@@ -15,7 +15,7 @@ import { Nullable, get, asString } from '@salesforce/ts-types';
 import { OAuth2 } from 'jsforce';
 import { Logger } from './logger';
 import { AuthInfo, DEFAULT_CONNECTED_APP_INFO, OAuth2Config } from './org/authInfo';
-import { SfdxError } from './sfdxError';
+import { SfError } from './sfError';
 import { Messages } from './messages';
 import { SfdxProjectJson } from './sfdxProject';
 
@@ -162,7 +162,7 @@ export class WebOAuthServer extends AsyncCreatable<WebOAuthServer.Options> {
           if (url.pathname && url.pathname.startsWith('/OauthRedirect')) {
             request.query = parseQueryString(url.query as string);
             if (request.query.error) {
-              const err = new SfdxError(request.query.error_description || request.query.error, request.query.error);
+              const err = new SfError(request.query.error_description || request.query.error, request.query.error);
               this.webServer.reportError(err, response);
               return reject(err);
             }
@@ -177,13 +177,13 @@ export class WebOAuthServer extends AsyncCreatable<WebOAuthServer.Options> {
             this.webServer.sendError(404, 'Resource not found', response);
             const errName = 'invalidRequestUri';
             const errMessage = messages.getMessage(errName, [url.pathname]);
-            reject(new SfdxError(errMessage, errName));
+            reject(new SfError(errMessage, errName));
           }
         } else {
           this.webServer.sendError(405, 'Unsupported http methods', response);
           const errName = 'invalidRequestMethod';
           const errMessage = messages.getMessage(errName, [request.method]);
-          reject(new SfdxError(errMessage, errName));
+          reject(new SfError(errMessage, errName));
         }
       });
     });
@@ -198,7 +198,7 @@ export class WebOAuthServer extends AsyncCreatable<WebOAuthServer.Options> {
    */
   private parseAuthCodeFromRequest(response: http.ServerResponse, request: WebOAuthServer.Request): Nullable<string> {
     if (!this.validateState(request)) {
-      const error = new SfdxError('urlStateMismatch');
+      const error = new SfError('urlStateMismatch');
       this.webServer.sendError(400, `${error.message}\n`, response);
       this.closeRequest(request);
       this.logger.warn('urlStateMismatchAttempt detected.');
@@ -369,14 +369,14 @@ export class WebServer extends AsyncCreatable<WebServer.Options> {
 
       socket.setTimeout(this.getSocketTimeout(), () => {
         socket.destroy();
-        const error = new SfdxError('timeout', 'SOCKET_TIMEOUT');
+        const error = new SfError('timeout', 'SOCKET_TIMEOUT');
         reject(error);
       });
 
       // An existing connection, means that the port is occupied
       socket.connect(clientConfig, () => {
         socket.destroy();
-        const error = new SfdxError('Address in use', 'EADDRINUSE');
+        const error = new SfError('Address in use', 'EADDRINUSE');
         error.data = {
           port: clientConfig.port,
           address: clientConfig.host,

--- a/test/unit/config/configFileTest.ts
+++ b/test/unit/config/configFileTest.ts
@@ -9,7 +9,7 @@ import { expect } from 'chai';
 
 import { assert } from '@salesforce/ts-types';
 import { ConfigFile } from '../../../src/config/configFile';
-import { SfdxError } from '../../../src/exported';
+import { SfError } from '../../../src/exported';
 import { shouldThrow, testSetup } from '../../../src/testSetup';
 import { fs } from '../../../src/util/fs';
 
@@ -257,7 +257,7 @@ describe('Config', () => {
     });
 
     it('sets contents as empty object when file does not exist', async () => {
-      const err = SfdxError.wrap(new Error());
+      const err = SfError.wrap(new Error());
       err.code = 'ENOENT';
       readJsonMapStub.throws(err);
 
@@ -273,7 +273,7 @@ describe('Config', () => {
       const err = new Error('not here');
       err.name = 'FileNotFound';
       (err as any).code = 'ENOENT';
-      readJsonMapStub.throws(SfdxError.wrap(err));
+      readJsonMapStub.throws(SfError.wrap(err));
 
       const configOptions = {
         filename: 'test',
@@ -347,7 +347,7 @@ describe('Config', () => {
     });
 
     it('sets contents as empty object when file does not exist', () => {
-      const err = SfdxError.wrap(new Error());
+      const err = SfError.wrap(new Error());
       err.code = 'ENOENT';
       readJsonMapStub.throws(err);
 
@@ -364,7 +364,7 @@ describe('Config', () => {
       const err = new Error('not here');
       err.name = 'FileNotFound';
       (err as any).code = 'ENOENT';
-      readJsonMapStub.throws(SfdxError.wrap(err));
+      readJsonMapStub.throws(SfError.wrap(err));
 
       const configOptions = {
         filename: 'test',

--- a/test/unit/crypto/cryptoTest.ts
+++ b/test/unit/crypto/cryptoTest.ts
@@ -10,7 +10,7 @@ import * as os from 'os';
 import { stubMethod } from '@salesforce/ts-sinon';
 import { expect } from 'chai';
 import { Crypto } from '../../../src/crypto/crypto';
-import { SfdxError } from '../../../src/sfdxError';
+import { SfError } from '../../../src/sfError';
 import { Messages } from '../../../src/messages';
 import { testSetup } from '../../../src/testSetup';
 
@@ -149,7 +149,7 @@ describe('CryptoTest', function () {
         'macKeychainOutOfSync'
       );
       const err = Error('Failed to decipher auth data. reason: Unsupported state or unable to authenticate data.');
-      const sfdxErr = SfdxError.wrap(err);
+      const sfdxErr = SfError.wrap(err);
       sfdxErr.actions = [];
       sfdxErr.actions[0] = message;
       stubMethod($$.SANDBOX, os, 'platform').returns('darwin');
@@ -174,7 +174,7 @@ describe('CryptoTest', function () {
       const message: string = Messages.load('@salesforce/core', 'encryption', ['authDecryptError']).getMessage(
         'authDecryptError'
       );
-      const errorMessage: object = SfdxError.wrap(new Error(message));
+      const errorMessage: object = SfError.wrap(new Error(message));
       stubMethod($$.SANDBOX, os, 'platform').returns('darwin');
       stubMethod($$.SANDBOX, crypto, 'decrypt').callsFake(() => ({
         setAuthTag: () => {

--- a/test/unit/fixtures/schemas/sfdxProjectSchema.json
+++ b/test/unit/fixtures/schemas/sfdxProjectSchema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "sfdxProjectSchema",
+  "id": "sfProjectSchema",
   "type": "object",
   "title": "SFDX Project",
   "description": "The properties and shape of the SFDX project",

--- a/test/unit/messagesTest.ts
+++ b/test/unit/messagesTest.ts
@@ -10,7 +10,7 @@ import { EOL } from 'os';
 import { cloneJson } from '@salesforce/kit';
 import { assert, expect } from 'chai';
 import { Messages } from '../../src/messages';
-import { SfdxError } from '../../src/sfdxError';
+import { SfError } from '../../src/sfError';
 import { testSetup } from '../../src/testSetup';
 
 // Setup the test environment.
@@ -127,7 +127,7 @@ describe('Messages', () => {
     const msgFiles = ['apexMessages.json', 'soqlMessages.json'];
 
     const messagesDirPath = `${path.sep}root${path.sep}myModule${path.sep}dist${path.sep}lib`;
-    const truncateErr = new SfdxError('truncate error');
+    const truncateErr = new SfError('truncate error');
     truncateErr['code'] = 'ENOENT';
     let truncatePath = `${path.sep}root${path.sep}myModule`;
 
@@ -212,7 +212,7 @@ describe('Messages', () => {
         loaderFn(Messages.getLocale());
         assert.fail('should have thrown an error that the file was empty.');
       } catch (err) {
-        expect(err.name).to.equal('SfdxError');
+        expect(err.name).to.equal('SfError');
         expect(err.message).to.equal('Invalid message file: myPluginMessages.json. No content.');
       }
     });

--- a/test/unit/org/authInfoTest.ts
+++ b/test/unit/org/authInfoTest.ts
@@ -25,7 +25,7 @@ import { ConfigFile } from '../../../src/config/configFile';
 import { ConfigContents } from '../../../src/config/configStore';
 import { AliasAccessor, GlobalInfo, OrgAccessor } from '../../../src/globalInfo';
 import { Crypto } from '../../../src/crypto/crypto';
-import { SfdxError } from '../../../src/sfdxError';
+import { SfError } from '../../../src/sfError';
 import { testSetup } from '../../../src/testSetup';
 import { fs } from '../../../src/util/fs';
 import { MyDomainResolver, SfdcUrl } from '../../../src/exported';
@@ -211,7 +211,7 @@ class MetaAuthDataMock {
 
   public async statForKeyFile(path: string): Promise<{}> {
     if (!path.includes('key.json')) {
-      return new SfdxError(`Unexpected path: ${path}`, 'UnexpectedInput');
+      return new SfError(`Unexpected path: ${path}`, 'UnexpectedInput');
     }
 
     return Promise.resolve({
@@ -1381,8 +1381,8 @@ describe('AuthInfo', () => {
       // @ts-ignore
       await AuthInfo.prototype['refreshFn'].call(context, null, testCallback);
       expect(testCallback.called).to.be.true;
-      const sfdxError = testCallback.firstCall.args[0];
-      expect(sfdxError.name).to.equal('OrgDataNotAvailableError', sfdxError.message);
+      const sfError = testCallback.firstCall.args[0];
+      expect(sfError.name).to.equal('OrgDataNotAvailableError', sfError.message);
     });
   });
 

--- a/test/unit/org/scratchOrgCreateTest.ts
+++ b/test/unit/org/scratchOrgCreateTest.ts
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { Connection } from 'jsforce'; // RecordResult
 import { AuthInfo, Org } from '../../../src/org';
-import { SfdxProjectJson, SfdxProject } from '../../../src/sfdxProject';
+import { SfProjectJson, SfProject } from '../../../src/sfProject';
 import { scratchOrgCreate, ScratchOrgCreateOptions } from '../../../src/org/scratchOrgCreate';
 
 const packageId = '05iB0000000cWwnIAE';
@@ -19,7 +19,7 @@ describe('scratchOrgCreate', () => {
   const sandbox = sinon.createSandbox();
   const hubOrgStub = sinon.createStubInstance(Org);
   const authInfoStub = sinon.createStubInstance(AuthInfo);
-  const sfdxProjectJsonStub = sinon.createStubInstance(SfdxProjectJson);
+  const sfProjectJsonStub = sinon.createStubInstance(SfProjectJson);
   const scratchOrgInfoId = '1234';
   const username = 'PlatformCLI';
   const retrieve = {
@@ -32,14 +32,14 @@ describe('scratchOrgCreate', () => {
   beforeEach(() => {
     sandbox.stub(Org, 'create').resolves(hubOrgStub);
     sandbox.stub(AuthInfo, 'create').resolves(authInfoStub);
-    sfdxProjectJsonStub.getPackageDirectories.resolves([
+    sfProjectJsonStub.getPackageDirectories.resolves([
       { path: 'foo', package: 'fooPkgName', versionNumber: '4.7.0.NEXT', ancestorId: packageId },
     ]);
-    sandbox.stub(SfdxProject, 'resolve').resolves({
+    sandbox.stub(SfProject, 'resolve').resolves({
       resolveProjectConfig: sandbox.stub().resolves({
         signupTargetLoginUrl: 'https://salesforce.com',
       }),
-    } as unknown as SfdxProject);
+    } as unknown as SfProject);
     hubOrgStub.isDevHubOrg.returns(false);
     hubOrgStub.determineIfDevHubOrg.withArgs(true).resolves();
     // @ts-ignore

--- a/test/unit/org/scratchOrgErrorCodesTest.ts
+++ b/test/unit/org/scratchOrgErrorCodesTest.ts
@@ -7,7 +7,7 @@
 import { expect } from 'chai';
 import { assert } from 'sinon';
 import { Logger } from '../../../src/logger';
-import { SfdxError } from '../../../src/sfdxError';
+import { SfError } from '../../../src/sfError';
 import { ScratchOrgInfo } from '../../../src/org/scratchOrgInfoApi';
 import { checkScratchOrgInfoForErrors } from '../../../src/org/scratchOrgErrorCodes';
 
@@ -32,7 +32,7 @@ describe('getHumanErrorMessage', () => {
       checkScratchOrgInfoForErrors({ ...baseOrgInfo, ErrorCode }, testUsername, logger);
       assert.fail('the above should throw an error');
     } catch (err) {
-      expect(err).to.be.an.instanceof(SfdxError);
+      expect(err).to.be.an.instanceof(SfError);
       expect(err.message).to.include('couldn’t find a');
       expect(err.message).to.not.include('%s');
       expect(err.actions[0]).to.include('information on error code');
@@ -47,7 +47,7 @@ describe('getHumanErrorMessage', () => {
       checkScratchOrgInfoForErrors({ ...baseOrgInfo, ErrorCode }, testUsername, logger);
       assert.fail('the above should throw an error');
     } catch (err) {
-      expect(err).to.be.an.instanceof(SfdxError);
+      expect(err).to.be.an.instanceof(SfError);
       expect(err.message).to.include('create scratch org');
       expect(err.message).to.not.include('%s');
       expect(err.actions[0]).to.include('information on error code');
@@ -62,7 +62,7 @@ describe('getHumanErrorMessage', () => {
       checkScratchOrgInfoForErrors({ ...baseOrgInfo, ErrorCode }, testUsername, logger);
       assert.fail('the above should throw an error');
     } catch (err) {
-      expect(err).to.be.an.instanceof(SfdxError);
+      expect(err).to.be.an.instanceof(SfError);
       expect(err.message).to.equal('The request to create a scratch org failed with error code: B-1717.');
       expect(err.message).to.not.include('%s');
       expect(err.actions).to.be.undefined;
@@ -74,7 +74,7 @@ describe('getHumanErrorMessage', () => {
       checkScratchOrgInfoForErrors({ ...baseOrgInfo }, testUsername, logger);
       assert.fail('the above should throw an error');
     } catch (err) {
-      expect(err).to.be.an.instanceof(SfdxError);
+      expect(err).to.be.an.instanceof(SfError);
       expect(err.message).to.include('An unknown server error occurred');
       expect(err.message).to.include(baseOrgInfo.Id);
       expect(err.message).to.not.include('%s');
@@ -87,7 +87,7 @@ describe('getHumanErrorMessage', () => {
       checkScratchOrgInfoForErrors({ ...baseOrgInfo, ErrorCode: null }, testUsername, logger);
       assert.fail('the above should throw an error');
     } catch (err) {
-      expect(err).to.be.an.instanceof(SfdxError);
+      expect(err).to.be.an.instanceof(SfError);
       expect(err.message).to.include('An unknown server error occurred');
       expect(err.message).to.include(baseOrgInfo.Id);
       expect(err.message).to.not.include('%s');
@@ -100,7 +100,7 @@ describe('getHumanErrorMessage', () => {
       checkScratchOrgInfoForErrors({ ...baseOrgInfo, Status: undefined }, testUsername, logger);
       assert.fail('the above should throw an error');
     } catch (err) {
-      expect(err).to.be.an.instanceof(SfdxError);
+      expect(err).to.be.an.instanceof(SfError);
       expect(err.message).to.include('unexpected status');
       expect(err.actions).to.be.undefined;
     }

--- a/test/unit/org/scratchOrgInfoGeneratorTest.ts
+++ b/test/unit/org/scratchOrgInfoGeneratorTest.ts
@@ -17,7 +17,7 @@ import {
   generateScratchOrgInfo,
   getScratchOrgInfoPayload,
 } from '../../../src/org/scratchOrgInfoGenerator';
-import { SfdxProjectJson } from '../../../src/sfdxProject';
+import { SfProjectJson } from '../../../src/sfProject';
 import { Messages } from '../../../src/messages';
 
 const packageId = '05iB0000000cWwnIAE';
@@ -56,7 +56,7 @@ describe('scratchOrgInfoGenerator', () => {
 
     describe('basic ids', () => {
       it('Should parse 05i ancestorId keys in sfdx-project.json', async () => {
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [
             { path: 'foo', package: 'fooPkgName', versionNumber: '4.7.0.NEXT', ancestorId: packageId },
           ],
@@ -64,13 +64,13 @@ describe('scratchOrgInfoGenerator', () => {
         expect(
           await getAncestorIds(
             {} as unknown as ScratchOrgInfoPayload,
-            projectJson as unknown as SfdxProjectJson,
+            projectJson as unknown as SfProjectJson,
             await Org.create({})
           )
         ).to.equal(packageId);
       });
       it('Should parse 04t ancestorId keys in sfdx-project.json', async () => {
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [
             { path: 'foo', package: 'fooPkgName', versionNumber: '4.7.0.NEXT', ancestorId: packageVersionSubscriberId },
           ],
@@ -78,13 +78,13 @@ describe('scratchOrgInfoGenerator', () => {
         expect(
           await getAncestorIds(
             {} as unknown as ScratchOrgInfoPayload,
-            projectJson as unknown as SfdxProjectJson,
+            projectJson as unknown as SfProjectJson,
             await Org.create({})
           )
         ).to.equal(packageId);
       });
       it('Should throw on a bad ID', async () => {
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [
             { path: 'foo', package: 'fooPkgName', versionNumber: '4.7.0.NEXT', ancestorId: 'ABC' },
           ],
@@ -93,7 +93,7 @@ describe('scratchOrgInfoGenerator', () => {
           await shouldThrow(
             getAncestorIds(
               { package2AncestorIds: 'foo' } as unknown as ScratchOrgInfoPayload,
-              projectJson as unknown as SfdxProjectJson,
+              projectJson as unknown as SfProjectJson,
               await Org.create({})
             )
           );
@@ -102,7 +102,7 @@ describe('scratchOrgInfoGenerator', () => {
         }
       });
       it('Should throw on a bad returned Id', async () => {
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [
             {
               path: 'foo',
@@ -122,7 +122,7 @@ describe('scratchOrgInfoGenerator', () => {
           await shouldThrow(
             getAncestorIds(
               { ancestorId: 'foABCo' } as unknown as ScratchOrgInfoPayload,
-              projectJson as unknown as SfdxProjectJson,
+              projectJson as unknown as SfProjectJson,
               await Org.create({})
             )
           );
@@ -134,7 +134,7 @@ describe('scratchOrgInfoGenerator', () => {
 
     describe('multiple ancestors', () => {
       it('Should merge duplicated ancestors', async () => {
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [
             { path: 'foo', package: 'fooPkgName', versionNumber: '4.7.0.NEXT', ancestorId: packageId },
             { path: 'bar', package: 'barPkgName', versionNumber: '4.7.0.NEXT', ancestorId: packageId },
@@ -143,7 +143,7 @@ describe('scratchOrgInfoGenerator', () => {
         expect(
           await getAncestorIds(
             {} as unknown as ScratchOrgInfoPayload,
-            projectJson as unknown as SfdxProjectJson,
+            projectJson as unknown as SfProjectJson,
             await Org.create({})
           )
         ).to.equal(packageId);
@@ -151,7 +151,7 @@ describe('scratchOrgInfoGenerator', () => {
 
       it('Should join multiple ancestors', async () => {
         const otherPackageId = packageId.replace('W', 'Q');
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [
             { path: 'foo', package: 'fooPkgName', versionNumber: '4.7.0.NEXT', ancestorId: packageId },
             { path: 'bar', package: 'barPkgName', versionNumber: '4.7.0.NEXT', ancestorId: otherPackageId },
@@ -160,7 +160,7 @@ describe('scratchOrgInfoGenerator', () => {
         expect(
           await getAncestorIds(
             {} as unknown as ScratchOrgInfoPayload,
-            projectJson as unknown as SfdxProjectJson,
+            projectJson as unknown as SfProjectJson,
             await Org.create({})
           )
         ).to.equal(`${packageId};${otherPackageId}`);
@@ -169,7 +169,7 @@ describe('scratchOrgInfoGenerator', () => {
 
     describe('unusual projects', () => {
       it('Should return an error if the package2AncestorIds key is included in the scratch org definition', async () => {
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [
             { path: 'foo', package: 'fooPkgName', versionNumber: '4.7.0.NEXT', ancestorId: packageVersionSubscriberId },
           ],
@@ -178,7 +178,7 @@ describe('scratchOrgInfoGenerator', () => {
           await shouldThrow(
             getAncestorIds(
               { package2AncestorIds: 'foo' } as unknown as ScratchOrgInfoPayload,
-              projectJson as unknown as SfdxProjectJson,
+              projectJson as unknown as SfProjectJson,
               await Org.create({})
             )
           );
@@ -189,26 +189,26 @@ describe('scratchOrgInfoGenerator', () => {
       });
 
       it('Should not fail with an empty packageDirectories key', async () => {
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [],
         });
         expect(
           await getAncestorIds(
             {} as unknown as ScratchOrgInfoPayload,
-            projectJson as unknown as SfdxProjectJson,
+            projectJson as unknown as SfProjectJson,
             await Org.create({})
           )
         ).to.equal('');
       });
 
       it('Should return empty string with no ancestors', async () => {
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [{ path: 'foo', package: 'fooPkgName' }],
         });
         expect(
           await getAncestorIds(
             {} as unknown as ScratchOrgInfoPayload,
-            projectJson as unknown as SfdxProjectJson,
+            projectJson as unknown as SfProjectJson,
             await Org.create({})
           )
         ).to.equal('');
@@ -217,7 +217,7 @@ describe('scratchOrgInfoGenerator', () => {
 
     describe('aliases as ancestorId', () => {
       it('Should resolve an alias', async () => {
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [
             { path: 'foo', package: 'fooPkgName', versionNumber: '4.7.0.NEXT', ancestorId: 'alias' },
           ],
@@ -230,14 +230,14 @@ describe('scratchOrgInfoGenerator', () => {
         expect(
           await getAncestorIds(
             {} as unknown as ScratchOrgInfoPayload,
-            projectJson as unknown as SfdxProjectJson,
+            projectJson as unknown as SfProjectJson,
             await Org.create({})
           )
         ).to.equal(packageId);
       });
 
       it('Should resolve an alias packageAliases is undefined', async () => {
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [
             { path: 'foo', package: 'fooPkgName', versionNumber: '4.7.0.NEXT', ancestorId: 'alias' },
           ],
@@ -251,7 +251,7 @@ describe('scratchOrgInfoGenerator', () => {
           await shouldThrow(
             getAncestorIds(
               {} as unknown as ScratchOrgInfoPayload,
-              projectJson as unknown as SfdxProjectJson,
+              projectJson as unknown as SfProjectJson,
               await Org.create({})
             )
           );
@@ -261,7 +261,7 @@ describe('scratchOrgInfoGenerator', () => {
       });
 
       it('Should throw on unresolvable alias', async () => {
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [
             { path: 'foo', package: 'fooPkgName', versionNumber: '4.7.0.NEXT', ancestorId: 'alias' },
           ],
@@ -275,7 +275,7 @@ describe('scratchOrgInfoGenerator', () => {
           await shouldThrow(
             getAncestorIds(
               { package2AncestorIds: 'foo' } as unknown as ScratchOrgInfoPayload,
-              projectJson as unknown as SfdxProjectJson,
+              projectJson as unknown as SfProjectJson,
               await Org.create({})
             )
           );
@@ -287,7 +287,7 @@ describe('scratchOrgInfoGenerator', () => {
 
     describe('ancestorVersion', () => {
       it('Should throw on an invalid ancestorVersion', async () => {
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [
             { path: 'foo', package: 'fooPkgName', versionNumber: '4.7.0.NEXT', ancestorVersion: '5.0' },
           ],
@@ -296,7 +296,7 @@ describe('scratchOrgInfoGenerator', () => {
           await shouldThrow(
             getAncestorIds(
               {} as unknown as ScratchOrgInfoPayload,
-              projectJson as unknown as SfdxProjectJson,
+              projectJson as unknown as SfProjectJson,
               await Org.create({})
             )
           );
@@ -307,7 +307,7 @@ describe('scratchOrgInfoGenerator', () => {
       });
 
       it('Should resolve an alias ancestor version', async () => {
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [
             { path: 'foo', package: 'fooPkgName', versionNumber: '4.7.0.NEXT', ancestorVersion: '4.0.0.0' },
           ],
@@ -320,7 +320,7 @@ describe('scratchOrgInfoGenerator', () => {
         expect(
           await getAncestorIds(
             {} as unknown as ScratchOrgInfoPayload,
-            projectJson as unknown as SfdxProjectJson,
+            projectJson as unknown as SfProjectJson,
             await Org.create({})
           )
         ).to.equal(packageId);
@@ -356,7 +356,7 @@ describe('scratchOrgInfoGenerator', () => {
 
     describe('basic ids throw', () => {
       it('Should throw on a bad returned Id', async () => {
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [
             {
               path: 'foo',
@@ -376,7 +376,7 @@ describe('scratchOrgInfoGenerator', () => {
           await shouldThrow(
             getAncestorIds(
               { ancestorId: 'ABC' } as unknown as ScratchOrgInfoPayload,
-              projectJson as unknown as SfdxProjectJson,
+              projectJson as unknown as SfProjectJson,
               await Org.create({})
             )
           );
@@ -415,7 +415,7 @@ describe('scratchOrgInfoGenerator', () => {
 
     describe('Invalid ancestorId throws', () => {
       it('Should throw on a bad packageAliases', async () => {
-        const projectJson = stubInterface<SfdxProjectJson>(sandbox, {
+        const projectJson = stubInterface<SfProjectJson>(sandbox, {
           getPackageDirectories: () => [
             {
               path: 'foo',
@@ -434,7 +434,7 @@ describe('scratchOrgInfoGenerator', () => {
           await shouldThrow(
             getAncestorIds(
               { ancestorId: 'ABC' } as unknown as ScratchOrgInfoPayload,
-              projectJson as unknown as SfdxProjectJson,
+              projectJson as unknown as SfProjectJson,
               await Org.create({})
             )
           );
@@ -454,7 +454,7 @@ describe('scratchOrgInfoGenerator', () => {
       getAuthInfoFieldsStub = stubMethod(sandbox, Connection.prototype, 'getAuthInfoFields').returns({
         clientId: '1234',
       });
-      stubMethod(sandbox, SfdxProjectJson, 'create').returns(SfdxProjectJson.prototype);
+      stubMethod(sandbox, SfProjectJson, 'create').returns(SfProjectJson.prototype);
     });
 
     afterEach(() => {
@@ -480,8 +480,8 @@ describe('scratchOrgInfoGenerator', () => {
       });
     });
     it('Generates empty package2AncestorIds scratch org property with hasPackages', async () => {
-      stubMethod(sandbox, SfdxProjectJson.prototype, 'hasPackages').returns(true);
-      stubMethod(sandbox, SfdxProjectJson.prototype, 'isGlobal').returns(true);
+      stubMethod(sandbox, SfProjectJson.prototype, 'hasPackages').returns(true);
+      stubMethod(sandbox, SfProjectJson.prototype, 'isGlobal').returns(true);
       expect(
         await generateScratchOrgInfo({
           hubOrg: await Org.create({}),
@@ -556,7 +556,7 @@ describe('scratchOrgInfoGenerator', () => {
     });
   });
 
-  describe('generateScratchOrgInfo no SfdxProjectJson', () => {
+  describe('generateScratchOrgInfo no SfProjectJson', () => {
     const sandbox = sinon.createSandbox();
     beforeEach(() => {
       stubMethod(sandbox, Org, 'create').resolves(Org.prototype);
@@ -564,7 +564,7 @@ describe('scratchOrgInfoGenerator', () => {
       stubMethod(sandbox, Connection.prototype, 'getAuthInfoFields').returns({
         clientId: '1234',
       });
-      stubMethod(sandbox, SfdxProjectJson, 'create').rejects();
+      stubMethod(sandbox, SfProjectJson, 'create').rejects();
     });
 
     afterEach(() => {
@@ -574,7 +574,7 @@ describe('scratchOrgInfoGenerator', () => {
     after(() => {
       sandbox.restore();
     });
-    it('Generates the package2AncestorIds scratch org property no SfdxProjectJson', async () => {
+    it('Generates the package2AncestorIds scratch org property no SfProjectJson', async () => {
       expect(
         await generateScratchOrgInfo({
           hubOrg: await Org.create({}),
@@ -599,8 +599,8 @@ describe('scratchOrgInfoGenerator', () => {
       stubMethod(sandbox, Connection.prototype, 'getAuthInfoFields').returns({
         clientId: '1234',
       });
-      stubMethod(sandbox, SfdxProjectJson, 'create').returns(SfdxProjectJson.prototype);
-      stubMethod(sandbox, SfdxProjectJson.prototype, 'get').withArgs('namespace').returns('my-namespace');
+      stubMethod(sandbox, SfProjectJson, 'create').returns(SfProjectJson.prototype);
+      stubMethod(sandbox, SfProjectJson.prototype, 'get').withArgs('namespace').returns('my-namespace');
     });
 
     afterEach(() => {
@@ -610,7 +610,7 @@ describe('scratchOrgInfoGenerator', () => {
     after(() => {
       sandbox.restore();
     });
-    it('calls generateScratchOrgInfo with no nonamespace but SfdxProjectJson.get("name") is true', async () => {
+    it('calls generateScratchOrgInfo with no nonamespace but SfProjectJson.get("name") is true', async () => {
       expect(
         await generateScratchOrgInfo({
           hubOrg: await Org.create({}),

--- a/test/unit/projectTest.ts
+++ b/test/unit/projectTest.ts
@@ -9,46 +9,46 @@ import { assert, expect } from 'chai';
 
 import { env } from '@salesforce/kit';
 import { Messages } from '../../src/exported';
-import { SfdxProject, SfdxProjectJson } from '../../src/sfdxProject';
+import { SfProject, SfProjectJson } from '../../src/sfProject';
 import { shouldThrow, testSetup } from '../../src/testSetup';
 
 // Setup the test environment.
 const $$ = testSetup();
 
-describe('SfdxProject', () => {
+describe('SfProject', () => {
   let projectPath;
 
   beforeEach(async () => {
     projectPath = await $$.localPathRetriever($$.id);
     // @ts-ignore
-    SfdxProject.instances.clear();
+    SfProject.instances.clear();
   });
 
   describe('json', () => {
     it('allows uppercase packaging aliases on write', async () => {
-      const json = await SfdxProjectJson.create();
+      const json = await SfProjectJson.create();
       await json.write({ packageAliases: { MyName: 'somePackage' } });
-      expect($$.getConfigStubContents('SfdxProjectJson').packageAliases['MyName']).to.equal('somePackage');
+      expect($$.getConfigStubContents('SfProjectJson').packageAliases['MyName']).to.equal('somePackage');
     });
     it('allows uppercase packaging aliases on read', async () => {
-      $$.setConfigStubContents('SfdxProjectJson', { contents: { packageAliases: { MyName: 'somePackage' } } });
-      const json = await SfdxProjectJson.create();
+      $$.setConfigStubContents('SfProjectJson', { contents: { packageAliases: { MyName: 'somePackage' } } });
+      const json = await SfProjectJson.create();
       expect(json.get('packageAliases')['MyName']).to.equal('somePackage');
     });
     it('read calls schemaValidate', async () => {
-      const defaultOptions = SfdxProjectJson.getDefaultOptions();
-      const sfdxProjectJson = new SfdxProjectJson(defaultOptions);
-      const schemaValidateStub = $$.SANDBOX.stub(sfdxProjectJson, 'schemaValidate');
+      const defaultOptions = SfProjectJson.getDefaultOptions();
+      const sfProjectJson = new SfProjectJson(defaultOptions);
+      const schemaValidateStub = $$.SANDBOX.stub(sfProjectJson, 'schemaValidate');
       schemaValidateStub.returns(Promise.resolve());
-      await sfdxProjectJson.read();
+      await sfProjectJson.read();
       expect(schemaValidateStub.calledOnce).to.be.true;
     });
     it('write calls schemaValidate', async () => {
-      const defaultOptions = SfdxProjectJson.getDefaultOptions();
-      const sfdxProjectJson = new SfdxProjectJson(defaultOptions);
-      const schemaValidateStub = $$.SANDBOX.stub(sfdxProjectJson, 'schemaValidate');
+      const defaultOptions = SfProjectJson.getDefaultOptions();
+      const sfProjectJson = new SfProjectJson(defaultOptions);
+      const schemaValidateStub = $$.SANDBOX.stub(sfProjectJson, 'schemaValidate');
       schemaValidateStub.returns(Promise.resolve());
-      await sfdxProjectJson.write();
+      await sfProjectJson.write();
       expect(schemaValidateStub.calledOnce).to.be.true;
     });
     it('getPackageDirectories should transform packageDir paths to have path separators that match the OS', async () => {
@@ -71,7 +71,7 @@ describe('SfdxProject', () => {
         transformedOtherPP = 'other\\bar';
       }
 
-      $$.setConfigStubContents('SfdxProjectJson', {
+      $$.setConfigStubContents('SfProjectJson', {
         contents: {
           packageDirectories: [
             { path: defaultPP, default: true },
@@ -79,8 +79,8 @@ describe('SfdxProject', () => {
           ],
         },
       });
-      const sfdxProjectJson = await SfdxProjectJson.create();
-      const packageDirs = await sfdxProjectJson.getPackageDirectories();
+      const sfProjectJson = await SfProjectJson.create();
+      const packageDirs = await sfProjectJson.getPackageDirectories();
 
       expect(packageDirs).to.deep.equal([
         {
@@ -98,7 +98,7 @@ describe('SfdxProject', () => {
       ]);
     });
     it('schemaValidate validates sfdx-project.json', async () => {
-      $$.setConfigStubContents('SfdxProjectJson', {
+      $$.setConfigStubContents('SfProjectJson', {
         contents: {
           packageDirectories: [
             { path: 'force-app', default: true },
@@ -110,11 +110,11 @@ describe('SfdxProject', () => {
       });
       const loggerSpy = $$.SANDBOX.spy($$.TEST_LOGGER, 'warn');
       // create() calls read() which calls schemaValidate()
-      await SfdxProjectJson.create();
+      await SfProjectJson.create();
       expect(loggerSpy.called).to.be.false;
     });
     it('schemaValidate throws when SFDX_PROJECT_JSON_VALIDATION=true and invalid file', async () => {
-      $$.setConfigStubContents('SfdxProjectJson', {
+      $$.setConfigStubContents('SfProjectJson', {
         contents: {
           packageDirectories: [{ path: 'force-app', default: true }],
           foo: 'bar',
@@ -124,14 +124,14 @@ describe('SfdxProject', () => {
       const expectedError = "Validation errors:\n should NOT have additional properties 'foo'";
       try {
         // create() calls read() which calls schemaValidate()
-        await shouldThrow(SfdxProjectJson.create());
+        await shouldThrow(SfProjectJson.create());
       } catch (e) {
         expect(e.name).to.equal('SchemaValidationError');
         expect(e.message).to.contain(expectedError);
       }
     });
     it('schemaValidate warns when SFDX_PROJECT_JSON_VALIDATION=false and invalid file', async () => {
-      $$.setConfigStubContents('SfdxProjectJson', {
+      $$.setConfigStubContents('SfProjectJson', {
         contents: {
           packageDirectories: [{ path: 'force-app', default: true }],
           foo: 'bar',
@@ -139,7 +139,7 @@ describe('SfdxProject', () => {
       });
       const loggerSpy = $$.SANDBOX.spy($$.TEST_LOGGER, 'warn');
       // create() calls read() which calls schemaValidate()
-      await SfdxProjectJson.create();
+      await SfProjectJson.create();
       expect(loggerSpy.calledOnce).to.be.true;
       expect(loggerSpy.args[0][0]).to.contains('is not schema valid');
     });
@@ -147,7 +147,7 @@ describe('SfdxProject', () => {
 
   describe('schemaValidate', () => {
     it('validates sfdx-project.json', async () => {
-      $$.setConfigStubContents('SfdxProjectJson', {
+      $$.setConfigStubContents('SfProjectJson', {
         contents: {
           packageDirectories: [
             { path: 'force-app', default: true },
@@ -158,12 +158,12 @@ describe('SfdxProject', () => {
         },
       });
       const loggerSpy = $$.SANDBOX.spy($$.TEST_LOGGER, 'warn');
-      const project = new SfdxProjectJson({});
+      const project = new SfProjectJson({});
       await project.schemaValidate();
       expect(loggerSpy.called).to.be.false;
     });
     it('throws when SFDX_PROJECT_JSON_VALIDATION=true and invalid file', async () => {
-      $$.setConfigStubContents('SfdxProjectJson', {
+      $$.setConfigStubContents('SfProjectJson', {
         contents: {
           packageDirectories: [{ path: 'force-app', default: true }],
           foo: 'bar',
@@ -172,7 +172,7 @@ describe('SfdxProject', () => {
       $$.SANDBOX.stub(env, 'getBoolean').callsFake((envVarName) => envVarName === 'SFDX_PROJECT_JSON_VALIDATION');
       const expectedError = "Validation errors:\n should NOT have additional properties 'foo'";
       try {
-        const project = new SfdxProjectJson({});
+        const project = new SfProjectJson({});
         await project.schemaValidate();
         assert(false, 'should throw');
       } catch (e) {
@@ -181,14 +181,14 @@ describe('SfdxProject', () => {
       }
     });
     it('warns when SFDX_PROJECT_JSON_VALIDATION=false and invalid file', async () => {
-      $$.setConfigStubContents('SfdxProjectJson', {
+      $$.setConfigStubContents('SfProjectJson', {
         contents: {
           packageDirectories: [{ path: 'force-app', default: true }],
           foo: 'bar',
         },
       });
       const loggerSpy = $$.SANDBOX.spy($$.TEST_LOGGER, 'warn');
-      const project = new SfdxProjectJson({});
+      const project = new SfProjectJson({});
       await project.schemaValidate();
       expect(loggerSpy.calledOnce).to.be.true;
       expect(loggerSpy.args[0][0]).to.contain('is not schema valid');
@@ -197,25 +197,25 @@ describe('SfdxProject', () => {
 
   describe('resolve', () => {
     it('caches the sfdx-project.json per path', async () => {
-      // @ts-ignore  SfdxProject.instances is private so override for testing.
-      const instanceSetSpy = $$.SANDBOX.spy(SfdxProject.instances, 'set');
-      const project1 = await SfdxProject.resolve('foo');
+      // @ts-ignore  SfProject.instances is private so override for testing.
+      const instanceSetSpy = $$.SANDBOX.spy(SfProject.instances, 'set');
+      const project1 = await SfProject.resolve('foo');
       expect(instanceSetSpy.calledOnce).to.be.true;
-      const project2 = await SfdxProject.resolve('foo');
+      const project2 = await SfProject.resolve('foo');
       expect(instanceSetSpy.calledOnce).to.be.true;
       expect(project1).to.equal(project2);
     });
     it('with working directory', async () => {
-      const project = await SfdxProject.resolve();
+      const project = await SfProject.resolve();
       expect(project.getPath()).to.equal(projectPath);
-      const sfdxProject = await project.retrieveSfdxProjectJson();
-      expect(sfdxProject.getPath()).to.equal(`${projectPath}${sep}${SfdxProjectJson.getFileName()}`);
+      const sfProject = await project.retrieveSfProjectJson();
+      expect(sfProject.getPath()).to.equal(`${projectPath}${sep}${SfProjectJson.getFileName()}`);
     });
     it('with working directory throws with no sfdx-project.json', async () => {
       $$.SANDBOXES.PROJECT.restore();
-      $$.SANDBOX.stub(SfdxProject, 'resolveProjectPath').throws(new Error('InvalidProjectWorkspaceError'));
+      $$.SANDBOX.stub(SfProject, 'resolveProjectPath').throws(new Error('InvalidProjectWorkspaceError'));
       try {
-        await SfdxProject.resolve();
+        await SfProject.resolve();
         assert.fail();
       } catch (e) {
         expect(e.message).to.equal('InvalidProjectWorkspaceError');
@@ -223,27 +223,27 @@ describe('SfdxProject', () => {
     });
     it('with path', async () => {
       $$.SANDBOXES.PROJECT.restore();
-      $$.SANDBOX.stub(SfdxProject, 'resolveProjectPath').resolves(projectPath);
-      const project = await SfdxProject.resolve(projectPath);
+      $$.SANDBOX.stub(SfProject, 'resolveProjectPath').resolves(projectPath);
+      const project = await SfProject.resolve(projectPath);
       expect(project.getPath()).to.equal(projectPath);
-      const sfdxProject = await project.retrieveSfdxProjectJson();
-      expect(sfdxProject.getPath()).to.equal(`${projectPath}${sep}${SfdxProjectJson.getFileName()}`);
+      const sfProject = await project.retrieveSfProjectJson();
+      expect(sfProject.getPath()).to.equal(`${projectPath}${sep}${SfProjectJson.getFileName()}`);
     });
     it('with path in project', async () => {
       $$.SANDBOXES.PROJECT.restore();
-      const resolveStub = $$.SANDBOX.stub(SfdxProject, 'resolveProjectPath');
+      const resolveStub = $$.SANDBOX.stub(SfProject, 'resolveProjectPath');
       resolveStub.onFirstCall().resolves('/path');
       resolveStub.onSecondCall().resolves('/path');
-      const project1 = await SfdxProject.resolve('/path');
-      const project2 = await SfdxProject.resolve('/path/in/side/project');
+      const project1 = await SfProject.resolve('/path');
+      const project2 = await SfProject.resolve('/path/in/side/project');
       expect(project2.getPath()).to.equal('/path');
       expect(project1).to.equal(project2);
     });
     it('with path throws with no sfdx-project.json', async () => {
       $$.SANDBOXES.PROJECT.restore();
-      $$.SANDBOX.stub(SfdxProject, 'resolveProjectPath').throws(new Error('InvalidProjectWorkspaceError'));
+      $$.SANDBOX.stub(SfProject, 'resolveProjectPath').throws(new Error('InvalidProjectWorkspaceError'));
       try {
-        await SfdxProject.resolve();
+        await SfProject.resolve();
         assert.fail();
       } catch (e) {
         expect(e.message).to.equal('InvalidProjectWorkspaceError');
@@ -254,27 +254,27 @@ describe('SfdxProject', () => {
   describe('getInstance', () => {
     it('with path', async () => {
       $$.SANDBOXES.PROJECT.restore();
-      $$.SANDBOX.stub(SfdxProject, 'resolveProjectPathSync').returns(projectPath);
-      const project = SfdxProject.getInstance(projectPath);
+      $$.SANDBOX.stub(SfProject, 'resolveProjectPathSync').returns(projectPath);
+      const project = SfProject.getInstance(projectPath);
       expect(project.getPath()).to.equal(projectPath);
-      const sfdxProject = await project.retrieveSfdxProjectJson();
-      expect(sfdxProject.getPath()).to.equal(`${projectPath}${sep}${SfdxProjectJson.getFileName()}`);
+      const sfProject = await project.retrieveSfProjectJson();
+      expect(sfProject.getPath()).to.equal(`${projectPath}${sep}${SfProjectJson.getFileName()}`);
     });
     it('with path in project', async () => {
       $$.SANDBOXES.PROJECT.restore();
-      const resolveStub = $$.SANDBOX.stub(SfdxProject, 'resolveProjectPathSync');
+      const resolveStub = $$.SANDBOX.stub(SfProject, 'resolveProjectPathSync');
       resolveStub.onFirstCall().returns('/path');
       resolveStub.onSecondCall().returns('/path');
-      const project1 = SfdxProject.getInstance('/path');
-      const project2 = SfdxProject.getInstance('/path/in/side/project');
+      const project1 = SfProject.getInstance('/path');
+      const project2 = SfProject.getInstance('/path/in/side/project');
       expect(project2.getPath()).to.equal('/path');
       expect(project1).to.equal(project2);
     });
     it('with path throws with no sfdx-project.json', async () => {
       $$.SANDBOXES.PROJECT.restore();
-      $$.SANDBOX.stub(SfdxProject, 'resolveProjectPathSync').throws(new Error('InvalidProjectWorkspaceError'));
+      $$.SANDBOX.stub(SfProject, 'resolveProjectPathSync').throws(new Error('InvalidProjectWorkspaceError'));
       try {
-        SfdxProject.getInstance();
+        SfProject.getInstance();
         assert.fail();
       } catch (e) {
         expect(e.message).to.equal('InvalidProjectWorkspaceError');
@@ -288,8 +288,8 @@ describe('SfdxProject', () => {
       delete process.env.SFDX_SCRATCH_ORG_CREATION_LOGIN_URL;
     });
     it('gets default login url', async () => {
-      $$.configStubs.SfdxProjectJson = { contents: {} };
-      const project = await SfdxProject.resolve();
+      $$.configStubs.SfProjectJson = { contents: {} };
+      const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
       expect(config['sfdcLoginUrl']).to.equal('https://login.salesforce.com');
     });
@@ -301,8 +301,8 @@ describe('SfdxProject', () => {
           return {};
         }
       };
-      $$.configStubs.SfdxProjectJson = { retrieveContents: read };
-      const project = await SfdxProject.resolve();
+      $$.configStubs.SfProjectJson = { retrieveContents: read };
+      const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
       expect(config['sfdcLoginUrl']).to.equal('globalUrl');
     });
@@ -314,8 +314,8 @@ describe('SfdxProject', () => {
           return { sfdcLoginUrl: 'localUrl' };
         }
       };
-      $$.configStubs.SfdxProjectJson = { retrieveContents: read };
-      const project = await SfdxProject.resolve();
+      $$.configStubs.SfProjectJson = { retrieveContents: read };
+      const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
       expect(config['sfdcLoginUrl']).to.equal('localUrl');
     });
@@ -328,9 +328,9 @@ describe('SfdxProject', () => {
           return { sfdcLoginUrl: 'localUrl' };
         }
       };
-      $$.configStubs.SfdxProjectJson = { retrieveContents: read };
+      $$.configStubs.SfProjectJson = { retrieveContents: read };
       $$.configStubs.Config = { contents: { instanceUrl: 'https://dontusethis.my.salesforce.com' } };
-      const project = await SfdxProject.resolve();
+      const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
       expect(config['sfdcLoginUrl']).to.equal('envarUrl');
     });
@@ -338,8 +338,8 @@ describe('SfdxProject', () => {
       const read = async function () {
         return { signupTargetLoginUrl: 'localUrl' };
       };
-      $$.configStubs.SfdxProjectJson = { retrieveContents: read };
-      const project = await SfdxProject.resolve();
+      $$.configStubs.SfProjectJson = { retrieveContents: read };
+      const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
       expect(config['signupTargetLoginUrl']).to.equal('localUrl');
     });
@@ -348,8 +348,8 @@ describe('SfdxProject', () => {
       const read = async function () {
         return { signupTargetLoginUrl: 'localUrl' };
       };
-      $$.configStubs.SfdxProjectJson = { retrieveContents: read };
-      const project = await SfdxProject.resolve();
+      $$.configStubs.SfProjectJson = { retrieveContents: read };
+      const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
       expect(config['signupTargetLoginUrl']).to.equal('envarUrl');
     });
@@ -361,9 +361,9 @@ describe('SfdxProject', () => {
           return { apiVersion: 39.0 };
         }
       };
-      $$.configStubs.SfdxProjectJson = { retrieveContents: read };
+      $$.configStubs.SfProjectJson = { retrieveContents: read };
       $$.configStubs.Config = { contents: { apiVersion: 40.0, instanceUrl: 'https://usethis.my.salesforce.com' } };
-      const project = await SfdxProject.resolve();
+      const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
       expect(config['sfdcLoginUrl']).to.equal('https://usethis.my.salesforce.com');
     });
@@ -375,9 +375,9 @@ describe('SfdxProject', () => {
           return { apiVersion: 39.0, sfdcLoginUrl: 'https://fromfiles.com' };
         }
       };
-      $$.configStubs.SfdxProjectJson = { retrieveContents: read };
+      $$.configStubs.SfProjectJson = { retrieveContents: read };
       $$.configStubs.Config = { contents: { apiVersion: 40.0, instanceUrl: 'https://dontusethis.my.salesforce.com' } };
-      const project = await SfdxProject.resolve();
+      const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
       expect(config['sfdcLoginUrl']).to.equal('https://fromfiles.com');
     });
@@ -389,9 +389,9 @@ describe('SfdxProject', () => {
           return { apiVersion: 39.0 };
         }
       };
-      $$.configStubs.SfdxProjectJson = { retrieveContents: read };
+      $$.configStubs.SfProjectJson = { retrieveContents: read };
       $$.configStubs.Config = { contents: { apiVersion: 40.0 } };
-      const project = await SfdxProject.resolve();
+      const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
       expect(config['apiVersion']).to.equal(40.0);
     });
@@ -402,7 +402,7 @@ describe('SfdxProject', () => {
       const expectedPackage1 = 'foo';
       const expectedPackage2 = 'bar';
 
-      $$.setConfigStubContents('SfdxProjectJson', {
+      $$.setConfigStubContents('SfProjectJson', {
         contents: {
           packageDirectories: [
             { path: expectedPackage1, default: true },
@@ -410,7 +410,7 @@ describe('SfdxProject', () => {
           ],
         },
       });
-      const project = await SfdxProject.resolve();
+      const project = await SfProject.resolve();
       const packageDirs = project.getPackageDirectories();
 
       expect(packageDirs.length).to.equal(2);
@@ -435,7 +435,7 @@ describe('SfdxProject', () => {
       const expectedPackage1 = 'foo';
       const expectedPackage2 = 'bar';
 
-      $$.setConfigStubContents('SfdxProjectJson', {
+      $$.setConfigStubContents('SfProjectJson', {
         contents: {
           packageDirectories: [
             { path: expectedPackage1, default: true },
@@ -443,7 +443,7 @@ describe('SfdxProject', () => {
           ],
         },
       });
-      const project = await SfdxProject.resolve();
+      const project = await SfProject.resolve();
       const actual = project.getDefaultPackage();
       const expected = {
         path: expectedPackage1,
@@ -457,12 +457,12 @@ describe('SfdxProject', () => {
     it('should set the a single package entry as default', async () => {
       const expectedPackage1 = 'foo';
 
-      $$.setConfigStubContents('SfdxProjectJson', {
+      $$.setConfigStubContents('SfProjectJson', {
         contents: {
           packageDirectories: [{ path: expectedPackage1 }],
         },
       });
-      const project = await SfdxProject.resolve();
+      const project = await SfProject.resolve();
       const actual = project.getDefaultPackage();
       const expected = {
         path: expectedPackage1,
@@ -476,12 +476,12 @@ describe('SfdxProject', () => {
     it('should error when one package is defined and set to default=false', async () => {
       const expectedPackage1 = 'foo';
 
-      $$.setConfigStubContents('SfdxProjectJson', {
+      $$.setConfigStubContents('SfProjectJson', {
         contents: {
           packageDirectories: [{ path: expectedPackage1, default: false }],
         },
       });
-      const project = await SfdxProject.resolve();
+      const project = await SfProject.resolve();
 
       try {
         project.getPackageDirectories();
@@ -497,13 +497,13 @@ describe('SfdxProject', () => {
       const expectedName = 'force-app';
       const expectedPackage = `.${sep}${expectedName}${sep}`;
 
-      $$.setConfigStubContents('SfdxProjectJson', {
+      $$.setConfigStubContents('SfProjectJson', {
         contents: {
           packageDirectories: [{ path: expectedPackage, default: true }],
         },
       });
 
-      const project = SfdxProject.getInstance();
+      const project = SfProject.getInstance();
       const actual = project.getDefaultPackage();
       const expected = {
         fullPath: join(projectPath, expectedPackage, sep),
@@ -517,7 +517,7 @@ describe('SfdxProject', () => {
     it('should filter based on package path', async () => {
       const expectedPackage1 = 'force-app';
 
-      $$.setConfigStubContents('SfdxProjectJson', {
+      $$.setConfigStubContents('SfProjectJson', {
         contents: {
           packageDirectories: [
             { path: expectedPackage1, default: true },
@@ -525,7 +525,7 @@ describe('SfdxProject', () => {
           ],
         },
       });
-      const project = await SfdxProject.resolve();
+      const project = await SfProject.resolve();
 
       expect(project.getPackageDirectories().length).to.equal(2);
       expect(project.getUniquePackageDirectories().length).to.equal(1);
@@ -537,7 +537,7 @@ describe('SfdxProject', () => {
       const expectedNestedPackage = join('force-app-two', 'nested');
 
       beforeEach(() => {
-        $$.setConfigStubContents('SfdxProjectJson', {
+        $$.setConfigStubContents('SfProjectJson', {
           contents: {
             packageDirectories: [
               { path: expectedNestedPackage, default: false },
@@ -549,28 +549,28 @@ describe('SfdxProject', () => {
       });
 
       it('should return the package that a source path belongs to', () => {
-        const actual = SfdxProject.getInstance().getPackageNameFromPath(
+        const actual = SfProject.getInstance().getPackageNameFromPath(
           join(projectPath, expectedPackage, 'main', 'apex', 'apecClass.cls')
         );
         expect(actual).to.equal(expectedPackage);
       });
 
       it('should return correct package name when the file name includes package name', () => {
-        const actual = SfdxProject.getInstance().getPackageNameFromPath(
+        const actual = SfProject.getInstance().getPackageNameFromPath(
           join(projectPath, expectedPackage, 'main', 'apex', `${expectedPackage}apecClass.cls`)
         );
         expect(actual).to.equal(expectedPackage);
       });
 
       it('should return correct package name when the file path includes a different package name', () => {
-        const actual = SfdxProject.getInstance().getPackageNameFromPath(
+        const actual = SfProject.getInstance().getPackageNameFromPath(
           join(projectPath, expectedContainedPackage, 'main', 'apex', 'apecClass.cls')
         );
         expect(actual).to.equal(expectedContainedPackage);
       });
 
       it('should return correct package name when the package has a nested path', () => {
-        const actual = SfdxProject.getInstance().getPackageNameFromPath(
+        const actual = SfProject.getInstance().getPackageNameFromPath(
           join(projectPath, expectedNestedPackage, 'main', 'apex', 'apecClass.cls')
         );
         expect(actual).to.equal(expectedNestedPackage);
@@ -581,7 +581,7 @@ describe('SfdxProject', () => {
       const expectedPackage = 'force-app';
 
       beforeEach(() => {
-        $$.setConfigStubContents('SfdxProjectJson', {
+        $$.setConfigStubContents('SfProjectJson', {
           contents: {
             packageDirectories: [{ path: expectedPackage, default: true }],
           },
@@ -590,11 +590,11 @@ describe('SfdxProject', () => {
 
       it('should return the package path given a package name', () => {
         const expectedPath = join(projectPath, expectedPackage, sep);
-        expect(SfdxProject.getInstance().getPackagePath(expectedPackage)).to.equal(expectedPath);
+        expect(SfProject.getInstance().getPackagePath(expectedPackage)).to.equal(expectedPath);
       });
 
       it('should return null when not matched', () => {
-        expect(SfdxProject.getInstance().getPackagePath('nonexistant')).to.equal(undefined);
+        expect(SfProject.getInstance().getPackagePath('nonexistant')).to.equal(undefined);
       });
     });
 
@@ -602,7 +602,7 @@ describe('SfdxProject', () => {
       const expectedPackage = 'force-app';
 
       beforeEach(() => {
-        $$.setConfigStubContents('SfdxProjectJson', {
+        $$.setConfigStubContents('SfProjectJson', {
           contents: {
             packageDirectories: [{ path: expectedPackage, default: true }],
           },
@@ -610,24 +610,24 @@ describe('SfdxProject', () => {
       });
 
       it('should set/get a null package', () => {
-        SfdxProject.getInstance().setActivePackage(null);
-        expect(SfdxProject.getInstance().getActivePackage()).to.equal(null);
+        SfProject.getInstance().setActivePackage(null);
+        expect(SfProject.getInstance().getActivePackage()).to.equal(null);
       });
 
       it('should set/get a nonexistent package', () => {
-        SfdxProject.getInstance().setActivePackage('force-app-?');
-        expect(SfdxProject.getInstance().getActivePackage()).to.equal(undefined);
+        SfProject.getInstance().setActivePackage('force-app-?');
+        expect(SfProject.getInstance().getActivePackage()).to.equal(undefined);
       });
 
       it('should set/get an existing package', () => {
-        SfdxProject.getInstance().setActivePackage(expectedPackage);
-        expect(SfdxProject.getInstance().getActivePackage().name).to.equal(expectedPackage);
+        SfProject.getInstance().setActivePackage(expectedPackage);
+        expect(SfProject.getInstance().getActivePackage().name).to.equal(expectedPackage);
       });
     });
 
     describe('hasMultiplePackages', () => {
       it('should return true if the project has multiple packages', () => {
-        $$.setConfigStubContents('SfdxProjectJson', {
+        $$.setConfigStubContents('SfProjectJson', {
           contents: {
             packageDirectories: [
               { path: 'force-app1', default: true },
@@ -636,17 +636,17 @@ describe('SfdxProject', () => {
           },
         });
 
-        expect(SfdxProject.getInstance().hasMultiplePackages()).to.equal(true);
+        expect(SfProject.getInstance().hasMultiplePackages()).to.equal(true);
       });
 
       it('should return false if the project does not have multiple packages', () => {
-        $$.setConfigStubContents('SfdxProjectJson', {
+        $$.setConfigStubContents('SfProjectJson', {
           contents: {
             packageDirectories: [{ path: 'force-app', default: true }],
           },
         });
 
-        expect(SfdxProject.getInstance().hasMultiplePackages()).to.equal(false);
+        expect(SfProject.getInstance().hasMultiplePackages()).to.equal(false);
       });
     });
   });

--- a/test/unit/sfdxErrorTest.ts
+++ b/test/unit/sfdxErrorTest.ts
@@ -6,17 +6,17 @@
  */
 import { expect } from 'chai';
 import { Messages } from '../../src/messages';
-import { SfdxError } from '../../src/sfdxError';
+import { SfError } from '../../src/sfError';
 
 Messages.importMessageFile('pname', 'testMessages.json');
 
-describe('SfdxError', () => {
+describe('SfError', () => {
   describe('constructor', () => {
-    it('should return a mutable SfdxError', () => {
+    it('should return a mutable SfError', () => {
       const msg = 'this is a test message';
-      const err = new SfdxError(msg);
+      const err = new SfError(msg);
       expect(err.message).to.equal(msg);
-      expect(err.name).to.equal('SfdxError');
+      expect(err.name).to.equal('SfError');
       expect(err.actions).to.be.undefined;
       expect(err.exitCode).to.equal(1);
       const actions = ['Do this action', 'Do that action'];
@@ -33,11 +33,11 @@ describe('SfdxError', () => {
       const myErrorName = 'OhMyError';
       const myError = new Error(myErrorMsg);
       myError.name = myErrorName;
-      const mySfdxError = SfdxError.wrap(myError);
-      expect(mySfdxError).to.be.an.instanceOf(SfdxError);
-      expect(mySfdxError.message).to.equal(myErrorMsg);
-      expect(mySfdxError.name).to.equal(myErrorName);
-      expect(mySfdxError.fullStack).to.contain('Caused by:').and.contain(myError.stack);
+      const mySfError = SfError.wrap(myError);
+      expect(mySfError).to.be.an.instanceOf(SfError);
+      expect(mySfError.message).to.equal(myErrorMsg);
+      expect(mySfError.name).to.equal(myErrorName);
+      expect(mySfError.fullStack).to.contain('Caused by:').and.contain(myError.stack);
     });
 
     it('should return a wrapped error with a code', () => {
@@ -47,22 +47,22 @@ describe('SfdxError', () => {
       const myErrorCode = 'OhMyError';
       const myError = new CodeError('test');
       myError.code = myErrorCode;
-      const mySfdxError = SfdxError.wrap(myError);
-      expect(mySfdxError).to.be.an.instanceOf(SfdxError);
-      expect(mySfdxError.code).to.equal(myErrorCode);
+      const mySfError = SfError.wrap(myError);
+      expect(mySfError).to.be.an.instanceOf(SfError);
+      expect(mySfError.code).to.equal(myErrorCode);
     });
 
     it('should return a new error with just a string', () => {
-      const mySfdxError = SfdxError.wrap('test');
-      expect(mySfdxError).to.be.an.instanceOf(SfdxError);
-      expect(mySfdxError.message).to.equal('test');
+      const mySfError = SfError.wrap('test');
+      expect(mySfError).to.be.an.instanceOf(SfError);
+      expect(mySfError.message).to.equal('test');
     });
 
-    it('should return the error if already a SfdxError', () => {
-      const existingSfdxError = new SfdxError('test');
-      const mySfdxError = SfdxError.wrap(existingSfdxError);
-      expect(mySfdxError).to.be.an.instanceOf(SfdxError);
-      expect(mySfdxError).to.equal(existingSfdxError);
+    it('should return the error if already a SfError', () => {
+      const existingSfError = new SfError('test');
+      const mySfError = SfError.wrap(existingSfError);
+      expect(mySfError).to.be.an.instanceOf(SfError);
+      expect(mySfError).to.equal(existingSfError);
     });
   });
 
@@ -75,10 +75,10 @@ describe('SfdxError', () => {
       const context = 'TestContext1';
       const data = { foo: 'pity the foo' };
 
-      const sfdxError = new SfdxError(message, name, actions, exitCode);
-      sfdxError.setContext(context).setData(data);
+      const sfError = new SfError(message, name, actions, exitCode);
+      sfError.setContext(context).setData(data);
 
-      expect(sfdxError.toObject()).to.deep.equal({
+      expect(sfError.toObject()).to.deep.equal({
         name,
         message,
         exitCode,
@@ -92,9 +92,9 @@ describe('SfdxError', () => {
       const message = "it's a trap!";
       const name = 'BadError';
 
-      const sfdxError = new SfdxError(message, name);
+      const sfError = new SfError(message, name);
 
-      expect(sfdxError.toObject()).to.deep.equal({
+      expect(sfError.toObject()).to.deep.equal({
         name,
         message,
         exitCode: 1,

--- a/test/unit/status/streamingClientTest.ts
+++ b/test/unit/status/streamingClientTest.ts
@@ -12,8 +12,8 @@ import { get, JsonMap } from '@salesforce/ts-types';
 import { CometClient, StatusResult, StreamingClient } from '../../../src/status/streamingClient';
 import { Connection } from '../../../src/org';
 import { Crypto } from '../../../src/crypto/crypto';
-import { Org } from '../../../src/org';
-import { SfdxError } from '../../../src/sfdxError';
+import { Org } from '../../../src/org/org';
+import { SfError } from '../../../src/sfError';
 import {
   shouldThrow,
   StreamingMockCometClient,
@@ -71,7 +71,7 @@ describe('streaming client tests', () => {
           completed: true,
         };
       } else {
-        throw new SfdxError('unexpected message', 'UnexpectedMessage');
+        throw new SfError('unexpected message', 'UnexpectedMessage');
       }
     };
 
@@ -126,9 +126,9 @@ describe('streaming client tests', () => {
 
     const streamProcessor = (message: JsonMap): StatusResult => {
       if (message.id === TEST_STRING) {
-        throw new SfdxError('TEST_ERROR', 'TEST_ERROR');
+        throw new SfError('TEST_ERROR', 'TEST_ERROR');
       } else {
-        throw new SfdxError('unexpected message', 'UnexpectedMessage');
+        throw new SfError('unexpected message', 'UnexpectedMessage');
       }
     };
 
@@ -171,7 +171,7 @@ describe('streaming client tests', () => {
           completed: true,
         };
       } else {
-        throw new SfdxError('unexpected message', 'UnexpectedMessage');
+        throw new SfError('unexpected message', 'UnexpectedMessage');
       }
     };
 
@@ -183,7 +183,7 @@ describe('streaming client tests', () => {
           url,
           id: TEST_STRING,
           subscriptionCall: StreamingMockSubscriptionCall.ERRORBACK,
-          subscriptionErrbackError: new SfdxError('TEST ERROR', TEST_STRING),
+          subscriptionErrbackError: new SfError('TEST ERROR', TEST_STRING),
         });
       },
       setLogger: () => {},
@@ -216,7 +216,7 @@ describe('streaming client tests', () => {
           completed: true,
         };
       } else {
-        throw new SfdxError('unexpected message', 'UnexpectedMessage');
+        throw new SfError('unexpected message', 'UnexpectedMessage');
       }
     };
 

--- a/test/unit/webOauthServerTest.ts
+++ b/test/unit/webOauthServerTest.ts
@@ -12,7 +12,7 @@ import { assert } from '@salesforce/ts-types';
 import { StubbedType, stubInterface, stubMethod } from '@salesforce/ts-sinon';
 import { Env } from '@salesforce/kit';
 import { testSetup, MockTestOrgData } from '../../src/testSetup';
-import { SfdxProjectJson } from '../../src/sfdxProject';
+import { SfProjectJson } from '../../src/sfProject';
 import { WebOAuthServer, WebServer } from '../../src/webOAuthServer';
 import { AuthFields, AuthInfo } from '../../src/org/authInfo';
 
@@ -21,7 +21,7 @@ const $$ = testSetup();
 describe('WebOauthServer', () => {
   describe('determineOauthPort', () => {
     it('should return configured oauth port if it exists', async () => {
-      $$.SANDBOX.stub(SfdxProjectJson.prototype, 'get').withArgs('oauthLocalPort').returns(8080);
+      $$.SANDBOX.stub(SfProjectJson.prototype, 'get').withArgs('oauthLocalPort').returns(8080);
       const port = await WebOAuthServer.determineOauthPort();
       expect(port).to.equal(8080);
     });

--- a/typedocExamples/sfdxProjectExamples.ts
+++ b/typedocExamples/sfdxProjectExamples.ts
@@ -1,9 +1,9 @@
-import { SfdxProject } from '../src/sfdxProject';
+import { SfProject } from '../src/sfProject';
 
-export const sfdxProjectExamples = {
+export const sfProjectExamples = {
   classDoc: async () => {
-    const project = await SfdxProject.resolve();
+    const project = await SfProject.resolve();
     const projectJson = await project.resolveProjectConfig();
     console.log(projectJson.sfdcLoginUrl);
-  }
+  },
 };


### PR DESCRIPTION
Renames and deprecates the following:
- `SfdxProject` -> `SfProject`
- `SfdxProjectJson` -> `SfProjectJson`
- `SfdxError` -> `SfError`


[skip-validate-pr]