### PR TITLE
feat: orgAccessor.get has throwOnNotFound option

### DIFF
--- a/src/org/authRemover.ts
+++ b/src/org/authRemover.ts
@@ -15,7 +15,6 @@ import { OrgConfigProperties } from './orgConfigProperties';
 import { AuthFields } from '.';
 
 Messages.importMessagesDirectory(__dirname);
-const coreMessages = Messages.load('@salesforce/core', 'core', ['namedOrgNotFound']);
 const messages = Messages.load('@salesforce/core', 'auth', ['targetOrgNotSet']);
 
 /**
@@ -80,12 +79,8 @@ export class AuthRemover extends AsyncOptionalCreatable {
    * @returns {Promise<SfOrg>}
    */
   public async findAuth(usernameOrAlias?: string): Promise<AuthFields> {
-    const username = await this.resolveUsername(usernameOrAlias || this.getTargetOrg());
-    const auth = this.stateAggregator.orgs.get(username);
-    if (!auth) {
-      throw coreMessages.createError('namedOrgNotFound');
-    }
-    return auth;
+    const username = await this.resolveUsername(usernameOrAlias ?? this.getTargetOrg());
+    return this.stateAggregator.orgs.get(username, false, true);
   }
 
   /**


### PR DESCRIPTION
### What does this PR do?

1. adds an option for the orgAccesor.get to ensure that the auth exists
see background here: https://salesforce.quip.com/BiusAnH1wdcE for the type problems and unexpected behavior there
2. updates AuthRemover to use the new option
3. has some tests for not-found-orgs

Note: there's something wrong in the UT for GlobalInfo tests in orgAccessorTest.ts
1. they pass when `yarn test` runs all the tests
2. 3 fail when you run just the test file.

Hypothesis: they're relying on some other test to set something and pass only because of that.

Given that GlobalInfo is going away soon, I'm not going to fix those, just making a note of it.

### What issues does this PR fix or reference?
@W-11477147@
https://github.com/forcedotcom/cli/issues/1639