### PR TITLE
Rotating log file

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import { Writable } from 'stream';
 // @ts-ignore
 import * as Bunyan from '@salesforce/bunyan';
-import { parseJson, parseJsonMap } from '@salesforce/kit';
+import { Env, parseJson, parseJsonMap } from '@salesforce/kit';
 import {
   Dictionary,
   ensure,
@@ -220,6 +220,21 @@ export class Logger {
   private static rootLogger?: Logger;
 
   /**
+   * The default rotation period for logs. Example '1d' will rotate logs daily (at midnight).
+   * See 'period' docs here: https://github.com/forcedotcom/node-bunyan#stream-type-rotating-file
+   */
+
+  public readonly logRotationPeriod = new Env().getString('SFDX_LOG_ROTATION_PERIOD') || '1d';
+
+  /**
+   * The number of backup rotated log files to keep.
+   * Example: '3' will have the base sfdx.log file, and the past 3 (period) log files.
+   * See 'count' docs here: https://github.com/forcedotcom/node-bunyan#stream-type-rotating-file
+   */
+
+  public readonly logRotationCount = new Env().getNumber('SFDX_LOG_ROTATION_COUNT') || 2;
+
+  /**
    * Whether debug is enabled for this Logger.
    */
   public debugEnabled = false;
@@ -416,14 +431,14 @@ export class Logger {
       !this.bunyan.streams.find(
         // No bunyan typings
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (stream: any) => stream.type === 'file' && stream.path === logFile
+        (stream: any) => stream.type === 'rotating-file' && stream.path === logFile
       )
     ) {
-      // TODO: rotating-file
-      // https://github.com/trentm/node-bunyan#stream-type-rotating-file
       this.addStream({
-        type: 'file',
+        type: 'rotating-file',
         path: logFile,
+        period: this.logRotationPeriod,
+        count: this.logRotationCount,
         level: this.bunyan.level() as number,
       });
     }
@@ -458,14 +473,14 @@ export class Logger {
       !this.bunyan.streams.find(
         // No bunyan typings
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (stream: any) => stream.type === 'file' && stream.path === logFile
+        (stream: any) => stream.type === 'rotating-file' && stream.path === logFile
       )
     ) {
-      // TODO: rotating-file
-      // https://github.com/trentm/node-bunyan#stream-type-rotating-file
       this.addStream({
-        type: 'file',
+        type: 'rotating-file',
         path: logFile,
+        period: this.logRotationPeriod,
+        count: this.logRotationCount,
         level: this.bunyan.level() as number,
       });
     }

--- a/test/unit/loggerTest.ts
+++ b/test/unit/loggerTest.ts
@@ -20,6 +20,8 @@ const $$ = testSetup();
 
 describe('Logger', () => {
   const sfdxEnv = process.env.SFDX_ENV;
+  const logRotationPeriodBackup = process.env.SFDX_LOG_ROTATION_PERIOD;
+  const logRotationCountBackup = process.env.SFDX_LOG_ROTATION_COUNT;
 
   beforeEach(async () => {
     process.env.SFDX_ENV = 'test';
@@ -33,6 +35,8 @@ describe('Logger', () => {
   afterEach(() => {
     Logger.destroyRoot();
     process.env.SFDX_ENV = sfdxEnv;
+    process.env.SFDX_LOG_ROTATION_PERIOD = logRotationPeriodBackup;
+    process.env.SFDX_LOG_ROTATION_COUNT = logRotationCountBackup;
   });
 
   describe('constructor', () => {
@@ -114,9 +118,23 @@ describe('Logger', () => {
       expect(utilMkdirpStub.called).to.be.false;
       expect(utilWriteFileStub.called).to.be.false;
       const addStreamArgs = addStreamStub.firstCall.args[0];
-      expect(addStreamArgs).to.have.property('type', 'file');
+      expect(addStreamArgs).to.have.property('type', 'rotating-file');
       expect(addStreamArgs).to.have.property('path', testLogFile);
       expect(addStreamArgs).to.have.property('level', logger.getLevel());
+    });
+
+    it('should allow log rotation count and period overrides', async () => {
+      process.env.SFDX_LOG_ROTATION_PERIOD = '1w';
+      process.env.SFDX_LOG_ROTATION_COUNT = '3';
+
+      utilAccessStub.returns(Promise.resolve({}));
+      const logger = new Logger('testing-env-vars');
+      const addStreamStub = $$.SANDBOX.stub(logger, 'addStream');
+      await logger.addLogFileStream(testLogFile);
+
+      const addStreamArgs = addStreamStub.firstCall.args[0];
+      expect(addStreamArgs).to.have.property('period', '1w');
+      expect(addStreamArgs).to.have.property('count', 3);
     });
 
     it('should create a new log file and all directories if nonexistent', async () => {


### PR DESCRIPTION
Outcome of [this SPIKE](https://salesforce.quip.com/IFBwADN7GUZk#GOLABAyMYnx)

[@W-10745422@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-10745422)

Implements the [rotating log stream](https://github.com/forcedotcom/node-bunyan#stream-type-rotating-file) supported in Bunyan into sfdx-core's logger

## Testing instructions
- Pull this branch
- Run `yarn link`
- `cd` to local `sfdx-cli`
- Run `yarn link @salesforce/core`
- Run a command that will log
  - Example: `SFDX_LOG_ROTATION_PERIOD='5000ms' ./bin/run force:org:list  --loglevel=trace`
    - Note `./bin/run`
- Run command a few more times
- Notice that you now have multiple log files in your home directory (`sfdx.log`, `sfdx.log.0`, `sfdx.log.1`, `sfdx.log.2`)
- Notice how logs move to "next" log file as commands are ran.


## Worth noting 
- The `ms` interval does not behave exactly like the other intervals. Hourly, Daily, Weekly, etc will "switch" log files at the start of a new period (e.g. daily happens at midnight). Milliseconds will rotated logs on each command regardless. This can be tested a little more accurately by modifying Bunyan's code slightly. 
  - In your linked `core` directory (`sfdx-cli/node_modules/@salesforce/core/node_modules/@salesforce/bunyan/lib/bunyan.js`) change:
- Potential for orphaned log files ([conversation](https://salesforce-internal.slack.com/archives/G02K6C90RBJ/p1646342677496859))