### PR TITLE
fix: type on TokenAccessor.set

### DIFF
--- a/src/stateAggregator/accessors/tokenAccessor.ts
+++ b/src/stateAggregator/accessors/tokenAccessor.ts
@@ -60,7 +60,7 @@ export class TokenAccessor extends AsyncOptionalCreatable {
    * @param name
    * @param token
    */
-  public set(name: string, token: SfToken): void {
+  public set(name: string, token: Partial<SfToken>): void {
     this.config.set(name, token);
   }
 


### PR DESCRIPTION
### What does this PR do?

Updates type on `TokenAccessor.set` so that plugin-functions can compile

### What issues does this PR fix or reference?
[skip-validate-pr]