### PR TITLE
feat: backward compatible messages.createError

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -548,14 +548,43 @@ export class Messages<T extends string> {
     exitCodeOrCause?: number | Error,
     cause?: Error
   ): SfError {
-    const structuredMessage = this.formatMessageContents('error', key, tokens, actionTokens);
-    return new SfError(
-      structuredMessage.message,
-      structuredMessage.name,
-      structuredMessage.actions,
-      exitCodeOrCause,
-      cause
-    );
+    const { message, name, actions } = this.formatMessageContents({
+      type: 'error',
+      key,
+      tokens,
+      actionTokens,
+    });
+    return new SfError(message, name, actions, exitCodeOrCause, cause);
+  }
+
+  /**
+   * SfError wants error to end with the word Error.  Use this to create errors while preserving their existing name (for compatibility reasons).
+   *
+   * @deprecated Use `createError` instead unless you need to preserver the error name to avoid breaking changes.
+   * `error.name` will be the upper-cased key, remove prefixed `error.` and will always end in Error.
+   * `error.actions` will be loaded using `${key}.actions` if available.
+   *
+   * @param key The key of the error message.
+   * @param tokens The error message tokens.
+   * @param actionTokens The action messages tokens.
+   * @param exitCodeOrCause The exit code which will be used by SfdxCommand or the underlying error that caused this error to be raised.
+   * @param cause The underlying error that caused this error to be raised.
+   */
+  public createErrorButPreserveName(
+    key: T,
+    tokens: Tokens = [],
+    actionTokens: Tokens = [],
+    exitCodeOrCause?: number | Error,
+    cause?: Error
+  ): SfError {
+    const { message, name, actions } = this.formatMessageContents({
+      type: 'error',
+      key,
+      tokens,
+      actionTokens,
+      preserveName: true,
+    });
+    return new SfError(message, name, actions, exitCodeOrCause, cause);
   }
 
   /**
@@ -569,7 +598,7 @@ export class Messages<T extends string> {
    * @param actionTokens The action messages tokens.
    */
   public createWarning(key: T, tokens: Tokens = [], actionTokens: Tokens = []): StructuredMessage {
-    return this.formatMessageContents('warning', key, tokens, actionTokens);
+    return this.formatMessageContents({ type: 'warning', key, tokens, actionTokens });
   }
 
   /**
@@ -583,7 +612,7 @@ export class Messages<T extends string> {
    * @param actionTokens The action messages tokens.
    */
   public createInfo(key: T, tokens: Tokens = [], actionTokens: Tokens = []): StructuredMessage {
-    return this.formatMessageContents('info', key, tokens, actionTokens);
+    return this.formatMessageContents({ type: 'info', key, tokens, actionTokens });
   }
 
   /**
@@ -596,13 +625,21 @@ export class Messages<T extends string> {
    * @param key The key of the warning message.
    * @param tokens The warning message tokens.
    * @param actionTokens The action messages tokens.
+   * @param preserveName Do not require that the name end in the type ('error' | 'warning' | 'info').
    */
