### PR TITLE
Sm/case-insensitive-scratch-org-create

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,7 @@ workflows:
                   'https://github.com/salesforcecli/plugin-limits',
                   'https://github.com/salesforcecli/plugin-schema',
                   'https://github.com/salesforcecli/plugin-env',
+                  'https://github.com/salesforcecli/plugin-org',
                   'https://github.com/salesforcecli/plugin-login',
                 ]
           context:

--- a/src/org/scratchOrgInfoApi.ts
+++ b/src/org/scratchOrgInfoApi.ts
@@ -283,7 +283,7 @@ export const requestScratchOrgCreation = async (
   delete scratchOrgRequest.objectSettings;
 
   // lowercase the username
-  scratchOrgRequest.Username = scratchOrgRequest.Username.toLowerCase();
+  scratchOrgRequest.Username = scratchOrgRequest.Username?.toLowerCase();
 
   // We do not allow you to specify the old and the new way of doing post create settings
   if (scratchOrgRequest.orgPreferences && settings.hasSettings()) {

--- a/src/org/scratchOrgInfoApi.ts
+++ b/src/org/scratchOrgInfoApi.ts
@@ -282,6 +282,9 @@ export const requestScratchOrgCreation = async (
   delete scratchOrgRequest.settings;
   delete scratchOrgRequest.objectSettings;
 
+  // lowercase the username
+  scratchOrgRequest.Username = scratchOrgRequest.Username.toLowerCase();
+
   // We do not allow you to specify the old and the new way of doing post create settings
   if (scratchOrgRequest.orgPreferences && settings.hasSettings()) {
     // This is not allowed

--- a/src/org/scratchOrgInfoApi.ts
+++ b/src/org/scratchOrgInfoApi.ts
@@ -282,9 +282,6 @@ export const requestScratchOrgCreation = async (
   delete scratchOrgRequest.settings;
   delete scratchOrgRequest.objectSettings;
 
-  // lowercase the username
-  scratchOrgRequest.Username = scratchOrgRequest.Username?.toLowerCase();
-
   // We do not allow you to specify the old and the new way of doing post create settings
   if (scratchOrgRequest.orgPreferences && settings.hasSettings()) {
     // This is not allowed
@@ -297,6 +294,10 @@ export const requestScratchOrgCreation = async (
   }
 
   const scratchOrgInfo = mapKeys(scratchOrgRequest, upperFirst, true);
+
+  if (typeof scratchOrgInfo.Username === 'string') {
+    scratchOrgInfo.Username = scratchOrgInfo.Username.toLowerCase();
+  }
 
   await checkOrgDoesntExist(scratchOrgInfo); // throw if it does exist.
   try {


### PR DESCRIPTION
### What does this PR do?
lowercase any scratch org username provided by the consumer for org creation
adds the plugin-org nuts to the CI run matrix

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1669
@W-11598550@

## QA Notes

The problem only happens on linux machines, so there's 2 things to review
1. a new nut on plugin-org to demonstrate the problem [merged PR](https://github.com/salesforcecli/plugin-org/pull/378),  [CI](https://app.circleci.com/pipelines/github/salesforcecli/plugin-org/3786/workflows/d06abab3-2af9-49cd-86ba-dd199708c579/jobs/10974) 
2. the equivalent [passing external nut](https://app.circleci.com/pipelines/github/forcedotcom/sfdx-core/2729/workflows/2ac2c817-723a-46a5-a9dc-aa0984a2c474/jobs/18267) from this branch 