### PR TITLE
fix: getPackageFromPath now handles nested package paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@salesforce/bunyan": "^2.0.0",
     "@salesforce/kit": "^1.7.0",
     "@salesforce/schemas": "^1.1.0",
-    "@salesforce/ts-types": "^1.5.20",
+    "@salesforce/ts-types": "^1.5.21",
     "@types/graceful-fs": "^4.1.5",
     "@types/semver": "^7.3.9",
     "ajv": "^8.11.0",

--- a/src/sfProject.ts
+++ b/src/sfProject.ts
@@ -608,7 +608,9 @@ export class SfProject {
       // fullPath will not have a trailing slash, so remove it from packageDir.fullPath, if it exists
       const fullPathSansTrailingSep = packageDir.fullPath.replace(/(\\|\/)$/, '');
       return (
-        basename(path) === packageDir.path || fullPath === fullPathSansTrailingSep || path.includes(packageDir.fullPath)
+        basename(path) === packageDir.path ||
+        fullPath === fullPathSansTrailingSep ||
+        fullPath.includes(packageDir.fullPath)
       );
     });
     return match;

--- a/test/unit/projectTest.ts
+++ b/test/unit/projectTest.ts
@@ -555,8 +555,8 @@ describe('SfProject', () => {
         $$.setConfigStubContents('SfProjectJson', {
           contents: {
             packageDirectories: [
-              { path: expectedNestedPackage, default: false },
               { path: expectedPackage, default: true },
+              { path: expectedNestedPackage, default: false },
               { path: expectedContainedPackage, default: false },
             ],
           },
@@ -588,6 +588,30 @@ describe('SfProject', () => {
         const actual = SfProject.getInstance().getPackageNameFromPath(
           join(projectPath, expectedNestedPackage, 'main', 'apex', 'apecClass.cls')
         );
+        expect(actual).to.equal(expectedNestedPackage);
+      });
+      it('should return correct package name when the package has a nested path and given path equal package full path', () => {
+        const actual = SfProject.getInstance().getPackageNameFromPath(join(projectPath, expectedNestedPackage));
+        expect(actual).to.equal(expectedNestedPackage);
+      });
+      it('should return correct package name when the package has a nested path and given relative path', () => {
+        $$.SANDBOX.stub(process, 'cwd').returns(projectPath);
+        const actual = SfProject.getInstance().getPackageNameFromPath(expectedNestedPackage);
+        expect(actual).to.equal(expectedNestedPackage);
+      });
+      it(`should return correct package name when the package has a nested path and given relative dir with leading sep .${sep}foodir`, () => {
+        $$.SANDBOX.stub(process, 'cwd').returns(projectPath);
+        const actual = SfProject.getInstance().getPackageNameFromPath(`.${sep}${expectedNestedPackage}`);
+        expect(actual).to.equal(expectedNestedPackage);
+      });
+      it(`should return correct package name when the package has a nested path and given relative dir trailing sep foodir${sep}`, () => {
+        $$.SANDBOX.stub(process, 'cwd').returns(projectPath);
+        const actual = SfProject.getInstance().getPackageNameFromPath(`${expectedNestedPackage}${sep}`);
+        expect(actual).to.equal(expectedNestedPackage);
+      });
+      it(`should return correct package name when the package has a nested path and given relative dir with leading and trailing sep .${sep}foodir${sep}`, () => {
+        $$.SANDBOX.stub(process, 'cwd').returns(projectPath);
+        const actual = SfProject.getInstance().getPackageNameFromPath(`.${sep}${expectedNestedPackage}${sep}`);
         expect(actual).to.equal(expectedNestedPackage);
       });
     });


### PR DESCRIPTION
### What does this PR do?
Modifies getPackageFromPath to better handle matching logic between a package dir entry's fullPath property and the path passed to the function.
### What issues does this PR fix or reference?
@W-11903179@
