### PR TITLE
fix: instanceUrl config now using org-instance-url

### DIFF
--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -758,7 +758,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
 
   private getInstanceUrl(options: unknown, aggregator: ConfigAggregator) {
     const instanceUrl =
-      getString(options, OrgConfigProperties.ORG_INSTANCE_URL) ||
+      getString(options, 'instanceUrl') ||
       (aggregator.getPropertyValue(OrgConfigProperties.ORG_INSTANCE_URL) as string);
     return instanceUrl || SfdcUrl.PRODUCTION;
   }

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -757,7 +757,9 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
   }
 
   private getInstanceUrl(options: unknown, aggregator: ConfigAggregator) {
-    const instanceUrl = getString(options, 'instanceUrl') || (aggregator.getPropertyValue('instanceUrl') as string);
+    const instanceUrl =
+      getString(options, OrgConfigProperties.ORG_INSTANCE_URL) ||
+      (aggregator.getPropertyValue(OrgConfigProperties.ORG_INSTANCE_URL) as string);
     return instanceUrl || SfdcUrl.PRODUCTION;
   }
 


### PR DESCRIPTION
`AuthInfo.getInstanceUrl` now checks for `org-instance-url` config key, instead of `instanceUrl`

any time you passed an auth token, instead of a username, connection requests would error with `Destination URL not reset. The URL returned from login must be set` if the config value wasn't set

[skip-validate-pr]
fixes: https://github.com/forcedotcom/cli/issues/1564