### PR TITLE
feat: getConnection accepts an optional version

### DIFF
--- a/src/org/connection.ts
+++ b/src/org/connection.ts
@@ -228,7 +228,7 @@ export class Connection<S extends Schema = Schema> extends JSForceConnection<S> 
    */
   public async deployRecentValidation(options: recentValidationOptions): Promise<JsonCollection> {
     // REST returns an object with an id property, SOAP returns the id as a string directly. That is now handled
-    // in jsforce, so we have to cast a string as unkown as JsonCollection to support backwards compatibility.
+    // in jsforce, so we have to cast a string as unknown as JsonCollection to support backwards compatibility.
     return (await this.metadata.deployRecentValidation(options)) as unknown as JsonCollection;
   }
   /**

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -873,6 +873,8 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
 
   /**
    * Returns the JSForce connection for the org.
+   * side effect: If you pass it an apiVersion, it will set it on the Org
+   * so that future calls to getConnection() will also use that version.
    *
    * @param apiVersion The API version to use for the connection.
    */

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -873,8 +873,13 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
 
   /**
    * Returns the JSForce connection for the org.
+   *
+   * @param apiVersion The API version to use for the connection.
    */
-  public getConnection(): Connection {
+  public getConnection(apiVersion?: string): Connection {
+    if (apiVersion && this.connection.getApiVersion() !== apiVersion) {
+      this.connection.setApiVersion(apiVersion);
+    }
     return this.connection;
   }
 

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -879,9 +879,14 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
    * @param apiVersion The API version to use for the connection.
    */
   public getConnection(apiVersion?: string): Connection {
-    if (apiVersion && this.connection.getApiVersion() !== apiVersion) {
-      this.connection.setApiVersion(apiVersion);
+    if (apiVersion) {
+      if (this.connection.getApiVersion() === apiVersion) {
+        this.logger.warn(`Default API version is already ${apiVersion}`);
+      } else {
+        this.connection.setApiVersion(apiVersion);
+      }
     }
+
     return this.connection;
   }
 

--- a/test/unit/org/orgTest.ts
+++ b/test/unit/org/orgTest.ts
@@ -28,7 +28,7 @@ import { ConfigAggregator } from '../../../src/config/configAggregator';
 import { ConfigFile } from '../../../src/config/configFile';
 import { OrgUsersConfig } from '../../../src/config/orgUsersConfig';
 import { Global } from '../../../src/global';
-import { MockTestOrgData, shouldThrow, TestContext } from '../../../src/testSetup';
+import { MockTestOrgData, shouldThrow, shouldThrowSync, TestContext } from '../../../src/testSetup';
 import { MyDomainResolver } from '../../../src/status/myDomainResolver';
 import { StateAggregator } from '../../../src/stateAggregator';
 import { OrgConfigProperties } from '../../../src/org/orgConfigProperties';
@@ -64,6 +64,25 @@ describe('Org Tests', () => {
         }),
       });
     };
+  });
+
+  describe('api version', () => {
+    it('uses latest api version when undefined', async () => {
+      const org = await Org.create({ aliasOrUsername: testData.username });
+      expect(org.getConnection().getApiVersion()).to.equal('50.0');
+    });
+    it('uses specified api version if offered', async () => {
+      const org = await Org.create({ aliasOrUsername: testData.username });
+      expect(org.getConnection('53.0').getApiVersion()).to.equal('53.0');
+    });
+    it('handles bad data', async () => {
+      const org = await Org.create({ aliasOrUsername: testData.username });
+      try {
+        shouldThrowSync(() => org.getConnection('bad'));
+      } catch (err) {
+        // validation rules are tested other places, not going to duplicate here
+      }
+    });
   });
 
   describe('fields', () => {


### PR DESCRIPTION
### What does this PR do?
getConnection accepts an optional version
used for apiversion flag on sfCommand-based commands

### What issues does this PR fix or reference?
@W-12068411@
