### PR TITLE
Disable schemaValidation [V2]

### DIFF
--- a/src/schema/validator.ts
+++ b/src/schema/validator.ts
@@ -92,6 +92,9 @@ export class SchemaValidator {
       // because the CLI team does not "own" the @salesforce/schemas repository.
       // Invalid schema would cause errors wherever SchemaValidator is used.
       strictSchema: false,
+      // If we end up getting an npm-shrinkwrap working in the future we could turn this back off.
+      // https://github.com/forcedotcom/cli/issues/1493
+      validateSchema: false,
     });
 
     // JSEN to AJV migration note - regarding the following "TODO":

--- a/test/unit/fixtures/schemas/invalidSchema.json
+++ b/test/unit/fixtures/schemas/invalidSchema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "invalidSchema",
+  "type": "object",
+  "title": "Testing external schema without $id",
+  "properties": {
+    "Company": {
+      "type": "string",
+      "title": "Company",
+      "description": "The org's company name"
+    }
+  },
+  "additionalProperties": false
+}

--- a/test/unit/schema/validatorTest.ts
+++ b/test/unit/schema/validatorTest.ts
@@ -282,5 +282,28 @@ describe('schemaValidator', () => {
         cat: 'meow',
       });
     });
+
+    // If you change `validateSchema` to `true` in the AJV options, this will fail
+    // because the schema is invalid for Draft 7
+    // https://github.com/forcedotcom/cli/issues/1493
+    it('should not error on invalid schema', async () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          ref: {
+            $ref: 'invalidSchema#',
+          },
+        },
+      };
+
+      const data = {
+        Company: 'Acme',
+      };
+
+      const validatedData = await validate(schema, data);
+      expect(validatedData).to.deep.equal({
+        Company: 'Acme',
+      });
+    });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/forcedotcom/cli/issues/1493

Adds a few comments and tests

To validate locally reproduce the steps outlined in the above issue ^
Then add the single `validateSchema: true` line on your local _npm_ install of `sfdc-cli`
Re-run `sfdx force:data:tree:import -p data/sample-data-plan.json`

[@W-11085202@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-11085202)