### PR TITLE
fix: set correct file mode for log file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ jobs:
         default: 'linux'
       sfdx_version:
         description: 'By default, the latest version of the standalone CLI will be installed. To install via npm, supply a version tag such as "latest" or "6".'
-        default: ''
         type: string
       sfdx_executable_path:
         description: "Path to sfdx executable to be used by NUTs, defaults to ''"
@@ -160,7 +159,7 @@ workflows:
               ignore: v3
           requires:
             - release-management/test-package
-          sfdx_version: latest
+          sfdx_version: ''
           node_version: lts
           matrix:
             parameters:
@@ -184,7 +183,7 @@ workflows:
               ignore: v3
           requires:
             - release-management/test-package
-          sfdx_version: latest
+          sfdx_version: ''
           branch: 'v2'
           node_version: lts
           matrix:
@@ -200,7 +199,7 @@ workflows:
               ignore: v3
           requires:
             - release-management/test-package
-          sfdx_version: latest
+          sfdx_version: ''
           size: xlarge
           node_version: lts
           matrix:

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -461,10 +461,10 @@ export class Logger {
         if (process.platform === 'win32') {
           fs.mkdirSync(path.dirname(logFile));
         } else {
-          fs.mkdirSync(path.dirname(logFile), { mode: 0x700 });
+          fs.mkdirSync(path.dirname(logFile), { mode: 0o700 });
         }
       } catch (err2) {
-        // noop; directory exists already
+        throw SfError.wrap(err2 as Error);
       }
       try {
         fs.writeFileSync(logFile, '', { mode: '600' });


### PR DESCRIPTION
A typo is causing core to create the log file with the wrong file mode making consumers crash.