### PR TITLE
Rotating file logs V3

### DIFF
--- a/messages/envVars.md
+++ b/messages/envVars.md
@@ -94,6 +94,14 @@ Set to true to send messages resulting from failed Salesforce CLI commands to st
 
 Level of messages that the CLI writes to the log file. Valid values are trace, debug, info, warn, error, fatal. Default value is warn.
 
+# sfdxLogRotationCount
+
+The default rotation period for logs. Example '1d' will rotate logs daily (at midnight).
+
+# sfdxLogRotationPeriod
+
+The number of backup rotated log files to keep. Example: '3' will have the base sf.log file, and the past 3 (period) log files.
+
 # sfdxMaxQueryLimit
 
 Maximum number of Salesforce records returned by a CLI command. Default value is 10,000. Overrides the maxQueryLimit configuration value.
@@ -221,6 +229,14 @@ Set to true to send messages resulting from failed Salesforce CLI commands to st
 # sfLogLevel
 
 Level of messages that the CLI writes to the log file. Valid values are trace, debug, info, warn, error, fatal. Default value is warn.
+
+# sfLogRotationCount
+
+The default rotation period for logs. Example '1d' will rotate logs daily (at midnight).
+
+# sfLogRotationPeriod
+
+The number of backup rotated log files to keep. Example: '3' will have the base sf.log file, and the past 3 (period) log files.
 
 # sfMaxQueryLimit
 

