### PR TITLE
fix(conn): only return emitted records from jsforce

### DIFF
--- a/src/config/envVars.ts
+++ b/src/config/envVars.ts
@@ -348,7 +348,7 @@ export const SUPPORTED_ENV_VARS: EnvType = {
   },
   [EnvironmentVariable.SF_ORG_MAX_QUERY_LIMIT]: {
     description: getMessage(EnvironmentVariable.SF_ORG_MAX_QUERY_LIMIT),
-    synonymOf: null,
+    synonymOf: EnvironmentVariable.SFDX_MAX_QUERY_LIMIT,
   },
   [EnvironmentVariable.SF_MDAPI_TEMP_DIR]: {
     description: getMessage(EnvironmentVariable.SF_MDAPI_TEMP_DIR),


### PR DESCRIPTION
This PR makes `autoFetchQuery` return records emitted from jsforce instead of the full `response`.

jsforce: https://github.com/jsforce/jsforce/blob/78c03336626e5264f4f5a4f84a9d74822ea274fb/src/query.ts#L636

https://github.com/forcedotcom/cli/issues/1543
@[W-11204187](https://gus.lightning.force.com/a07EE00000xoHkAYAU)@