-  private formatMessageContents(
-    type: 'error' | 'warning' | 'info',
-    key: T,
-    tokens: Tokens = [],
-    actionTokens: Tokens = []
-  ): StructuredMessage {
+  private formatMessageContents({
+    type,
+    key,
+    tokens = [],
+    actionTokens = [],
+    preserveName = false,
+  }: {
+    type: 'error' | 'warning' | 'info';
+    key: T;
+    tokens?: Tokens;
+    actionTokens?: Tokens;
+    preserveName?: boolean;
+  }): StructuredMessage {
     const label = upperFirst(type);
     const labelRegExp = new RegExp(`${label}$`);
     const searchValue: RegExp = type === 'error' ? /^error.*\./ : new RegExp(`^${type}.`);
@@ -610,7 +647,7 @@ export class Messages<T extends string> {
     //     'myMessage' -> `MyMessageWarning`
     //     'myMessageError' -> `MyMessageError`
     //     'warning.myMessage' -> `MyMessageWarning`
-    const name = `${upperFirst(key.replace(searchValue, ''))}${labelRegExp.exec(key) ? '' : label}`;
+    const name = `${upperFirst(key.replace(searchValue, ''))}${labelRegExp.exec(key) || preserveName ? '' : label}`;
     const message = this.getMessage(key, tokens);
     let actions;
     try {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -561,7 +561,7 @@ export class Messages<T extends string> {
    * SfError wants error to end with the word Error.  Use this to create errors while preserving their existing name (for compatibility reasons).
    *
    * @deprecated Use `createError` instead unless you need to preserver the error name to avoid breaking changes.
-   * `error.name` will be the upper-cased key, remove prefixed `error.` and will always end in Error.
+   * `error.name` will be the upper-cased key, remove prefixed `error.`.
    * `error.actions` will be loaded using `${key}.actions` if available.
    *
    * @param key The key of the error message.

--- a/test/unit/messagesTest.ts
+++ b/test/unit/messagesTest.ts
@@ -338,6 +338,16 @@ describe('Messages', () => {
       expect(error.actions[0]).to.equal(testMessages.msg2);
     });
 
+    it('creates error with actions (preserved name)', () => {
+      const messages = new Messages('myBundle', Messages.getLocale(), msgMap);
+      const error = messages.createErrorButPreserveName('msg1');
+
+      expect(error.name).to.equal('Msg1');
+      expect(error.message).to.equal(testMessages.msg1);
+      expect(error.actions.length).to.equal(1);
+      expect(error.actions[0]).to.equal(testMessages.msg2);
+    });
+
     it('creates error with removed error prefix', () => {
       msgMap.set('error.msg1', msgMap.get('msg1'));
       msgMap.set('error.msg1.actions', ['from prefix']);
@@ -345,6 +355,18 @@ describe('Messages', () => {
       const error = messages.createError('error.msg1');
 
       expect(error.name).to.equal('Msg1Error');
+      expect(error.message).to.equal(testMessages.msg1);
+      expect(error.actions.length).to.equal(1);
+      expect(error.actions[0]).to.equal('from prefix');
+    });
+
+    it('creates error with removed error prefix (preserved name)', () => {
+      msgMap.set('error.msg1', msgMap.get('msg1'));
+      msgMap.set('error.msg1.actions', ['from prefix']);
+      const messages = new Messages('myBundle', Messages.getLocale(), msgMap);
+      const error = messages.createErrorButPreserveName('error.msg1');
+
+      expect(error.name).to.equal('Msg1');
       expect(error.message).to.equal(testMessages.msg1);
       expect(error.actions.length).to.equal(1);
       expect(error.actions[0]).to.equal('from prefix');
@@ -358,6 +380,20 @@ describe('Messages', () => {
       const error = messages.createError('errors.msg1');
 
       expect(error.name).to.equal('Msg1Error');
+      expect(error.message).to.equal(testMessages.msg1);
+      expect(error.actions.length).to.equal(1);
+      expect(error.actions[0]).to.equal('from prefix');
+    });
+
+    it('creates error with removed errors prefix (preserved name)', () => {
+      msgMap.set('errors.msg1', msgMap.get('msg1'));
+      msgMap.set('errors.msg1.actions', ['from prefix']);
+      msgMap.set('errors.msg1', msgMap.get('msg1'));
+      msgMap.set('errors.msg1.actions', ['from prefix']);
+      const messages = new Messages('myBundle', Messages.getLocale(), msgMap);
+      const error = messages.createErrorButPreserveName('errors.msg1');
+
+      expect(error.name).to.equal('Msg1');
       expect(error.message).to.equal(testMessages.msg1);
       expect(error.actions.length).to.equal(1);
       expect(error.actions[0]).to.equal('from prefix');

--- a/test/unit/sfErrorTest.ts
+++ b/test/unit/sfErrorTest.ts
@@ -25,6 +25,12 @@ describe('SfError', () => {
       err.exitCode = 100;
       expect(err.exitCode).to.equal(100);
     });
+
+    it('does not change the error name if provided', () => {
+      const msg = 'this is a test message';
+      const err = new SfError(msg, 'myErrorName');
+      expect(err.name).to.equal('myErrorName');
+    });
   });
 
   describe('wrap', () => {


### PR DESCRIPTION
### What does this PR do?
messages.createError will tinker with the error key/name so that it ends in Error.  That's cool, unless you're trying to avoid breaking changes to JSON error output.

now you can avoid this pattern where you have to "fix" the name.

https://github.com/salesforcecli/plugin-trust/blob/3d6123010f0fc50203e1064ccd238b43c725c614/src/commands/plugins/trust/verify.ts#L77


### What issues does this PR fix or reference?
@W-12173611@
