### PR TITLE
refactor: remove tooling.autoFetch

### DIFF
--- a/src/org/connection.ts
+++ b/src/org/connection.ts
@@ -65,15 +65,6 @@ export type DeployOptionsWithRest = Partial<DeployOptions> & { rest?: boolean };
 export interface Tooling<S extends Schema = Schema> extends JSForceTooling<S> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   _logger: any;
-  /**
-   * Executes a query and auto-fetches (i.e., "queryMore") all results.  This is especially
-   * useful with large query result sizes, such as over 2000 records.  The default maximum
-   * fetch size is 10,000 records.  Modify this via the options argument.
-   *
-   * @param soql The SOQL string.
-   * @param options The query options.  NOTE: the autoFetch option will always be true.
-   */
-  autoFetchQuery<T extends Schema = S>(soql: string, options?: QueryOptions): Promise<QueryResult<T>>;
 }
 
 /**
@@ -116,12 +107,7 @@ export class Connection<S extends Schema = Schema> extends JSForceConnection<S> 
    */
   public constructor(options: Connection.Options<S>) {
     super(options.connectionOptions || {});
-
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    this.tooling.autoFetchQuery = Connection.prototype.autoFetchQuery;
-
     this.options = options;
-
     this.username = options.authInfo.getUsername();
   }
 

--- a/src/org/connection.ts
+++ b/src/org/connection.ts
@@ -59,9 +59,6 @@ export const DNS_ERROR_NAME = 'DomainNotFoundError';
 type recentValidationOptions = { id: string; rest?: boolean };
 export type DeployOptionsWithRest = Partial<DeployOptions> & { rest?: boolean };
 
-// This interface is so we can add the autoFetchQuery method to both the Connection
-// and Tooling classes and get nice typing info for it within editors.  JSForce is
-// unlikely to accept a PR for this method, but that would be another approach.
 export interface Tooling<S extends Schema = Schema> extends JSForceTooling<S> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   _logger: any;


### PR DESCRIPTION
JSForce2 changed the typing on this and it made a mess of our Connection hackery.
This removes it because jsforce2 now has this natively in query (for regular and tooling)

```
conn.tooling.autoFetchQuery<Foo>(query, { maxFetch: 50000 });
```

can just be

```
conn.tooling.query<Foo>(query, {
        autoFetch: true,
      });
```
[@W-11109910@](https://gus.lightning.force.com/a07EE00000wX73DYAS)
