### PR TITLE
Sm/org-tracking-property

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "form-data": "^4.0.0",
     "graceful-fs": "^4.2.9",
     "js2xmlparser": "^4.0.1",
-    "jsforce": "2.0.0-beta.9",
+    "jsforce": "2.0.0-beta.10",
     "jsonwebtoken": "8.5.1",
     "mkdirp": "1.0.4",
     "ts-retry-promise": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "@salesforce/bunyan": "^2.0.0",
-    "@salesforce/kit": "^1.5.34",
+    "@salesforce/kit": "^1.5.41",
     "@salesforce/schemas": "^1.1.0",
     "@salesforce/ts-types": "^1.5.20",
     "@types/graceful-fs": "^4.1.5",

--- a/src/config/sandboxProcessCache.ts
+++ b/src/config/sandboxProcessCache.ts
@@ -15,7 +15,7 @@ export type SandboxRequestCacheEntry = {
   prodOrgUsername: string;
   sandboxProcessObject: Partial<SandboxProcessObject>;
   sandboxRequest: Partial<SandboxRequest>;
-  tracking?: boolean;
+  tracksSource?: boolean;
 };
 
 export class SandboxRequestCache extends TTLConfig<TTLConfig.Options, SandboxRequestCacheEntry> {

--- a/src/config/sandboxProcessCache.ts
+++ b/src/config/sandboxProcessCache.ts
@@ -15,6 +15,7 @@ export type SandboxRequestCacheEntry = {
   prodOrgUsername: string;
   sandboxProcessObject: Partial<SandboxProcessObject>;
   sandboxRequest: Partial<SandboxRequest>;
+  tracking?: boolean;
 };
 
 export class SandboxRequestCache extends TTLConfig<TTLConfig.Options, SandboxRequestCacheEntry> {

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -120,7 +120,7 @@ export type AuthSideEffects = {
   alias?: string;
   setDefault: boolean;
   setDefaultDevHub: boolean;
-  setTracking?: boolean;
+  setTracksSource?: boolean;
 };
 
 type UserInfo = AnyJson & {
@@ -651,13 +651,13 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
       sideEffects.alias ||
       sideEffects.setDefault ||
       sideEffects.setDefaultDevHub ||
-      typeof sideEffects.setTracking === 'boolean'
+      typeof sideEffects.setTracksSource === 'boolean'
     ) {
       if (sideEffects.alias) await this.setAlias(sideEffects.alias);
       if (sideEffects.setDefault) await this.setAsDefault({ org: true });
       if (sideEffects.setDefaultDevHub) await this.setAsDefault({ devHub: true });
-      if (typeof sideEffects.setTracking === 'boolean') {
-        await this.save({ tracksSource: sideEffects.setTracking });
+      if (typeof sideEffects.setTracksSource === 'boolean') {
+        await this.save({ tracksSource: sideEffects.setTracksSource });
       } else {
         await this.save();
       }

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -89,7 +89,7 @@ export type AuthFields = {
   usernames?: string[];
   userProfileName?: string;
   expirationDate?: string;
-  tracking?: boolean;
+  tracksSource?: boolean;
 };
 
 export type OrgAuthorization = {
@@ -657,7 +657,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
       if (sideEffects.setDefault) await this.setAsDefault({ org: true });
       if (sideEffects.setDefaultDevHub) await this.setAsDefault({ devHub: true });
       if (typeof sideEffects.setTracking === 'boolean') {
-        await this.save({ tracking: sideEffects.setTracking });
+        await this.save({ tracksSource: sideEffects.setTracking });
       } else {
         await this.save();
       }

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -89,6 +89,7 @@ export type AuthFields = {
   usernames?: string[];
   userProfileName?: string;
   expirationDate?: string;
+  tracking?: boolean;
 };
 
 export type OrgAuthorization = {
@@ -119,6 +120,7 @@ export type AuthSideEffects = {
   alias?: string;
   setDefault: boolean;
   setDefaultDevHub: boolean;
+  setTracking?: boolean;
 };
 
 type UserInfo = AnyJson & {
@@ -649,7 +651,11 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
       if (sideEffects.alias) await this.setAlias(sideEffects.alias);
       if (sideEffects.setDefault) await this.setAsDefault({ org: true });
       if (sideEffects.setDefaultDevHub) await this.setAsDefault({ devHub: true });
-      await this.save();
+      if (typeof sideEffects.setTracking === 'boolean') {
+        await this.save({ tracking: sideEffects.setTracking });
+      } else {
+        await this.save();
+      }
     }
   }
 

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -647,7 +647,12 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
    * @param sideEffects - instance of AuthSideEffects
    */
   public async handleAliasAndDefaultSettings(sideEffects: AuthSideEffects): Promise<void> {
-    if (sideEffects.alias || sideEffects.setDefault || sideEffects.setDefaultDevHub) {
+    if (
+      sideEffects.alias ||
+      sideEffects.setDefault ||
+      sideEffects.setDefaultDevHub ||
+      typeof sideEffects.setTracking === 'boolean'
+    ) {
       if (sideEffects.alias) await this.setAlias(sideEffects.alias);
       if (sideEffects.setDefault) await this.setAsDefault({ org: true });
       if (sideEffects.setDefaultDevHub) await this.setAsDefault({ devHub: true });

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -548,24 +548,24 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
    */
   public async tracksSource(): Promise<boolean> {
     // use the property if it exists
-    const tracksSource = this.getField(Org.Fields.TRACKING);
+    const tracksSource = this.getField(Org.Fields.TRACKS_SOURCE);
     if (isBoolean(tracksSource)) {
       return tracksSource;
     }
     // scratch orgs with no property use tracking by default
     if (await this.determineIfScratch()) {
       // save true for next time to avoid checking again
-      await this.setTracking(true);
+      await this.setTracksSource(true);
       return true;
     }
     if (await this.determineIfSandbox()) {
       // does the sandbox know about the SourceMember object?
       const supportsSourceMembers = await this.supportsSourceTracking();
-      await this.setTracking(supportsSourceMembers);
+      await this.setTracksSource(supportsSourceMembers);
       return supportsSourceMembers;
     }
     // any other non-sandbox, non-scratch orgs won't use tracking
-    await this.setTracking(false);
+    await this.setTracksSource(false);
     return false;
   }
 
@@ -574,7 +574,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
    *
    * @param value true or false (whether the org should use source tracking or not)
    */
-  public async setTracking(value: boolean): Promise<void> {
+  public async setTracksSource(value: boolean): Promise<void> {
     const originalAuth = await AuthInfo.create({ username: this.getUsername() });
     originalAuth.handleAliasAndDefaultSettings({ setDefault: false, setDefaultDevHub: false, setTracking: value });
   }
@@ -1505,7 +1505,7 @@ export namespace Org {
      * true: the org supports and wants source tracking
      * false: the org opted out of tracking or can't support it
      */
-    TRACKING = 'tracksSource',
+    TRACKS_SOURCE = 'tracksSource',
 
     // Should it be on org? Leave it off for now, as it might
     // be confusing to the consumer what this actually is.

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -576,7 +576,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
    */
   public async setTracksSource(value: boolean): Promise<void> {
     const originalAuth = await AuthInfo.create({ username: this.getUsername() });
-    originalAuth.handleAliasAndDefaultSettings({ setDefault: false, setDefaultDevHub: false, setTracking: value });
+    originalAuth.handleAliasAndDefaultSettings({ setDefault: false, setDefaultDevHub: false, setTracksSource: value });
   }
 
   /**

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -546,11 +546,11 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
    * Returns `true` if the org uses source tracking.
    * Side effect: updates files where the property doesn't currently exist
    */
-  public async usesTracking(): Promise<boolean> {
+  public async tracksSource(): Promise<boolean> {
     // use the property if it exists
-    const tracking = this.getField(Org.Fields.TRACKING);
-    if (isBoolean(tracking)) {
-      return tracking;
+    const tracksSource = this.getField(Org.Fields.TRACKING);
+    if (isBoolean(tracksSource)) {
+      return tracksSource;
     }
     // scratch orgs with no property use tracking by default
     if (await this.determineIfScratch()) {
@@ -576,7 +576,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
    */
   public async setTracking(value: boolean): Promise<void> {
     const originalAuth = await AuthInfo.create({ username: this.getUsername() });
-    originalAuth.save({ tracking: value });
+    originalAuth.handleAliasAndDefaultSettings({ setDefault: false, setDefaultDevHub: false, setTracking: value });
   }
 
   /**
@@ -1505,7 +1505,7 @@ export namespace Org {
      * true: the org supports and wants source tracking
      * false: the org opted out of tracking or can't support it
      */
-    TRACKING = 'tracking',
+    TRACKING = 'tracksSource',
 
     // Should it be on org? Leave it off for now, as it might
     // be confusing to the consumer what this actually is.

--- a/src/org/scratchOrgCache.ts
+++ b/src/org/scratchOrgCache.ts
@@ -20,6 +20,7 @@ export type CachedOptions = {
   apiVersion?: string;
   alias?: string;
   setDefault?: boolean;
+  tracking?: boolean;
 };
 
 export class ScratchOrgCache extends TTLConfig<TTLConfig.Options, CachedOptions> {

--- a/src/org/scratchOrgCache.ts
+++ b/src/org/scratchOrgCache.ts
@@ -20,7 +20,7 @@ export type CachedOptions = {
   apiVersion?: string;
   alias?: string;
   setDefault?: boolean;
-  tracking?: boolean;
+  tracksSource?: boolean;
 };
 
 export class ScratchOrgCache extends TTLConfig<TTLConfig.Options, CachedOptions> {

--- a/src/org/scratchOrgCreate.ts
+++ b/src/org/scratchOrgCreate.ts
@@ -178,7 +178,7 @@ export const scratchOrgResume = async (jobId: string): Promise<ScratchOrgCreateR
     alias,
     setDefault: setDefault ?? false,
     setDefaultDevHub: false,
-    setTracking: tracksSource ?? true,
+    setTracksSource: tracksSource ?? true,
   });
   cache.unset(soi.Id ?? jobId);
   const authFields = authInfo.getFields();

--- a/src/org/scratchOrgCreate.ts
+++ b/src/org/scratchOrgCreate.ts
@@ -90,7 +90,7 @@ export interface ScratchOrgCreateOptions {
   /** after complete, set the org as the default */
   setDefault?: boolean;
   /** do not use source tracking for this org */
-  tracking?: boolean;
+  tracksSource?: boolean;
 }
 
 const validateDuration = (durationDays: number): void => {
@@ -132,7 +132,7 @@ export const scratchOrgResume = async (jobId: string): Promise<ScratchOrgCreateR
     definitionjson,
     alias,
     setDefault,
-    tracking,
+    tracksSource,
   } = cache.get(jobId);
 
   const hubOrg = await Org.create({ aliasOrUsername: hubUsername });
@@ -178,7 +178,7 @@ export const scratchOrgResume = async (jobId: string): Promise<ScratchOrgCreateR
     alias,
     setDefault: setDefault ?? false,
     setDefaultDevHub: false,
-    setTracking: tracking ?? true,
+    setTracking: tracksSource ?? true,
   });
   cache.unset(soi.Id ?? jobId);
   const authFields = authInfo.getFields();
@@ -214,7 +214,7 @@ export const scratchOrgCreate = async (options: ScratchOrgCreateOptions): Promis
     clientSecret = undefined,
     alias,
     setDefault = false,
-    tracking = true,
+    tracksSource = true,
   } = options;
 
   validateDuration(durationDays);
@@ -257,7 +257,7 @@ export const scratchOrgCreate = async (options: ScratchOrgCreateOptions): Promis
     clientSecret,
     alias,
     setDefault,
-    tracking,
+    tracksSource,
   });
   await cache.write();
   logger.debug(`scratch org has recordId ${scratchOrgInfoId}`);
@@ -307,7 +307,7 @@ export const scratchOrgCreate = async (options: ScratchOrgCreateOptions): Promis
       alias,
       setDefault,
       setDefaultDevHub: false,
-      setTracking: tracking === false ? false : true,
+      setTracking: tracksSource === false ? false : true,
     },
   });
   cache.unset(scratchOrgInfoId);

--- a/src/org/scratchOrgCreate.ts
+++ b/src/org/scratchOrgCreate.ts
@@ -307,7 +307,7 @@ export const scratchOrgCreate = async (options: ScratchOrgCreateOptions): Promis
       alias,
       setDefault,
       setDefaultDevHub: false,
-      setTracking: tracksSource === false ? false : true,
+      setTracksSource: tracksSource === false ? false : true,
     },
   });
   cache.unset(scratchOrgInfoId);

--- a/src/org/scratchOrgCreate.ts
+++ b/src/org/scratchOrgCreate.ts
@@ -307,9 +307,8 @@ export const scratchOrgCreate = async (options: ScratchOrgCreateOptions): Promis
       alias,
       setDefault,
       setDefaultDevHub: false,
+      setTracking: tracking === false ? false : true,
     },
-    // scratch orgs will track source unless you tell them not to
-    ...(typeof tracking === 'boolean' ? { setTracking: tracking } : { setTracking: true }),
   });
   cache.unset(scratchOrgInfoId);
   const authFields = authInfo.getFields();

