### PR TITLE
chore(ci): only use node LTS on Windows [ci skip]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,11 @@ workflows:
                 - latest
                 - lts
                 - maintenance
+            exclude:
+              - os: windows
+                node_version: latest
+              - os: windows
+                node_version: maintenance
       - external-nut:
           filters:
             branches:


### PR DESCRIPTION
Node v14.19.2 (currently in maintenance) comes with npm v6.14.17, looks like the URL nvm-windows creates for this version stopped working:

❌  https://github.com/npm/cli/archive/v6.14.17.zip
✅  https://github.com/npm/cli/archive/v8.1.2.zip

nvm-windows:
https://github.com/coreybutler/nvm-windows/blob/5803c4f8c7766c670996fbce3fc113a9b0d95050/src/web/web.go#L65
https://github.com/coreybutler/nvm-windows/blob/5803c4f8c7766c670996fbce3fc113a9b0d95050/src/web/web.go#L27

on `main`: https://github.com/forcedotcom/sfdx-core/blob/246ee3331483efde32fbe62a04ac1a9d47ea10ab/.circleci/config.yml#L116-L120

We already run these tests on current maintenance, lts and latest on linux.

@W-0@