### PR TITLE
fix: ajv allows union type schema, sfProject doesn't validate

### DIFF
--- a/src/schema/validator.ts
+++ b/src/schema/validator.ts
@@ -86,6 +86,7 @@ export class SchemaValidator {
 
     const ajv = new Ajv({
       allErrors: true,
+      allowUnionTypes: true,
       schemas: externalSchemas,
       useDefaults: true,
       // TODO: We may someday want to enable strictSchema. This is disabled for now

--- a/src/sfProject.ts
+++ b/src/sfProject.ts
@@ -112,7 +112,6 @@ export class SfProjectJson extends ConfigFile {
   public async read(): Promise<ConfigContents> {
     const contents = await super.read();
     this.validateKeys();
-    await this.schemaValidate();
     return contents;
   }
 
@@ -164,19 +163,18 @@ export class SfProjectJson extends ConfigFile {
     if (!this.hasRead) {
       // read calls back into this method after necessarily setting this.hasRead=true
       await this.read();
-    } else {
-      try {
-        const projectJsonSchemaPath = require.resolve('@salesforce/schemas/sfdx-project.schema.json');
-        const validator = new SchemaValidator(this.logger, projectJsonSchemaPath);
-        await validator.validate(this.getContents());
-      } catch (err) {
-        const error = err as Error;
-        // Don't throw errors if the global isn't valid, but still warn the user.
-        if (env.getBoolean('SFDX_PROJECT_JSON_VALIDATION', false) && !this.options.isGlobal) {
-          throw messages.createError('schemaValidationError', [this.getPath(), error.message], [this.getPath()], error);
-        } else {
-          this.logger.warn(messages.getMessage('schemaValidationError', [this.getPath(), error.message]));
-        }
+    }
+    try {
+      const projectJsonSchemaPath = require.resolve('@salesforce/schemas/sfdx-project.schema.json');
+      const validator = new SchemaValidator(this.logger, projectJsonSchemaPath);
+      await validator.validate(this.getContents());
+    } catch (err) {
+      const error = err as Error;
+      // Don't throw errors if the global isn't valid, but still warn the user.
+      if (env.getBoolean('SFDX_PROJECT_JSON_VALIDATION', false) && !this.options.isGlobal) {
+        throw messages.createError('schemaValidationError', [this.getPath(), error.message], [this.getPath()], error);
+      } else {
+        this.logger.warn(messages.getMessage('schemaValidationError', [this.getPath(), error.message]));
       }
     }
   }
@@ -202,19 +200,18 @@ export class SfProjectJson extends ConfigFile {
     if (!this.hasRead) {
       // read calls back into this method after necessarily setting this.hasRead=true
       this.readSync();
-    } else {
-      try {
-        const projectJsonSchemaPath = require.resolve('@salesforce/schemas/sfdx-project.schema.json');
-        const validator = new SchemaValidator(this.logger, projectJsonSchemaPath);
-        validator.validateSync(this.getContents());
-      } catch (err) {
-        const error = err as Error;
-        // Don't throw errors if the global isn't valid, but still warn the user.
-        if (env.getBoolean('SFDX_PROJECT_JSON_VALIDATION', false) && !this.options.isGlobal) {
-          throw messages.createError('schemaValidationError', [this.getPath(), error.message], [this.getPath()], error);
-        } else {
-          this.logger.warn(messages.getMessage('schemaValidationError', [this.getPath(), error.message]));
-        }
+    }
+    try {
+      const projectJsonSchemaPath = require.resolve('@salesforce/schemas/sfdx-project.schema.json');
+      const validator = new SchemaValidator(this.logger, projectJsonSchemaPath);
+      validator.validateSync(this.getContents());
+    } catch (err) {
+      const error = err as Error;
+      // Don't throw errors if the global isn't valid, but still warn the user.
+      if (env.getBoolean('SFDX_PROJECT_JSON_VALIDATION', false) && !this.options.isGlobal) {
+        throw messages.createError('schemaValidationError', [this.getPath(), error.message], [this.getPath()], error);
+      } else {
+        this.logger.warn(messages.getMessage('schemaValidationError', [this.getPath(), error.message]));
       }
     }
   }

--- a/src/sfProject.ts
+++ b/src/sfProject.ts
@@ -119,7 +119,6 @@ export class SfProjectJson extends ConfigFile {
   public readSync(): ConfigContents {
     const contents = super.readSync();
     this.validateKeys();
-    this.schemaValidateSync();
     return contents;
   }
 
@@ -128,7 +127,6 @@ export class SfProjectJson extends ConfigFile {
       this.setContents(newContents);
     }
     this.validateKeys();
-    await this.schemaValidate();
     return super.write();
   }
 
@@ -137,7 +135,6 @@ export class SfProjectJson extends ConfigFile {
       this.setContents(newContents);
     }
     this.validateKeys();
-    this.schemaValidateSync();
     return super.writeSync();
   }
 

--- a/test/unit/projectTest.ts
+++ b/test/unit/projectTest.ts
@@ -36,22 +36,6 @@ describe('SfProject', () => {
       const json = await SfProjectJson.create();
       expect(json.get('packageAliases')['MyName']).to.equal('somePackage');
     });
-    it('read calls schemaValidate', async () => {
-      const defaultOptions = SfProjectJson.getDefaultOptions();
-      const sfProjectJson = new SfProjectJson(defaultOptions);
-      const schemaValidateStub = $$.SANDBOX.stub(sfProjectJson, 'schemaValidate');
-      schemaValidateStub.returns(Promise.resolve());
-      await sfProjectJson.read();
-      expect(schemaValidateStub.calledOnce).to.be.true;
-    });
-    it('write calls schemaValidate', async () => {
-      const defaultOptions = SfProjectJson.getDefaultOptions();
-      const sfProjectJson = new SfProjectJson(defaultOptions);
-      const schemaValidateStub = $$.SANDBOX.stub(sfProjectJson, 'schemaValidate');
-      schemaValidateStub.returns(Promise.resolve());
-      await sfProjectJson.write();
-      expect(schemaValidateStub.calledOnce).to.be.true;
-    });
     it('getPackageDirectories should transform packageDir paths to have path separators that match the OS', async () => {
       let defaultPP: string;
       let transformedDefaultPP: string;
@@ -97,55 +81,6 @@ describe('SfProject', () => {
           default: false,
         },
       ]);
-    });
-    it('schemaValidate validates sfdx-project.json', async () => {
-      $$.setConfigStubContents('SfProjectJson', {
-        contents: {
-          packageDirectories: [
-            { path: 'force-app', default: true },
-            { path: 'common', default: false },
-          ],
-          namespace: 'test_ns',
-          sourceApiVersion: '48.0',
-        },
-      });
-      const loggerSpy = $$.SANDBOX.spy($$.TEST_LOGGER, 'warn');
-      // create() calls read() which calls schemaValidate()
-      await SfProjectJson.create();
-      expect(loggerSpy.called).to.be.false;
-    });
-    it('schemaValidate throws when SFDX_PROJECT_JSON_VALIDATION=true and invalid file', async () => {
-      $$.setConfigStubContents('SfProjectJson', {
-        contents: {
-          packageDirectories: [{ path: 'force-app', default: true }],
-          foo: 'bar',
-        },
-      });
-      $$.SANDBOX.stub(env, 'getBoolean').callsFake((envVarName) => envVarName === 'SFDX_PROJECT_JSON_VALIDATION');
-      const expectedError = "Validation errors:\n#/additionalProperties: must NOT have additional properties 'foo'";
-      try {
-        // create() calls read() which calls schemaValidate()
-        await shouldThrow(SfProjectJson.create());
-      } catch (e) {
-        if (!(e instanceof Error)) {
-          expect.fail('Expected error to be an instance of Error');
-        }
-        expect(e.name).to.equal('SchemaValidationError');
-        expect(e.message).to.contain(expectedError);
-      }
-    });
-    it('schemaValidate warns when SFDX_PROJECT_JSON_VALIDATION=false and invalid file', async () => {
-      $$.setConfigStubContents('SfProjectJson', {
-        contents: {
-          packageDirectories: [{ path: 'force-app', default: true }],
-          foo: 'bar',
-        },
-      });
-      const loggerSpy = $$.SANDBOX.spy($$.TEST_LOGGER, 'warn');
-      // create() calls read() which calls schemaValidate()
-      await SfProjectJson.create();
-      expect(loggerSpy.calledOnce).to.be.true;
-      expect(loggerSpy.args[0][0]).to.contains('is not schema valid');
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
**skip project.json schema validations on project read/write**

fixes noisy schema validation messages

```txt
strict mode: use allowUnionTypes to allow union type keyword at "http://schemas.salesforce.com/sfdx-project.json#/properties/replacements/items/anyOf/0/properties/replaceWhenEnv/items/properties/value" (strictTypes)
``` 

or this stuff from the logs (trying to validate non-existent global project.json)
<img width="1228" alt="image (9)" src="https://user-images.githubusercontent.com/4261788/201397536-5f75a510-693b-483b-8ff4-3e672266dc25.png">


### What issues does this PR fix or reference?
[@W-12048460@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001CQcAWYA1/view)

---
QA notes:
link core to some plugin (plugin-source can reproduce via `source:push`) and run the command.
You should see the errors on 7.176.1 and not with core linked to your plugin.