### PR TITLE
Sh/no greedy regex

### DIFF
--- a/src/config/authInfoConfig.ts
+++ b/src/config/authInfoConfig.ts
@@ -17,7 +17,7 @@ import { ConfigFile } from './configFile';
  * ```
  */
 export class AuthInfoConfig extends ConfigFile<ConfigFile.Options, AuthFields> {
-  protected static encryptedKeys = [/token/gi, /password/gi, /secret/gi];
+  protected static encryptedKeys = [/token/i, /password/i, /secret/i];
   /**
    * Gets the config options for a given org ID.
    *

--- a/test/unit/config/configStoreTest.ts
+++ b/test/unit/config/configStoreTest.ts
@@ -5,10 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { expect } from 'chai';
-import * as sinon from 'sinon';
 import { AuthInfoConfig } from '../../../src/config/authInfoConfig';
 import { BaseConfigStore, ConfigContents } from '../../../src/config/configStore';
 import { AuthFields } from '../../../src/org/authInfo';
+import { testSetup } from '../../../src/testSetup';
+
+const $$ = testSetup();
 
 const specialKey = 'spe@cial.property';
 
@@ -79,10 +81,9 @@ describe('ConfigStore', () => {
   });
 
   describe('encryption', () => {
-    const sandbox = sinon.createSandbox();
-
-    afterEach(() => {
-      sandbox.restore();
+    beforeEach(() => {
+      $$.SANDBOXES.CONFIG.restore();
+      $$.SANDBOX.restore();
     });
 
     it('throws if crypto is not initialized', () => {
@@ -214,7 +215,7 @@ describe('ConfigStore', () => {
 
     // Ensures accessToken and refreshToken are both decrypted upon config.get()
     it('decrypts multiple regex matches per AuthInfoConfig encryptedKeys', async () => {
-      sandbox.stub(AuthInfoConfig.prototype, 'read');
+      $$.SANDBOX.stub(AuthInfoConfig.prototype, 'read');
       const accessToken = '1234';
       const refreshToken = '5678';
       const config = await AuthInfoConfig.create({});


### PR DESCRIPTION
This fixes decryption of multiple matching encryptionKeys in AuthInfo fields.  This was preventing an actual refreshToken from being used when refreshing expired accessTokens.

@W-11404143@