### PR TITLE
fix: reset SFDX_INTEROPERABILITY on contextRestore

### DIFF
--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -606,6 +606,8 @@ export const stubContext = (testContext: TestContext): Record<string, sinonType.
  * @param testContext
  */
 export const restoreContext = (testContext: TestContext): void => {
+  // Restore the default value for this setting on restore.
+  Global.SFDX_INTEROPERABILITY = true;
   testContext.SANDBOX.restore();
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   Object.values(testContext.SANDBOXES).forEach((theSandbox) => theSandbox.restore());


### PR DESCRIPTION
### What does this PR do?
Update the restoreContext function to reset the Global.SFDX_INTEROPERABILITY value to true. 

### What issues does this PR fix or reference?
#672