### PR TITLE
Sm/headers dedupe

### DIFF
--- a/src/org/connection.ts
+++ b/src/org/connection.ts
@@ -197,7 +197,14 @@ export class Connection<S extends Schema = Schema> extends JSForceConnection<S> 
    */
   public request<R = unknown>(request: string | HttpRequest, options?: JsonMap): StreamPromise<R> {
     const httpRequest: HttpRequest = isString(request) ? { method: 'GET', url: request } : request;
-    httpRequest.headers = Object.assign({}, SFDX_HTTP_HEADERS, httpRequest.headers);
+    // prevent duplicate headers by lowercasing the keys on the incoming request
+    const lowercasedHeaders = httpRequest.headers
+      ? Object.fromEntries(Object.entries(httpRequest.headers).map(([key, value]) => [key.toLowerCase(), value]))
+      : {};
+    httpRequest.headers = {
+      ...SFDX_HTTP_HEADERS,
+      ...lowercasedHeaders,
+    };
     this.logger.debug(`request: ${JSON.stringify(httpRequest)}`);
     return super.request(httpRequest, options);
   }

--- a/test/unit/util/directoryWriterTest.ts
+++ b/test/unit/util/directoryWriterTest.ts
@@ -39,7 +39,7 @@ describe('DirectoryWriter', () => {
     validateFileContents(path.join(directoryPath, filename), contents);
   });
   it('addToStore - Buffer', async () => {
-    const contents = new Buffer('my-contents');
+    const contents = Buffer.from('my-contents');
     await directoryWriter.addToStore(contents, filename);
     await directoryWriter.finalize();
     expect(fs.existsSync(path.join(directoryPath, filename))).to.be.true;


### PR DESCRIPTION
### What does this PR do?
fixes duplicate headers on .request

### What issues does this PR fix or reference?
@W-12020863@

QA: create a sandbox 
`sf env create sandbox -o admin@integrationtesthubna40.org -l Developer -a qa697 -w 600 -n qa697 -i 60`
once it's done, logout of it
`sfdx force:auth:logout admin@integrationtesthubna40.org.qa697`

link core into plugin-org, then run 
DEBUG=* ../plugin-org/bin/dev force:org:status -u admin@integrationtesthubna40.org -n qa12008578

you should see a line like this with deduped headers
```
  sf:connection DEBUG request: {"method":"POST","url":"https://na40-dev-hub.my.salesforce.com/services/data/v56.0/tooling/sandboxAuth","headers":{"content-type":"application/json","user-agent":"sfdx toolbelt:"},"body":"{\"clientId\":\"PlatformCLI\",\"sandboxName\":\"qa12008578\",\"callbackUrl\":\"http://localhost:1717/OauthRedirect\"}"} +345ms
```

The original (and the cause of the error for hyperforce instances) looked like this

<img width="1711" alt="Screen Shot 2022-11-07 at 9 30 22 AM" src="https://user-images.githubusercontent.com/4261788/200364744-ed4aa037-eb4d-4d4b-b4f8-7fbfa76ee032.png">

