### PR TITLE
fix: allow ConfigAggregator to accept custom config vars

### DIFF
--- a/src/config/configAggregator.ts
+++ b/src/config/configAggregator.ts
@@ -73,7 +73,7 @@ export interface ConfigInfo {
  * console.log(aggregator.getPropertyValue('target-org'));
  * ```
  */
-export class ConfigAggregator extends AsyncOptionalCreatable<JsonMap> {
+export class ConfigAggregator extends AsyncOptionalCreatable<ConfigAggregator.Options> {
   private static instance: AsyncOptionalCreatable;
   private static encrypted = true;
 
@@ -92,8 +92,12 @@ export class ConfigAggregator extends AsyncOptionalCreatable<JsonMap> {
    *
    * @ignore
    */
-  public constructor(options?: JsonMap) {
+  public constructor(options?: ConfigAggregator.Options) {
     super(options || {});
+
+    if (options?.customConfigMeta) {
+      Config.addAllowedProperties(options.customConfigMeta);
+    }
 
     // Don't throw an project error with the aggregator, since it should resolve to global if
     // there is no project.
@@ -405,6 +409,10 @@ export namespace ConfigAggregator {
      */
     ENVIRONMENT = 'Environment',
   }
+
+  export type Options = {
+    customConfigMeta?: ConfigPropertyMeta[];
+  };
 }
 
 /**

--- a/src/config/configAggregator.ts
+++ b/src/config/configAggregator.ts
@@ -418,8 +418,20 @@ export namespace ConfigAggregator {
 /**
  * A ConfigAggregator that will work with deprecated config vars (e.g. defaultusername, apiVersion).
  * We do NOT recommend using this class unless you absolutelty have to.
+ *
+ * @deprecated
  */
 export class SfdxConfigAggregator extends ConfigAggregator {
+  // org-metadata-rest-deploy has been moved to plugin-deploy-retrieve but we need to have a placeholder
+  // for it here since sfdx needs to know how to set the deprecated restDeploy config var.
+  private static CUSTOM_CONFIG_VARS = [{ key: 'org-metadata-rest-deploy', hidden: true }] as ConfigPropertyMeta[];
+
+  public constructor(options: ConfigAggregator.Options = {}) {
+    const customConfigMeta = options.customConfigMeta || [];
+    options.customConfigMeta = [...customConfigMeta, ...SfdxConfigAggregator.CUSTOM_CONFIG_VARS];
+    super(options || {});
+  }
+
   public getPropertyMeta(key: string): ConfigPropertyMeta {
     const match = this.getAllowedProperties().find((element) => key === element.key);
     if (match?.deprecated && match?.newKey) {

--- a/src/config/configFile.ts
+++ b/src/config/configFile.ts
@@ -335,7 +335,7 @@ export class ConfigFile<
         : ConfigFile.resolveRootFolderSync(!!this.options.isGlobal);
 
       if (_isGlobal || _isState) {
-        configRootFolder = pathJoin(configRootFolder, this.options.stateFolder || Global.SFDX_STATE_FOLDER);
+        configRootFolder = pathJoin(configRootFolder, this.options.stateFolder || Global.SF_STATE_FOLDER);
       }
 
       this.path = pathJoin(configRootFolder, this.options.filePath ? this.options.filePath : '', this.options.filename);

--- a/test/unit/org/orgTest.ts
+++ b/test/unit/org/orgTest.ts
@@ -466,7 +466,7 @@ describe('Org Tests', () => {
       await org.remove();
 
       expect(deletedPaths).includes(
-        pathJoin(await $$.globalPathRetriever($$.id), Global.SFDX_STATE_FOLDER, `${testData.orgId}.json`)
+        pathJoin(await $$.globalPathRetriever($$.id), Global.SF_STATE_FOLDER, `${testData.orgId}.json`)
       );
     });
 


### PR DESCRIPTION
Allow consumers of `ConfigAggregator` to optionally provide a list of custom config vars. This is necessary because the plugin-config init hook (which is supposed to load all custom config vars) isn't guaranteed to modify the same instance of `Config` as the one that `ConfigAggregator` will be using at run time

[skip-validate-pr]