### PR TITLE
fix: add interop between templates config/env var

### DIFF
--- a/messages/config.md
+++ b/messages/config.md
@@ -142,3 +142,7 @@ URL of the Salesforce instance hosting your org. Default: https://login.salesfor
 # org-instance-url
 
 URL of the Salesforce instance hosting your org. Default: https://login.salesforce.com.
+
+# customOrgMetadataTemplates
+
+A valid repository URL or directory for the custom org metadata templates.

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -40,6 +40,7 @@ const messages = Messages.load('@salesforce/core', 'config', [
   'restDeploy',
   'instanceUrl',
   'disable-telemetry',
+  'customOrgMetadataTemplates',
 ]);
 
 const SFDX_CONFIG_FILE_NAME = 'sfdx-config.json';
@@ -270,6 +271,12 @@ export const SFDX_ALLOWED_PROPERTIES = [
       validator: (value: ConfigValue) => value == null || ['true', 'false'].includes(value.toString()),
       failedMessage: messages.getMessage('invalidBooleanConfigValue'),
     },
+  },
+  {
+    key: SfdxPropertyKeys.CUSTOM_ORG_METADATA_TEMPLATES,
+    newKey: OrgConfigProperties.ORG_CUSTOM_METADATA_TEMPLATES,
+    deprecated: true,
+    description: messages.getMessage(SfdxPropertyKeys.CUSTOM_ORG_METADATA_TEMPLATES),
   },
   {
     key: SfdxPropertyKeys.REST_DEPLOY,


### PR DESCRIPTION
@W-11445939@

adds interop between old/new config value for `plugin-templates`