### PR TITLE
chore: add plugin-alias to external-NUTs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ workflows:
               node_version: [lts]
               external_project_git_url:
                 [
+                  'https://github.com/salesforcecli/plugin-alias',
                   'https://github.com/salesforcecli/plugin-config#v2',
                   'https://github.com/salesforcecli/plugin-env',
                   'https://github.com/salesforcecli/plugin-login',


### PR DESCRIPTION
adds `plugin-alias` to external NUTs that run