### PR TITLE
fix: update `NamedOrgNotFound` err name

### DIFF
--- a/src/org/scratchOrgInfoApi.ts
+++ b/src/org/scratchOrgInfoApi.ts
@@ -253,7 +253,7 @@ const checkOrgDoesntExist = async (scratchOrgInfo: Record<string, unknown>): Pro
     } catch (error) {
       const sfError = SfError.wrap(error as Error);
       // if an AuthInfo couldn't be created that means no AuthFile exists.
-      if (sfError.name === 'NamedOrgNotFound') {
+      if (sfError.name === 'NamedOrgNotFoundError') {
         return;
       }
       // Something unexpected

--- a/test/unit/org/scratchOrgInfoApiTest.ts
+++ b/test/unit/org/scratchOrgInfoApiTest.ts
@@ -66,7 +66,7 @@ describe('requestScratchOrgCreation', () => {
 
   it('requestScratchOrgCreation tests basic ScratchOrgInfo object with all fields included', async () => {
     const error = new Error('MyError');
-    error.name = 'NamedOrgNotFound';
+    error.name = 'NamedOrgNotFoundError';
     stubMethod(sandbox, AuthInfo, 'create').rejects(error);
     const hubOrg = new Org({});
     const settings = new SettingsGenerator();
@@ -105,7 +105,7 @@ describe('requestScratchOrgCreation', () => {
 
   it('requestScratchOrgCreation Error AuthInfo.create fails with NamedOrgNotFound and sobject fails too', async () => {
     const err = new Error('MyError');
-    err.name = 'NamedOrgNotFound';
+    err.name = 'NamedOrgNotFoundError';
     stubMethod(sandbox, AuthInfo, 'create').rejects(err);
     // @ts-ignore
     connectionStub.sobject.withArgs('ScratchOrgInfo').returns({
@@ -140,7 +140,7 @@ describe('requestScratchOrgCreation', () => {
 
   it('requestScratchOrgCreation sobject().create fails with REQUIRED_FIELD_MISSING', async () => {
     const err = new Error('MyError');
-    err.name = 'NamedOrgNotFound';
+    err.name = 'NamedOrgNotFoundError';
     stubMethod(sandbox, AuthInfo, 'create').rejects(err);
     const jsForceError = {
       ...new Error('JsForce-Error'),


### PR DESCRIPTION
### What does this PR do?
updates the error name coming from AuthInfo:
https://github.com/forcedotcom/sfdx-core/blob/69f374cb6fd955f84258c237f67ef16c87cfda11/src/org/authInfo.ts#L753

`messages.createError` sets the error name to `NamedOrgNotFoundError`.

This is causing parking-orbited plugin-org to fail when passing a username as a vararg 

### What issues does this PR fix or reference?
@W-10743851@
