### PR TITLE
fix: ensure the hubOrg passes is actually a DevHub, throw error if not

### DIFF
--- a/messages/scratchOrgInfoApi.md
+++ b/messages/scratchOrgInfoApi.md
@@ -16,4 +16,4 @@ Successfully created org with ID: %s and name: %s. Unfortunately, source trackin
 
 # hubOrgIsNotDevHub
 
-Ensure that org with username: %s and id %s is enabled as a DevHub
+Make sure that the org with username %s and ID %s is enabled as a Dev Hub. To enable it, open the org in your browser, navigate to the Dev Hub page in Setup, and click Enable.

--- a/messages/scratchOrgInfoApi.md
+++ b/messages/scratchOrgInfoApi.md
@@ -13,3 +13,7 @@ We've deprecated OrgPreferences. Update the scratch org definition file to repla
 # SourceStatusResetFailureError
 
 Successfully created org with ID: %s and name: %s. Unfortunately, source tracking isn’t working as expected. If you run force:source:status, the results may be incorrect. Try again by creating another scratch org.
+
+# hubOrgIsNotDevHub
+
+Ensure that org with username: %s and id %s is enabled as a DevHub

--- a/src/org/scratchOrgInfoApi.ts
+++ b/src/org/scratchOrgInfoApi.ts
@@ -277,6 +277,9 @@ export const requestScratchOrgCreation = async (
   scratchOrgRequest: ScratchOrgInfo,
   settings: SettingsGenerator
 ): Promise<SaveResult> => {
+  if (!hubOrg.isDevHubOrg()) {
+    throw messages.createError('hubOrgIsNotDevHub', [hubOrg.getUsername(), hubOrg.getOrgId()]);
+  }
   // If these were present, they were already used to initialize the scratchOrgSettingsGenerator.
   // They shouldn't be submitted as part of the scratchOrgInfo.
   delete scratchOrgRequest.settings;

--- a/test/unit/org/scratchOrgCreateTest.ts
+++ b/test/unit/org/scratchOrgCreateTest.ts
@@ -46,7 +46,7 @@ describe('scratchOrgCreate', () => {
         signupTargetLoginUrl: 'https://salesforce.com',
       }),
     } as unknown as SfProject);
