### PR TITLE
fix(logger): support `SF_*` env vars

### DIFF
--- a/messages/envVars.md
+++ b/messages/envVars.md
@@ -90,6 +90,10 @@ URL of the Salesforce instance that is hosting your org. Default value is https:
 
 Set to true to send messages resulting from failed Salesforce CLI commands to stdout instead of stderr.
 
+# sfdxDisableLogFile
+
+Set to true to disable log file writing
+
 # sfdxLogLevel
 
 Level of messages that the CLI writes to the log file. Valid values are trace, debug, info, warn, error, fatal. Default value is warn.
@@ -225,6 +229,10 @@ URL of the Salesforce instance that is hosting your org. Default value is https:
 # sfJsonToStdout
 
 Set to true to send messages resulting from failed Salesforce CLI commands to stdout instead of stderr.
+
+# sfDisableLogFile
+
+Set to true to disable log file writing
 
 # sfLogLevel
 

--- a/src/config/envVars.ts
+++ b/src/config/envVars.ts
@@ -37,6 +37,7 @@ export enum EnvironmentVariable {
   'SFDX_IMPROVED_CODE_COVERAGE' = 'SFDX_IMPROVED_CODE_COVERAGE',
   'SFDX_INSTANCE_URL' = 'SFDX_INSTANCE_URL',
   'SFDX_JSON_TO_STDOUT' = 'SFDX_JSON_TO_STDOUT',
+  'SFDX_DISABLE_LOG_FILE' = 'SFDX_DISABLE_LOG_FILE',
   'SFDX_LOG_LEVEL' = 'SFDX_LOG_LEVEL',
   'SFDX_LOG_ROTATION_COUNT' = 'SFDX_LOG_ROTATION_COUNT',
   'SFDX_LOG_ROTATION_PERIOD' = 'SFDX_LOG_ROTATION_PERIOD',
@@ -71,6 +72,7 @@ export enum EnvironmentVariable {
   'SF_IMPROVED_CODE_COVERAGE' = 'SF_IMPROVED_CODE_COVERAGE',
   'SF_ORG_INSTANCE_URL' = 'SF_ORG_INSTANCE_URL',
   'SF_JSON_TO_STDOUT' = 'SF_JSON_TO_STDOUT',
+  'SF_DISABLE_LOG_FILE' = 'SF_DISABLE_LOG_FILE',
   'SF_LOG_LEVEL' = 'SF_LOG_LEVEL',
   'SF_LOG_ROTATION_COUNT' = 'SF_LOG_ROTATION_COUNT',
   'SF_LOG_ROTATION_PERIOD' = 'SF_LOG_ROTATION_PERIOD',
@@ -194,6 +196,10 @@ export const SUPPORTED_ENV_VARS: EnvType = {
   [EnvironmentVariable.SFDX_JSON_TO_STDOUT]: {
     description: getMessage(EnvironmentVariable.SFDX_JSON_TO_STDOUT),
     synonymOf: EnvironmentVariable.SF_JSON_TO_STDOUT,
+  },
+  [EnvironmentVariable.SFDX_DISABLE_LOG_FILE]: {
+    description: getMessage(EnvironmentVariable.SFDX_DISABLE_LOG_FILE),
+    synonymOf: EnvironmentVariable.SF_DISABLE_LOG_FILE,
   },
   [EnvironmentVariable.SFDX_LOG_LEVEL]: {
     description: getMessage(EnvironmentVariable.SFDX_LOG_LEVEL),
@@ -333,6 +339,10 @@ export const SUPPORTED_ENV_VARS: EnvType = {
   [EnvironmentVariable.SF_JSON_TO_STDOUT]: {
     description: getMessage(EnvironmentVariable.SF_JSON_TO_STDOUT),
     synonymOf: null,
+  },
+  [EnvironmentVariable.SF_DISABLE_LOG_FILE]: {
+    description: getMessage(EnvironmentVariable.SF_DISABLE_LOG_FILE),
+    synonymOf: EnvironmentVariable.SFDX_DISABLE_LOG_FILE,
   },
   [EnvironmentVariable.SF_LOG_LEVEL]: {
     description: getMessage(EnvironmentVariable.SF_LOG_LEVEL),

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -316,7 +316,8 @@ export class Logger {
     const rootLogger = (this.rootLogger = new Logger(Logger.ROOT_NAME).setLevel());
 
     // disable log file writing, if applicable
-    if (process.env.SFDX_DISABLE_LOG_FILE !== 'true' && Global.getEnvironmentMode() !== Mode.TEST) {
+    const disableLogFile = new Env().getString('SF_DISABLE_LOG_FILE');
+    if (disableLogFile !== 'true' && Global.getEnvironmentMode() !== Mode.TEST) {
       await rootLogger.addLogFileStream(Global.LOG_FILE_PATH);
     }
 
@@ -528,7 +529,8 @@ export class Logger {
    */
   public setLevel(level?: LoggerLevelValue): Logger {
     if (level == null) {
-      level = process.env.SFDX_LOG_LEVEL ? Logger.getLevelByName(process.env.SFDX_LOG_LEVEL) : Logger.DEFAULT_LEVEL;
+      const logLevelFromEnvVar = new Env().getString('SF_LOG_LEVEL');
+      level = logLevelFromEnvVar ? Logger.getLevelByName(logLevelFromEnvVar) : Logger.DEFAULT_LEVEL;
     }
     this.bunyan.level(level);
     return this;


### PR DESCRIPTION
  ### What does this PR do?
Adds support for `SF_DISABLE_LOG_FILE` and `SF_LOG_LEVEL` env vars.

The `Logger` class was checking for  `process.env.SFDX_DISABLE_LOG_FILE` only, now it supports both `SF` and `SFDX` versions.

`SF_LOG_LEVEL` was already in the `EnvironmentVariable` enum but `Logger` was checking `process.env.SFDX_LOG_LEVEL` only

**QA**:

link this change into any sf/sfdx plugin that logs something, then check:

1. both `SFDX_DISABLE_LOG_FILE` and `SF_DISABLE_LOG_FILE` set to true should disable log file writing.
2. both `SFDX_LOG_LEVEL` and `SF_LOG_LEVEL` should set the log level for the root logger, see the `logging` section of the plugin dev guide: https://github.com/salesforcecli/cli/wiki/Code-Your-Plug-In#logging 

### What issues does this PR fix or reference?
@W-11770007@