### PR TITLE
fix: add password to mock org getConfig

### DIFF
--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -1128,6 +1128,10 @@ export class MockTestOrgData {
 
     config.isDevHub = this.isDevHub;
 
+    if (this.password) {
+      config.password = crypto.encrypt(this.password);
+    }
+
     return config as AuthFields;
   }
 


### PR DESCRIPTION
### What does this PR do?
Adds password to get config function in MockTestOrgData
### What issues does this PR fix or reference?
@W-12083436@