### PR TITLE
fix: homedir can change after Core loads

### DIFF
--- a/src/crypto/keyChainImpl.ts
+++ b/src/crypto/keyChainImpl.ts
@@ -427,7 +427,7 @@ const _darwinImpl: OsImpl = {
   },
 };
 
-const secretFile: string = path.join(homedir(), Global.SFDX_STATE_FOLDER, 'key.json');
+const getSecretFile = () => path.join(Global.SFDX_DIR, 'key.json');
 
 enum SecretField {
   SERVICE = 'service',
@@ -448,6 +448,7 @@ async function _writeFile(opts: ProgramOpts, fn: (error: Nullable<Error>, conten
       [SecretField.KEY]: opts.password,
       [SecretField.SERVICE]: opts.service,
     };
+    const secretFile = getSecretFile();
     await mkdirp(path.dirname(secretFile));
     await fs.promises.writeFile(secretFile, JSON.stringify(contents, null, 4), { mode: '600' });
 
@@ -459,7 +460,7 @@ async function _writeFile(opts: ProgramOpts, fn: (error: Nullable<Error>, conten
 
 async function _readFile(): Promise<ProgramOpts> {
   // The file and access is validated before this method is called
-  const fileContents = parseJsonMap(await fs.promises.readFile(secretFile, 'utf8'));
+  const fileContents = parseJsonMap(await fs.promises.readFile(getSecretFile(), 'utf8'));
   return {
     account: ensureString(fileContents[SecretField.ACCOUNT]),
     password: asString(fileContents[SecretField.KEY]),
@@ -486,7 +487,7 @@ export class GenericKeychainAccess implements PasswordStore {
           } else {
             // if the service and account names don't match then maybe someone or something is editing
             // that file. #donotallow
-            fn(messages.createError('genericKeychainServiceError', [secretFile]));
+            fn(messages.createError('genericKeychainServiceError', [getSecretFile()]));
           }
         } catch (readJsonErr) {
           fn(readJsonErr as Error);
@@ -547,6 +548,7 @@ export class GenericUnixKeychainAccess extends GenericKeychainAccess {
       if (err != null) {
         await cb(err);
       } else {
+        const secretFile = getSecretFile();
         const stats = await fs.promises.stat(secretFile);
         const octalModeStr = (stats.mode & 0o777).toString(8);
         const EXPECTED_OCTAL_PERM_VALUE = '600';
@@ -576,7 +578,7 @@ export class GenericWindowsKeychainAccess extends GenericKeychainAccess {
         await cb(err);
       } else {
         try {
-          await fs.promises.access(secretFile, fs.constants.R_OK | fs.constants.W_OK);
+          await fs.promises.access(getSecretFile(), fs.constants.R_OK | fs.constants.W_OK);
           await cb(null);
         } catch (e) {
           await cb(e as Error);

--- a/src/global.ts
+++ b/src/global.ts
@@ -49,14 +49,18 @@ export class Global {
    *
    * **See** {@link Global.SFDX_STATE_FOLDER}
    */
-  public static readonly SFDX_DIR: string = path.join(os.homedir(), Global.SFDX_STATE_FOLDER);
+  public static get SFDX_DIR() {
+    return path.join(os.homedir(), Global.SFDX_STATE_FOLDER);
+  }
 
   /**
    * The full system path to the global sf state folder.
    *
    * **See** {@link Global.SF_STATE_FOLDER}
    */
-  public static readonly SF_DIR: string = path.join(os.homedir(), Global.SF_STATE_FOLDER);
+  public static get SF_DIR() {
+    return path.join(os.homedir(), Global.SF_STATE_FOLDER);
+  }
 
   /**
    * The full system path to the global log file.


### PR DESCRIPTION
NUTs that called sfdx-core to get an org/authinfo/connection weren't hitting the stubbed homedir.

@W-11120486@