### PR TITLE
feat: detect if org is a devhub at auth time

### DIFF
--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -1077,7 +1077,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
    * Check access to the ScratchOrgInfo object to determine if the org is a dev hub.
    */
   private async determineIfDevHub(instanceUrl: string, accessToken: string): Promise<boolean> {
-    // Make a REST call for the SratchOrgInfo obj directly.  Normally this is done via a connection
+    // Make a REST call for the ScratchOrgInfo obj directly.  Normally this is done via a connection
     // but we don't want to create circular dependencies or lots of snowflakes
     // within this file to support it.
     const apiVersion = 'v51.0'; // hardcoding to v51.0 just for this call is okay.
@@ -1087,7 +1087,10 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     const headers = Object.assign({ Authorization: `Bearer ${accessToken}` }, SFDX_HTTP_HEADERS);
 
     try {
-      await new Transport().httpRequest({ url: scratchOrgInfoUrl, method: 'GET', headers });
+      const res = await new Transport().httpRequest({ url: scratchOrgInfoUrl, method: 'GET', headers });
+      if (res.statusCode >= 400) {
+        return false;
+      }
       return true;
     } catch (err) {
       /* Not a dev hub */

--- a/test/unit/org/orgTest.ts
+++ b/test/unit/org/orgTest.ts
@@ -672,6 +672,8 @@ describe('Org Tests', () => {
         return Promise.resolve(responseBody);
       });
 
+      stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
+
       for (const user of users) {
         userAuthResponse = {
           // eslint-disable-next-line camelcase

--- a/test/unit/org/userTest.ts
+++ b/test/unit/org/userTest.ts
@@ -70,8 +70,13 @@ describe('User Tests', () => {
     });
 
     stubMethod($$.SANDBOX, AuthInfo.prototype, 'buildRefreshTokenConfig').callsFake(() => {
-      return {};
+      return {
+        instanceUrl: '',
+        accessToken: '',
+      };
     });
+
+    stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
 
     refreshSpy = stubMethod($$.SANDBOX, Org.prototype, 'refreshAuth').resolves({});
   });


### PR DESCRIPTION
### What does this PR do?

Updates `AuthInfo` class to always set`isDevHub` field based on a server-check.

**Before**:
It was up to consumers to set the field based on a server-check or anything else like [passing a flag in a plugin](https://github.com/salesforcecli/plugin-auth/pull/375)

**After**:
sfdx-core will do a server-side check and set the field to either `true` or `false`.

**QA steps**:

1. Clone [plugin-auth](https://github.com/salesforcecli/plugin-auth/)
2. `yarn link @salesforce/core` into ⬆️ 
3. test all auth commands both with/without `--setdefaultdevhubusername`
4. Even without passing `--setdefaultdevhubusername `, you should see the `isDevHub` field in the authfile.

### What issues does this PR fix or reference?
@[W-10999290](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-10999290)@