### PR TITLE
fix(logger): idempotent mkdir when creating sf dir

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -459,9 +459,9 @@ export class Logger {
     } catch (err1) {
       try {
         if (process.platform === 'win32') {
-          fs.mkdirSync(path.dirname(logFile));
+          fs.mkdirSync(path.dirname(logFile), { recursive: true });
         } else {
-          fs.mkdirSync(path.dirname(logFile), { mode: 0o700 });
+          fs.mkdirSync(path.dirname(logFile), { mode: 0o700, recursive: true });
         }
       } catch (err2) {
         throw SfError.wrap(err2 as Error);


### PR DESCRIPTION
Fixes issue with `Logger` class throwing an error when trying to get the root logger.
This only happens if the logfile doesn't exists **and** the sf state folder `~/.sf` does.
 
The issue is in the `addLogFileStreamSync` method, when it detects there's no logfile it tries to create the sf dir but `fs.mkdirSync` fails if the dir already exists, setting `recursive: true` in the opts arg makes it idempotent.

repro:

1) `rm ~/.sf/sf.log*`

2) execute this code:

```typescript
const log = Logger.getRoot()

log.warn('lalala')
```

you should get:

`EEXIST: file already exists, mkdir '/Users/cdominguez/.sf'`

@W-11730976@