### PR TITLE
fix: remove source tracking files with Org.delete()

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2022, Salesforce.com, Inc.
+Copyright (c) 2023, Salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -1470,10 +1470,9 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
         force: true,
       });
     } catch (e) {
+      const err = SfError.wrap(e as string | Error);
       // consume the error in case something  went wrong
-      this.logger.debug(
-        `error deleting source tracking information for ${this.getOrgId()} error: ${(e as Error).message}`
-      );
+      this.logger.debug(`error deleting source tracking information for ${this.getOrgId()} error: ${err.message}`);
     }
   }
 }

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -1466,12 +1466,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
     try {
       const rootFolder = await Config.resolveRootFolder(false);
       const orgPath = pathJoin(rootFolder, Global.SF_STATE_FOLDER, 'orgs', this.getOrgId());
-      await fs.promises.rm(pathJoin(orgPath, 'localSourceTracking'), { recursive: true });
-      await fs.promises.rm(pathJoin(orgPath, 'maxRevision.json'));
-      if (!(await fs.promises.readdir(orgPath))) {
-        // if the directory is now empty, remove it completely
-        await fs.promises.rm(orgPath, { recursive: true });
-      }
+      await fs.promises.rm(pathJoin(orgPath), { recursive: true, force: true });
     } catch (e) {
       // consume the error in case something  went wrong
       this.logger.debug(

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -1465,8 +1465,10 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
   private async removeSourceTrackingFiles(): Promise<void> {
     try {
       const rootFolder = await Config.resolveRootFolder(false);
-      const orgPath = pathJoin(rootFolder, Global.SF_STATE_FOLDER, 'orgs', this.getOrgId());
-      await fs.promises.rm(pathJoin(orgPath), { recursive: true, force: true });
+      await fs.promises.rm(pathJoin(rootFolder, Global.SF_STATE_FOLDER, 'orgs', this.getOrgId()), {
+        recursive: true,
+        force: true,
+      });
     } catch (e) {
       // consume the error in case something  went wrong
       this.logger.debug(

--- a/test/unit/org/orgTest.ts
+++ b/test/unit/org/orgTest.ts
@@ -280,9 +280,8 @@ describe('Org Tests', () => {
 
           expect(devHubDelete.calledOnce).to.be.true;
           expect(devHubDelete.firstCall.args[1]).to.equal(orgTestData.orgId);
-          expect(fsSpy.callCount).to.equal(2);
-          expect(fsSpy.firstCall.args[0]).to.include('localSourceTracking');
-          expect(fsSpy.secondCall.args[0]).to.include('maxRevision.json');
+          expect(fsSpy.callCount).to.equal(1);
+          expect(fsSpy.firstCall.args[0]).to.include(pathJoin('orgs', org.getOrgId()));
         });
 
         it('should not throw when attempting to delete the source tracking files', async () => {
@@ -306,7 +305,7 @@ describe('Org Tests', () => {
           expect(devHubDelete.calledOnce).to.be.true;
           expect(devHubDelete.firstCall.args[1]).to.equal(orgTestData.orgId);
           expect(fsSpy.callCount).to.equal(1);
-          expect(fsSpy.firstCall.args[0]).to.include('localSourceTracking');
+          expect(fsSpy.firstCall.args[0]).to.include(pathJoin('orgs', org.getOrgId()));
         });
 
         it('should handle INVALID_TYPE or INSUFFICIENT_ACCESS_OR_READONLY errors', async () => {

--- a/test/unit/org/orgTest.ts
+++ b/test/unit/org/orgTest.ts
@@ -260,6 +260,55 @@ describe('Org Tests', () => {
           expect(removeSpy.calledOnce).to.be.true;
         });
 
+        it('should delete the source tracking files', async () => {
+          const dev = await createOrgViaAuthInfo(testData.username);
+          const orgTestData = new MockTestOrgData();
+          const org = await createOrgViaAuthInfo(orgTestData.username, orgTestData);
+          const fsSpy = $$.SANDBOX.stub(fs.promises, 'rm');
+
+          const devHubQuery = stubMethod($$.SANDBOX, Connection.prototype, 'singleRecordQuery').resolves({
+            Id: orgTestData.orgId,
+          });
+          const devHubDelete = stubMethod($$.SANDBOX, Org.prototype, 'destroyScratchOrg').resolves();
+
+          await org.deleteFrom(dev);
+
+          expect(devHubQuery.calledOnce).to.be.true;
+          expect(devHubQuery.firstCall.args[0]).to.equal(
+            `SELECT Id FROM ActiveScratchOrg WHERE SignupUsername='${orgTestData.username}'`
+          );
+
+          expect(devHubDelete.calledOnce).to.be.true;
+          expect(devHubDelete.firstCall.args[1]).to.equal(orgTestData.orgId);
+          expect(fsSpy.callCount).to.equal(2);
+          expect(fsSpy.firstCall.args[0]).to.include('localSourceTracking');
+          expect(fsSpy.secondCall.args[0]).to.include('maxRevision.json');
+        });
+
+        it('should not throw when attempting to delete the source tracking files', async () => {
+          const dev = await createOrgViaAuthInfo(testData.username);
+          const orgTestData = new MockTestOrgData();
+          const org = await createOrgViaAuthInfo(orgTestData.username, orgTestData);
+          const fsSpy = $$.SANDBOX.stub(fs.promises, 'rm').throws('error');
+
+          const devHubQuery = stubMethod($$.SANDBOX, Connection.prototype, 'singleRecordQuery').resolves({
+            Id: orgTestData.orgId,
+          });
+          const devHubDelete = stubMethod($$.SANDBOX, Org.prototype, 'destroyScratchOrg').resolves();
+
+          await org.deleteFrom(dev);
+
+          expect(devHubQuery.calledOnce).to.be.true;
+          expect(devHubQuery.firstCall.args[0]).to.equal(
+            `SELECT Id FROM ActiveScratchOrg WHERE SignupUsername='${orgTestData.username}'`
+          );
+
+          expect(devHubDelete.calledOnce).to.be.true;
+          expect(devHubDelete.firstCall.args[1]).to.equal(orgTestData.orgId);
+          expect(fsSpy.callCount).to.equal(1);
+          expect(fsSpy.firstCall.args[0]).to.include('localSourceTracking');
+        });
+
         it('should handle INVALID_TYPE or INSUFFICIENT_ACCESS_OR_READONLY errors', async () => {
           const dev = await createOrgViaAuthInfo();
 


### PR DESCRIPTION
### What does this PR do?

removes source tracking information from the local project when `Org.delete()` is called

### What issues does this PR fix or reference?
@W-12375821@ https://github.com/forcedotcom/cli/issues/1879