-    hubOrgStub.isDevHubOrg.returns(false);
+    hubOrgStub.isDevHubOrg.returns(true);
     hubOrgStub.determineIfDevHubOrg.withArgs(true).resolves();
     // @ts-ignore
     hubOrgStub.getConnection.returns({

--- a/test/unit/org/scratchOrgInfoApiTest.ts
+++ b/test/unit/org/scratchOrgInfoApiTest.ts
@@ -6,7 +6,7 @@
  */
 
 import * as sinon from 'sinon';
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { env, Duration } from '@salesforce/kit';
 import { stubMethod } from '@salesforce/ts-sinon';
 import { Connection } from '../../../src/org';
@@ -50,6 +50,9 @@ const TEMPLATE_SCRATCH_ORG_INFO: ScratchOrgInfo = {
 describe('requestScratchOrgCreation', () => {
   const sandbox = sinon.createSandbox();
   const connectionStub = sinon.createStubInstance(Connection);
+  let isDevHubStub: sinon.SinonStub;
+  let hubOrg: Org;
+  let settings: SettingsGenerator;
 
   beforeEach(() => {
     stubMethod(sandbox, Org, 'create').resolves(Org.prototype);
@@ -58,6 +61,9 @@ describe('requestScratchOrgCreation', () => {
       create: sinon.stub().resolves(true),
     });
     stubMethod(sandbox, Org.prototype, 'getConnection').returns(connectionStub);
+    hubOrg = new Org({});
+    settings = new SettingsGenerator();
+    isDevHubStub = stubMethod(sandbox, hubOrg, 'isDevHubOrg').returns(true);
   });
 
   afterEach(() => {
@@ -68,33 +74,36 @@ describe('requestScratchOrgCreation', () => {
     const error = new Error('MyError');
     error.name = 'NamedOrgNotFoundError';
     stubMethod(sandbox, AuthInfo, 'create').rejects(error);
-    const hubOrg = new Org({});
-    const settings = new SettingsGenerator();
     const result = await requestScratchOrgCreation(hubOrg, TEMPLATE_SCRATCH_ORG_INFO, settings);
     expect(result).to.be.true;
+  });
+
+  it('requestScratchOrgCreation throws when HubOrg is not a DevHub', async () => {
+    isDevHubStub.returns(false);
+    sandbox.stub(hubOrg, 'getOrgId').returns('00D530000008eXXXXX');
+    try {
+      await requestScratchOrgCreation(hubOrg, TEMPLATE_SCRATCH_ORG_INFO, settings);
+      assert.fail('Should have thrown');
+    } catch (e) {
+      expect(e.message).to.equal(messages.getMessage('hubOrgIsNotDevHub', [hubOrg.getUsername(), hubOrg.getOrgId()]));
+    }
   });
 
   it('requestScratchOrgCreation no username field in scratchOrgRequest', async () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { Username, ...scratchOrgRequest } = { ...TEMPLATE_SCRATCH_ORG_INFO };
-    const hubOrg = new Org({});
-    const settings = new SettingsGenerator();
     const result = await requestScratchOrgCreation(hubOrg, scratchOrgRequest as ScratchOrgInfo, settings);
     expect(result).to.be.true;
   });
 
   it('requestScratchOrgCreation no username field in scratchOrgRequest is empty', async () => {
     const scratchOrgRequest = { ...TEMPLATE_SCRATCH_ORG_INFO, Username: undefined };
-    const hubOrg = new Org({});
-    const settings = new SettingsGenerator();
     const result = await requestScratchOrgCreation(hubOrg, scratchOrgRequest, settings);
     expect(result).to.be.true;
   });
 
   it('requestScratchOrgCreation user exists', async () => {
     stubMethod(sandbox, AuthInfo, 'create').resolves();
-    const hubOrg = new Org({});
-    const settings = new SettingsGenerator();
     try {
       await shouldThrow(requestScratchOrgCreation(hubOrg, TEMPLATE_SCRATCH_ORG_INFO, settings));
     } catch (error) {
@@ -111,8 +120,6 @@ describe('requestScratchOrgCreation', () => {
     connectionStub.sobject.withArgs('ScratchOrgInfo').returns({
       create: sinon.stub().rejects(new Error('MyCreateError')),
     });
-    const hubOrg = new Org({});
-    const settings = new SettingsGenerator();
     try {
       await shouldThrow(requestScratchOrgCreation(hubOrg, TEMPLATE_SCRATCH_ORG_INFO, settings));
     } catch (error) {
@@ -128,8 +135,7 @@ describe('requestScratchOrgCreation', () => {
     connectionStub.sobject.withArgs('ScratchOrgInfo').returns({
       create: sinon.stub().rejects(),
     });
-    const hubOrg = new Org({});
-    const settings = new SettingsGenerator();
+
     try {
       await shouldThrow(requestScratchOrgCreation(hubOrg, TEMPLATE_SCRATCH_ORG_INFO, settings));
     } catch (error) {
@@ -152,8 +158,7 @@ describe('requestScratchOrgCreation', () => {
     connectionStub.sobject.withArgs('ScratchOrgInfo').returns({
       create: sinon.stub().rejects(jsForceError),
     });
-    const hubOrg = new Org({});
-    const settings = new SettingsGenerator();
+
     try {
       await shouldThrow(requestScratchOrgCreation(hubOrg, TEMPLATE_SCRATCH_ORG_INFO, settings));
     } catch (error) {
@@ -168,7 +173,7 @@ describe('requestScratchOrgCreation', () => {
     const err = new Error('MyError');
     err.name = 'NamedOrgNotFound';
     stubMethod(sandbox, AuthInfo, 'create').rejects(err);
-    const hubOrg = new Org({});
+
     const s = { a: 'b' };
     const scratchDef = {
       ...TEMPLATE_SCRATCH_ORG_INFO,
@@ -177,7 +182,7 @@ describe('requestScratchOrgCreation', () => {
         preference: true,
       },
     } as unknown as ScratchOrgInfo;
-    const settings = new SettingsGenerator();
+
     await settings.extract(scratchDef);
     try {
       await shouldThrow(requestScratchOrgCreation(hubOrg, scratchDef, settings));
@@ -192,14 +197,13 @@ describe('requestScratchOrgCreation', () => {
     const err = new Error('MyError');
     err.name = 'NamedOrgNotFound';
     stubMethod(sandbox, AuthInfo, 'create').rejects(err);
-    const hubOrg = new Org({});
+
     const scratchDef = {
       ...TEMPLATE_SCRATCH_ORG_INFO,
       orgPreferences: {
         preference: true,
       },
     } as unknown as ScratchOrgInfo;
-    const settings = new SettingsGenerator();
     await settings.extract(scratchDef);
     try {
       await shouldThrow(requestScratchOrgCreation(hubOrg, scratchDef, settings));


### PR DESCRIPTION
### What does this PR do?
throws a nicer error message when the `hubOrg` is not actually enabled as a `DevHub`

# Before
`ERROR running force:org:create:  The requested resource does not exist`

# After

`ERROR running force:org:create:  Ensure that org, with id: test-podeygqvfh7u@example.com and username 00D530000008eONEAY is enabled as a DevHub`

*Messaging to be reviewed by Juliet

### What issues does this PR fix or reference?
@W-11838125@