### PR TITLE
fix: incorrect url for scratch org error codes documentation

### DIFF
--- a/messages/scratchOrgErrorCodes.md
+++ b/messages/scratchOrgErrorCodes.md
@@ -8,7 +8,7 @@ An unknown server error occurred. Please try again. If you still see this error,
 
 # SignupFailedActionError
 
-See https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_signuprequest.htm for information on error code %s.
+See https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_scratch_orgs_error_codes.htm for information on error code %s.
 
 # SignupUnexpectedError
 


### PR DESCRIPTION
### What does this PR do?
Update the url to point to the scratch org error codes documentation
### What issues does this PR fix or reference?
[680](https://github.com/forcedotcom/sfdx-core/issues/680)
