### PR TITLE
feat: add metadata-rest-deploy

### DIFF
--- a/messages/config.md
+++ b/messages/config.md
@@ -113,6 +113,10 @@ Maximum number of Salesforce records returned by a CLI command. Default: 10,000.
 
 # restDeploy
 
+Whether deployments use the Metadata REST API (true) or SOAP API (false, default value). (sfdx only)
+
+# metadataRestDeploy
+
 Whether deployments use the Metadata REST API (true) or SOAP API (false, default value).
 
 # instanceUrl

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -151,7 +151,10 @@ export enum SfdxPropertyKeys {
    */
   MAX_QUERY_LIMIT = 'maxQueryLimit',
 
-  /** */
+  /**
+   * @deprecated Replaced by OrgConfigProperties.METADATA_REST_DEPLOY in v3 {@link https://github.com/forcedotcom/sfdx-core/blob/v3/MIGRATING_V2-V3.md#config}
+   * will remain in v3 for the foreseeable future so that `sfdx-core` can map between `sf` and `sfdx` config values
+   */
   REST_DEPLOY = 'restDeploy',
 
   /** */
@@ -228,11 +231,19 @@ export const SFDX_ALLOWED_PROPERTIES = [
       failedMessage: messages.getMessage('invalidBooleanConfigValue'),
     },
   },
-  // This should be brought in by a plugin, but there isn't a way to do that right now.
+  /**
+   * Ideally config vars like these should be brought in by the plugin's that need them, using
+   * the configMeta property in the oclif section of the package.json
+   *
+   * However, we need the new config var in sfdx-core so that we can enable interoperability between
+   * the old and new vars.
+   */
   {
     key: SfdxPropertyKeys.REST_DEPLOY,
     description: messages.getMessage(SfdxPropertyKeys.REST_DEPLOY),
     hidden: true,
+    newKey: OrgConfigProperties.METADATA_REST_DEPLOY,
+    deprecated: true,
     input: {
       validator: (value: ConfigValue) => value != null && ['true', 'false'].includes(value.toString()),
       failedMessage: messages.getMessage('invalidBooleanConfigValue'),

--- a/src/org/orgConfigProperties.ts
+++ b/src/org/orgConfigProperties.ts
@@ -6,14 +6,21 @@
  */
 
 import { join as pathJoin } from 'path';
+import { ConfigValue } from '../config/configStore';
 import { Messages } from '../messages';
 
 Messages.importMessagesDirectory(pathJoin(__dirname));
-const messages = Messages.load('@salesforce/core', 'config', ['targetOrg', 'targetDevHub']);
+const messages = Messages.load('@salesforce/core', 'config', [
+  'invalidBooleanConfigValue',
+  'metadataRestDeploy',
+  'targetOrg',
+  'targetDevHub',
+]);
 
 export enum OrgConfigProperties {
   TARGET_ORG = 'target-org',
   TARGET_DEV_HUB = 'target-dev-hub',
+  METADATA_REST_DEPLOY = 'metadata-rest-deploy',
 }
 
 export const ORG_CONFIG_ALLOWED_PROPERTIES = [
@@ -24,5 +31,14 @@ export const ORG_CONFIG_ALLOWED_PROPERTIES = [
   {
     key: OrgConfigProperties.TARGET_DEV_HUB,
     description: messages.getMessage('targetDevHub'),
+  },
+  {
+    key: OrgConfigProperties.METADATA_REST_DEPLOY,
+    description: messages.getMessage('metadataRestDeploy'),
+    hidden: true,
+    input: {
+      validator: (value: ConfigValue) => value != null && ['true', 'false'].includes(value.toString()),
+      failedMessage: messages.getMessage('invalidBooleanConfigValue'),
+    },
   },
 ];


### PR DESCRIPTION
Replaces `restDeploy` config var with the more specific `metadata-rest-deploy`

[skip-validate-pr]
