### PR TITLE
test: remove parking-orbit plugins from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,13 +129,9 @@ workflows:
               external_project_git_url:
                 [
                   'https://github.com/salesforcecli/plugin-user',
-                  'https://github.com/salesforcecli/plugin-config',
-                  'https://github.com/salesforcecli/plugin-alias',
-                  'https://github.com/salesforcecli/plugin-limits',
-                  'https://github.com/salesforcecli/plugin-auth',
-                  'https://github.com/salesforcecli/plugin-schema',
                   'https://github.com/salesforcecli/plugin-telemetry',
                   'https://github.com/salesforcecli/plugin-data',
+                  'https://github.com/salesforcecli/plugin-org',
                 ]
                 # TODO
                 # toolbelt (git auth because private)


### PR DESCRIPTION
[skip-validate-pr]

removes plugins that rely on Core3 now
adds plugin-org because it relies on Core2