### PR TITLE
test: testsetup issue

### DIFF
--- a/test/unit/org/orgTest.ts
+++ b/test/unit/org/orgTest.ts
@@ -33,6 +33,7 @@ import { MyDomainResolver } from '../../../src/status/myDomainResolver';
 import { StateAggregator } from '../../../src/stateAggregator';
 import { OrgConfigProperties } from '../../../src/org/orgConfigProperties';
 import { Messages } from '../../../src/messages';
+import { SfError } from '../../../src/sfError';
 
 /* eslint-disable no-await-in-loop */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
@@ -154,6 +155,15 @@ describe('Org Tests', () => {
     it('should expose getOrgId', async () => {
       const org = await Org.create({ aliasOrUsername: testData.username });
       expect(org.getOrgId()).to.eq(testData.orgId);
+    });
+
+    it('should not create org when bad username', async () => {
+      try {
+        await shouldThrow(Org.create({ aliasOrUsername: 'bad@nope.fail' }));
+      } catch (err) {
+        assert(err instanceof SfError);
+        expect(err.name).to.equal('NamedOrgNotFound');
+      }
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
there's a problem with TestSetup where it should throw when use Org.create with bad usernames, but it's got a side effect of stubbing out those auth files when they're not found.  From debug...probably something in here: 

https://github.com/forcedotcom/sfdx-core/blob/3349e68b1a0a9cfdf500a2422380dcadae218cd5/src/testSetup.ts#L564

This test replicates the issue.  

### What issues does this PR fix or reference?
