### PR TITLE
fix: function addLogFileStreamSync to use recursive mkdir

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -467,9 +467,9 @@ export class Logger {
     } catch (err1) {
       try {
         if (process.platform === 'win32') {
-          fs.mkdirSync(path.dirname(logFile));
+          fs.mkdirSync(path.dirname(logFile), { recursive: true });
         } else {
-          fs.mkdirSync(path.dirname(logFile), { mode: 0o700 });
+          fs.mkdirSync(path.dirname(logFile), { recursive: true, mode: 0o700 });
         }
       } catch (err2) {
         throw SfError.wrap(err2 as Error);


### PR DESCRIPTION
@W-11903179@

Function addLogFileStreamSync now uses mkdir w/recursive = true
