### PR TITLE
[V2] Fix log rotation errors

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -16,7 +16,6 @@ import { SfdcUrl } from '../util/sfdcUrl';
 import { ConfigFile } from './configFile';
 import { ConfigContents, ConfigValue } from './configStore';
 
-const log = Logger.childFromRoot('core:config');
 const SFDX_CONFIG_FILE_NAME = 'sfdx-config.json';
 
 /**
@@ -212,6 +211,7 @@ export class Config extends ConfigFile<ConfigFile.Options> {
   ];
 
   private static messages: Messages;
+  private static logger: Logger;
   private crypto?: Crypto;
 
   public constructor(options?: ConfigFile.Options) {
@@ -220,6 +220,8 @@ export class Config extends ConfigFile<ConfigFile.Options> {
     if (!Config.messages) {
       Config.messages = Messages.loadMessages('@salesforce/core', 'config');
     }
+
+    Config.logger = Logger.childFromRoot('core:config');
 
     // Resolve the config path on creation.
     this.getPath();
@@ -251,7 +253,7 @@ export class Config extends ConfigFile<ConfigFile.Options> {
 
     metas.forEach((meta) => {
       if (currentMetaKeys.includes(meta.key)) {
-        log.info(`Key ${meta.key} already exists in allowedProperties, skipping.`);
+        Config.logger.info(`Key ${meta.key} already exists in allowedProperties, skipping.`);
         return;
       }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -211,7 +211,6 @@ export class Config extends ConfigFile<ConfigFile.Options> {
   ];
 
   private static messages: Messages;
-  private static logger: Logger;
   private crypto?: Crypto;
 
   public constructor(options?: ConfigFile.Options) {
@@ -220,8 +219,6 @@ export class Config extends ConfigFile<ConfigFile.Options> {
     if (!Config.messages) {
       Config.messages = Messages.loadMessages('@salesforce/core', 'config');
     }
-
-    Config.logger = Logger.childFromRoot('core:config');
 
     // Resolve the config path on creation.
     this.getPath();
@@ -251,9 +248,13 @@ export class Config extends ConfigFile<ConfigFile.Options> {
   public static addAllowedProperties(metas: ConfigPropertyMeta[]): void {
     const currentMetaKeys = Object.keys(Config.propertyConfigMap);
 
+    // If logger is needed elsewhere in this file, do not move this outside of the Config class.
+    // It was causing issues with Bunyan log rotation. See https://github.com/forcedotcom/sfdx-core/pull/562
+    const logger = Logger.childFromRoot('core:config');
+
     metas.forEach((meta) => {
       if (currentMetaKeys.includes(meta.key)) {
-        Config.logger.info(`Key ${meta.key} already exists in allowedProperties, skipping.`);
+        logger.info(`Key ${meta.key} already exists in allowedProperties, skipping.`);
         return;
       }
 


### PR DESCRIPTION
[@W-11017499@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-11017499)

[Slack conversation](https://salesforce-internal.slack.com/archives/G02K6C90RBJ/p1650294097684579)

Since `sfdx v7.145.0` Bunyan throws `ENOENT` errors when rotating logs. You can replicate the error with the following command:
`SFDX_LOG_ROTATION_PERIOD='1000ms' sfdx  config:list`

```
[Error: ENOENT: no such file or directory, rename '/Users/ewillhoit/.sfdx/sfdx.log.0' -> '/Users/ewillhoit/.sfdx/sfdx.log.1'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'rename',
  path: '/Users/ewillhoit/.sfdx/sfdx.log.0',
  dest: '/Users/ewillhoit/.sfdx/sfdx.log.1'
}
```

This issue has been around in Bunyan for a long time ([235](https://github.com/trentm/node-bunyan/issues/235) and [374](https://github.com/trentm/node-bunyan/issues/374)). There seems to be a multitude of reasons you might get these errors. I believe that we were getting this error because of multiple instances of a root logger. 

After some debugging, I noticed that it seemed to be related to the `core:config` logger. If you run the command with `DEBUG=*`, the number of `ENOENT` errors will always match the number of `sfdx:core TRACE Setup child 'core:config' logger instance` messages. Looking at the code, the child logger was being created outside of the Config class. This early instantiation was causing the issue.

Testing this is a little tricky. I could not replicated the errors with my cloned `sfdx-cli` repo and running `bin/run`. I was only able to reproduce it with a version installed from `npm` (did not try the Installer). Trying to use `yarn link @salesforce/core` did not work well either now that we have multiple major version of `core`. To be confident this was working as it will be once it is released, I modified the code (in this PR) in the `node_modules` folder of the installed `sfdx`. Here is a video of the testing. 

https://user-images.githubusercontent.com/1715111/164053232-325b4202-5f60-4fdc-aca2-fdcaf3d6c5de.mov


