### PR TITLE
fix: improve `hubOrgIsNotDevHub` error msg

### DIFF
--- a/messages/scratchOrgInfoApi.md
+++ b/messages/scratchOrgInfoApi.md
@@ -17,3 +17,4 @@ Successfully created org with ID: %s and name: %s. Unfortunately, source trackin
 # hubOrgIsNotDevHub
 
 Make sure that the org with username %s and ID %s is enabled as a Dev Hub. To enable it, open the org in your browser, navigate to the Dev Hub page in Setup, and click Enable.
+If you still see this error after enabling the Dev Hub feature, then re-authenticate to the org.


### PR DESCRIPTION
### What does this PR do?
Updates `hubOrgIsNotDevHub` error msg.
After a user enables the dev hub settings in the org UI, `sfdx` doesn't know about this so the auth file needs to be updated (re-authenticate to the org).
See: https://github.com/forcedotcom/sfdx-core/pull/669#discussion_r1003431576

### What issues does this PR fix or reference?
[skip ci]
[skip-validate-pr]