--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -730,6 +730,7 @@ export class MockTestOrgData {
   public authcode: string;
   public accessToken: string;
   public refreshToken: string;
+  public tracksSource: boolean | undefined;
   public userId: string;
   public redirectUri: string;
   public isDevHub?: boolean;
@@ -814,6 +815,7 @@ export class MockTestOrgData {
     config.createdOrgInstance = 'CS1';
     config.created = '1519163543003';
     config.userId = this.userId;
+    config.tracksSource = this.tracksSource;
 
     if (this.devHubUsername) {
       config.devHubUsername = this.devHubUsername;

--- a/test/unit/org/orgTest.ts
+++ b/test/unit/org/orgTest.ts
@@ -995,4 +995,76 @@ describe('Org Tests', () => {
       }
     });
   });
+
+  describe('tracking', () => {
+    it('orgs with property return the property', async () => {
+      $$.configStubs.GlobalInfo.contents = {
+        orgs: {
+          [testData.username]: { tracking: false },
+        },
+      };
+      const org = await Org.create({ aliasOrUsername: testData.username });
+      const usesTracking = await org.usesTracking();
+      expect(usesTracking).to.be.false;
+    });
+
+    it('scratch orgs without property return true', async () => {
+      $$.configStubs.GlobalInfo.contents = {
+        orgs: {
+          [testData.username]: { isScratch: true },
+        },
+      };
+      const org = await Org.create({ aliasOrUsername: testData.username });
+      const usesTracking = await org.usesTracking();
+      expect(usesTracking).to.be.true;
+    });
+
+    it('prod orgs without property return false', async () => {
+      $$.configStubs.GlobalInfo.contents = {
+        orgs: {
+          [testData.username]: { isScratch: false },
+        },
+      };
+
+      const org = await Org.create({ aliasOrUsername: testData.username });
+      stubMethod($$.SANDBOX, org, 'determineIfSandbox').resolves(false);
+      stubMethod($$.SANDBOX, org, 'determineIfScratch').resolves(false);
+      const usesTracking = await org.usesTracking();
+      expect(usesTracking).to.be.false;
+    });
+
+    describe('sandboxes without property', () => {
+      it('return true if they support tracking', async () => {
+        $$.configStubs.GlobalInfo.contents = {
+          orgs: {
+            [testData.username]: { isScratch: false },
+          },
+        };
+
+        const org = await Org.create({ aliasOrUsername: testData.username });
+        stubMethod($$.SANDBOX, org, 'determineIfScratch').resolves(false);
+        stubMethod($$.SANDBOX, org, 'determineIfSandbox').resolves(true);
+        stubMethod($$.SANDBOX, org, 'supportsSourceTracking').resolves(true);
+
+        const usesTracking = await org.usesTracking();
+        expect(usesTracking).to.be.true;
+      });
+
+      it("return false if they don't support tracking", async () => {
+        $$.configStubs.GlobalInfo.contents = {
+          orgs: {
+            [testData.username]: { isScratch: false },
+          },
+        };
+
+        const org = await Org.create({ aliasOrUsername: testData.username });
+        stubMethod($$.SANDBOX, org, 'determineIfScratch').resolves(false);
+        stubMethod($$.SANDBOX, org, 'determineIfSandbox').resolves(true);
+        stubMethod($$.SANDBOX, org, 'supportsSourceTracking').resolves(false);
+
+        const usesTracking = await org.usesTracking();
+        expect(usesTracking).to.be.false;
+      });
+    });
+  });
 });