--- a/src/config/envVars.ts
+++ b/src/config/envVars.ts
@@ -38,6 +38,8 @@ export enum EnvironmentVariable {
   'SFDX_INSTANCE_URL' = 'SFDX_INSTANCE_URL',
   'SFDX_JSON_TO_STDOUT' = 'SFDX_JSON_TO_STDOUT',
   'SFDX_LOG_LEVEL' = 'SFDX_LOG_LEVEL',
+  'SFDX_LOG_ROTATION_COUNT' = 'SFDX_LOG_ROTATION_COUNT',
+  'SFDX_LOG_ROTATION_PERIOD' = 'SFDX_LOG_ROTATION_PERIOD',
   'SFDX_MAX_QUERY_LIMIT' = 'SFDX_MAX_QUERY_LIMIT',
   'SFDX_MDAPI_TEMP_DIR' = 'SFDX_MDAPI_TEMP_DIR',
   'SFDX_NPM_REGISTRY' = 'SFDX_NPM_REGISTRY',
@@ -70,6 +72,8 @@ export enum EnvironmentVariable {
   'SF_INSTANCE_URL' = 'SF_INSTANCE_URL',
   'SF_JSON_TO_STDOUT' = 'SF_JSON_TO_STDOUT',
   'SF_LOG_LEVEL' = 'SF_LOG_LEVEL',
+  'SF_LOG_ROTATION_COUNT' = 'SF_LOG_ROTATION_COUNT',
+  'SF_LOG_ROTATION_PERIOD' = 'SF_LOG_ROTATION_PERIOD',
   'SF_MAX_QUERY_LIMIT' = 'SF_MAX_QUERY_LIMIT',
   'SF_MDAPI_TEMP_DIR' = 'SF_MDAPI_TEMP_DIR',
   'SF_NPM_REGISTRY' = 'SF_NPM_REGISTRY',
@@ -194,6 +198,14 @@ export const SUPPORTED_ENV_VARS: EnvType = {
   [EnvironmentVariable.SFDX_LOG_LEVEL]: {
     description: getMessage(EnvironmentVariable.SFDX_LOG_LEVEL),
     synonymOf: EnvironmentVariable.SF_LOG_LEVEL,
+  },
+  [EnvironmentVariable.SFDX_LOG_ROTATION_COUNT]: {
+    description: getMessage(EnvironmentVariable.SFDX_LOG_ROTATION_COUNT),
+    synonymOf: EnvironmentVariable.SF_LOG_ROTATION_COUNT,
+  },
+  [EnvironmentVariable.SFDX_LOG_ROTATION_PERIOD]: {
+    description: getMessage(EnvironmentVariable.SFDX_LOG_ROTATION_PERIOD),
+    synonymOf: EnvironmentVariable.SF_LOG_ROTATION_PERIOD,
   },
   [EnvironmentVariable.SFDX_MAX_QUERY_LIMIT]: {
     description: getMessage(EnvironmentVariable.SFDX_MAX_QUERY_LIMIT),
@@ -324,6 +336,14 @@ export const SUPPORTED_ENV_VARS: EnvType = {
   },
   [EnvironmentVariable.SF_LOG_LEVEL]: {
     description: getMessage(EnvironmentVariable.SF_LOG_LEVEL),
+    synonymOf: null,
+  },
+  [EnvironmentVariable.SF_LOG_ROTATION_COUNT]: {
+    description: getMessage(EnvironmentVariable.SF_LOG_ROTATION_COUNT),
+    synonymOf: null,
+  },
+  [EnvironmentVariable.SF_LOG_ROTATION_PERIOD]: {
+    description: getMessage(EnvironmentVariable.SF_LOG_ROTATION_PERIOD),
     synonymOf: null,
   },
   [EnvironmentVariable.SF_MAX_QUERY_LIMIT]: {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -12,7 +12,7 @@ import * as fs from 'fs';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import * as Bunyan from '@salesforce/bunyan';
-import { parseJson, parseJsonMap } from '@salesforce/kit';
+import { Env, parseJson, parseJsonMap } from '@salesforce/kit';
 import {
   Dictionary,
   ensure,
@@ -222,6 +222,21 @@ export class Logger {
   private static rootLogger?: Logger;
 
   /**
+   * The default rotation period for logs. Example '1d' will rotate logs daily (at midnight).
+   * See 'period' docs here: https://github.com/forcedotcom/node-bunyan#stream-type-rotating-file
+   */
+
+  public readonly logRotationPeriod = new Env().getString('SF_LOG_ROTATION_PERIOD') || '1d';
+
+  /**
+   * The number of backup rotated log files to keep.
+   * Example: '3' will have the base sf.log file, and the past 3 (period) log files.
+   * See 'count' docs here: https://github.com/forcedotcom/node-bunyan#stream-type-rotating-file
+   */
+
+  public readonly logRotationCount = new Env().getNumber('SF_LOG_ROTATION_COUNT') || 2;
+
+  /**
    * Whether debug is enabled for this Logger.
    */
   public debugEnabled = false;
@@ -418,14 +433,14 @@ export class Logger {
       !this.bunyan.streams.find(
         // No bunyan typings
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (stream: any) => stream.type === 'file' && stream.path === logFile
+        (stream: any) => stream.type === 'rotating-file' && stream.path === logFile
       )
     ) {
-      // TODO: rotating-file
-      // https://github.com/trentm/node-bunyan#stream-type-rotating-file
       this.addStream({
-        type: 'file',
+        type: 'rotating-file',
         path: logFile,
+        period: this.logRotationPeriod,
+        count: this.logRotationCount,
         level: this.bunyan.level() as number,
       });
     }
@@ -460,14 +475,14 @@ export class Logger {
       !this.bunyan.streams.find(
         // No bunyan typings
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (stream: any) => stream.type === 'file' && stream.path === logFile
+        (stream: any) => stream.type === 'rotating-file' && stream.path === logFile
       )
     ) {
-      // TODO: rotating-file
-      // https://github.com/trentm/node-bunyan#stream-type-rotating-file
       this.addStream({
-        type: 'file',
+        type: 'rotating-file',
         path: logFile,
+        period: this.logRotationPeriod,
+        count: this.logRotationCount,
         level: this.bunyan.level() as number,
       });
     }


### PR DESCRIPTION
Outcome of [this SPIKE](https://salesforce.quip.com/IFBwADN7GUZk#GOLABAyMYnx)

[@W-10745422@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-10745422)

https://github.com/forcedotcom/cli/issues/1408

Implements the [rotating log stream](https://github.com/forcedotcom/node-bunyan#stream-type-rotating-file) supported in Bunyan into sfdx-core's logger

## Testing instructions
- Pull this branch of `sfdx-core` 
- Run `yarn build`
- Run `yarn link`
- `cd` to local `cli` (`sf`)
- Pull this branch of `sf` https://github.com/salesforcecli/cli/pull/199
- Run `yarn`
- Run `npm ls @salesforce/core`
  - Confirm all `3.x` versions of core are the same
- Run `yarn link @salesforce/core`
- Run a command that will log
  - Example: `SF_LOG_ROTATION_PERIOD='5000ms' SFDX_LOG_LEVEL=trace bin/dev env list`
    - Note `bin/dev`
- Run command a few more times
- Notice that you now have multiple log files in your `~/.sf` directory (`sf.log`, `sf.log.0`, `sf.log.1`, `sf.log.2`)
- Notice how logs move to "next" log file as commands are ran.
  - Watch files with `tail -F sf.log`


## Worth noting 
- There is a potential for orphaned log files ([conversation](https://salesforce-internal.slack.com/archives/G02K6C90RBJ/p1646342677496859))
- Existing [huge log files](https://github.com/forcedotcom/cli/issues/1408#issuecomment-1057064648) will be automatically cleaned up with this change. The only downside is that when an existing large log files gets removed (on the 3rd day with current defaults), it will potentially take a very long time to remove the file and the user will have no indication as to what is happening.
  - This can be tested by creating a large file in place of `sf.log` and run commands until is is removed.
    -  Create large file on mac: `mkfile 30g ./sf.log`
    - Then time how long commands take until it is removed. In my testing `time bin/run force:org:list` typically took about 5 seconds to run but when my `30gb` was cleared it took close to 15 seconds. 
- The `ms` interval does not behave exactly like the other intervals. Hourly, Daily, Weekly, etc will "switch" log files at the start of a new period (e.g. daily happens at midnight). Docs on "period" [here](https://github.com/forcedotcom/node-bunyan#stream-type-rotating-file). Milliseconds will rotate logs on each command regardless. This can be tested a little more accurately by modifying Bunyan's code slightly. 
  - In your linked `core` directory (`cli/node_modules/@salesforce/core/node_modules/@salesforce/bunyan/lib/bunyan.js`) change:
  ```js
  var m = /^([1-9][0-9]*)([hdwmy]|ms)$/.exec(period);
  // to
  var m = /^([1-9][0-9]*)([hdwmy]|ms|min)$/.exec(period);
  ```
  - And then add the following to the `switch` statement on line `1314`:
  ```js
  case 'min':
      if (this.rotAt) {
          rotAt = this.rotAt + this.periodNum * 60 * 60 * 60 * 1000 * periodOffset;
      } else {
          // First time: top of the next minute.
          rotAt = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(),
              d.getUTCDate(), d.getUTCHours(), d.getUTCMinutes() + periodOffset);
      }
      break;
  ```
  - You can now use `min` intervals and the logs will rotate at the start of each new minute
    -  `SF_LOG_ROTATION_PERIOD='1min' SFDX_LOG_LEVEL=trace bin/dev env list`