### PR TITLE
fix: deprecate maxQueryLimit config var

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -288,6 +288,7 @@ export const SFDX_ALLOWED_PROPERTIES = [
     description: messages.getMessage(SfdxPropertyKeys.MAX_QUERY_LIMIT),
     hidden: true,
     newKey: OrgConfigProperties.ORG_MAX_QUERY_LIMIT,
+    deprecated: true,
     input: {
       // the bit shift will remove the negative bit, and any decimal numbers
       // then the parseFloat will handle converting it to a number from a string


### PR DESCRIPTION
### What does this PR do?

Marks `maxQueryLimit` as deprecated,  right now it shows as a 'normal' config var so this method:
https://github.com/forcedotcom/sfdx-core/blob/95cfdd0269dbf84b436b26a3d5f885415e526336/src/config/configAggregator.ts#L457
returns the same key.

This should fix SfdxConfigAgg not respecting `SFDX_MAX_QUERY_LIMIT`
https://github.com/salesforcecli/plugin-data/pull/316#issuecomment-1155603365

### What issues does this PR fix or reference?
@W-11204187@
https://github.com/forcedotcom/cli/issues/1543