### PR TITLE
fix(url): support sandboxes with enhanced domains enabled

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+### What does this PR do?
+
+### What issues does this PR fix or reference?

--- a/src/util/sfdcUrl.ts
+++ b/src/util/sfdcUrl.ts
@@ -150,6 +150,11 @@ export class SfdcUrl extends URL {
     if (this.origin.endsWith('.my.salesforce.mil')) {
       return this.origin.replace('.my.salesforce.mil', '.lightning.crmforce.mil');
     }
+    // enhanced domains
+    if (this.origin.endsWith('sandbox.my.salesforce.com')) {
+      return this.origin.replace('sandbox.my.salesforce.com', 'sandbox.lightning.force.com');
+    }
+
     // all non-mil domains
     return `https://${ensureArray(/https?:\/\/([^.]*)/.exec(this.origin))
       .slice(1, 2)

--- a/test/unit/util/sfdcUrlTest.ts
+++ b/test/unit/util/sfdcUrlTest.ts
@@ -32,6 +32,11 @@ describe('util/sfdcUrl', () => {
         'https://some-instance.lightning.force.com'
       );
     });
+    it('works for com (sandbox - enhanced domains)', () => {
+      expect(new SfdcUrl('https://some-instance--sboxname.sandbox.my.salesforce.com').toLightningDomain()).to.equal(
+        'https://some-instance--sboxname.sandbox.lightning.force.com'
+      );
+    });
     it('works for mil (prod)', () => {
       expect(new SfdcUrl('https://some-instance.my.salesforce.mil').toLightningDomain()).to.equal(
         'https://some-instance.lightning.crmforce.mil'


### PR DESCRIPTION
### What does this PR do?

Adds support for sandboxes with enhanced domains enabled.

[Considerations for enhanced domains](https://help.salesforce.com/s/articleView?id=sf.domain_name_enhanced_considerations.htm&type=5)

> Differences Between Sandbox and Production
When you enable enhanced domains, your production My Domain login URL format, MyDomainName.my.salesforce.com, doesn’t change unless you also change your My Domain name or suffix. However, enabling enhanced domains in a sandbox adds the word “sandbox” to the org’s My Domain login URL: MyDomainName--SandboxName.sandbox.my.salesforce.com.


**QA steps**:

1. checkout the `plugin-org`parking-orbit PR locally https://github.com/salesforcecli/plugin-org/pull/332
2. checkout https://github.com/forcedotcom/sfdx-core/pull/597
3. `yarn build` and link it into `plugin-org`
4. try `force:org:open -u <sanbdox-username>` with a sbox with enhanced domains enabled, it should open it in the browser.

### What issues does this PR fix or reference?
@W-11286708@
https://github.com/forcedotcom/cli/issues/1556