--- a/test/unit/org/orgTest.ts
+++ b/test/unit/org/orgTest.ts
@@ -996,15 +996,15 @@ describe('Org Tests', () => {
     });
   });
 
-  describe('tracking', () => {
+  describe('source tracking detection', () => {
     it('orgs with property return the property', async () => {
       $$.configStubs.GlobalInfo.contents = {
         orgs: {
-          [testData.username]: { tracking: false },
+          [testData.username]: { tracksSource: false },
         },
       };
       const org = await Org.create({ aliasOrUsername: testData.username });
-      const usesTracking = await org.usesTracking();
+      const usesTracking = await org.tracksSource();
       expect(usesTracking).to.be.false;
     });
 
@@ -1015,7 +1015,7 @@ describe('Org Tests', () => {
         },
       };
       const org = await Org.create({ aliasOrUsername: testData.username });
-      const usesTracking = await org.usesTracking();
+      const usesTracking = await org.tracksSource();
       expect(usesTracking).to.be.true;
     });
 
@@ -1029,7 +1029,7 @@ describe('Org Tests', () => {
       const org = await Org.create({ aliasOrUsername: testData.username });
       stubMethod($$.SANDBOX, org, 'determineIfSandbox').resolves(false);
       stubMethod($$.SANDBOX, org, 'determineIfScratch').resolves(false);
-      const usesTracking = await org.usesTracking();
+      const usesTracking = await org.tracksSource();
       expect(usesTracking).to.be.false;
     });
 
@@ -1046,7 +1046,7 @@ describe('Org Tests', () => {
         stubMethod($$.SANDBOX, org, 'determineIfSandbox').resolves(true);
         stubMethod($$.SANDBOX, org, 'supportsSourceTracking').resolves(true);
 
-        const usesTracking = await org.usesTracking();
+        const usesTracking = await org.tracksSource();
         expect(usesTracking).to.be.true;
       });
 
@@ -1062,7 +1062,7 @@ describe('Org Tests', () => {
         stubMethod($$.SANDBOX, org, 'determineIfSandbox').resolves(true);
         stubMethod($$.SANDBOX, org, 'supportsSourceTracking').resolves(false);
 
-        const usesTracking = await org.usesTracking();
+        const usesTracking = await org.tracksSource();
         expect(usesTracking).to.be.false;
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3855,10 +3855,10 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-jsforce@2.0.0-beta.9:
-  version "2.0.0-beta.9"
-  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-2.0.0-beta.9.tgz#692f205151551a601cb17fc6b891ecbb230eff58"
-  integrity sha512-DsmjBiLaAL4ECmpNjwcMuYoA2o7v42cnokmTvNtnsOoABb7goIZp/PIXRHhmN44HJxNw2RpEpjMv0rJNOkrAtg==
+jsforce@2.0.0-beta.10:
+  version "2.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-2.0.0-beta.10.tgz#c33fee5dd01c96d121235cffb8fee1458a35423e"
+  integrity sha512-AFigJHQocj8t36Eu+9XffoKoC2FO4/uMDMg08TfTXgvIp53lzvnQJoQrhEnwnKReof4tO2d+7j+d1QyiOa2yGg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -618,10 +618,10 @@
     typedoc-plugin-missing-exports "0.22.6"
     typescript "^4.1.3"
 
-"@salesforce/kit@^1.5.34":
-  version "1.5.34"
-  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.5.34.tgz#7967c3f0ba8caccc0718077193d9cbebe1816871"
-  integrity sha512-vd3f9bwdx8GxAwJpfhzVQAnO82YxbaPLcYiRTS9qmo5mFnhOKsMvbjNQz/wtT4AFs2sC3yyCzvq5Vq6rAcMc7w==
+"@salesforce/kit@^1.5.41":
+  version "1.5.41"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.5.41.tgz#3248d4d28fe24ed47827716cfe416c21a2a90651"
+  integrity sha512-nhi7jw3LNITl7rHSnCLnEDTaq6nvolSMFBg7poniG84Q7kJPezgTEj5OKAyQ9hJoRE4u59n5M5bUFvwRoXmJzQ==
   dependencies:
     "@salesforce/ts-types" "^1.5.20"
     shx "^0.3.3"


### PR DESCRIPTION
> This does not depend on updates to jsforce, but the [sibling PR](https://github.com/salesforcecli/plugin-env/pull/282) for plugin-env_ does, so you probably want to update that dep as part of this PR since core pin jsforce and plugin-env uses jsforce via core: https://github.com/jsforce/jsforce/pull/1236

AuthField has a new optional `tracking` property
* Populated from sideEffects method on AuthInfo or via Org.setTracking
* Persisted in the TTLCache for scratch orgs and sandboxes so resumes work as expected

Since all the scratch org create logic lives in core, that field is populate from inside core and part of the scratch org create request.

Org has a new method `usesTracking` which returns a boolean.  There's logic in there to do smart defaults when the field doesn't exist (and populate it so that it will the next time it's asked)

@W-10864470@
