### PR TITLE
Sm/better-project-error

### DIFF
--- a/src/sfProject.ts
+++ b/src/sfProject.ts
@@ -684,7 +684,9 @@ export class SfProject {
    */
   public getDefaultPackage(): NamedPackageDir {
     if (!this.hasPackages()) {
-      throw new SfError('The sfdx-project.json does not have any packageDirectories defined.');
+      throw new SfError('The sfdx-project.json does not have any packageDirectories defined.', 'NoPackageDirectories', [
+        `Check ${this.getPath()} for packageDirectories.`,
+      ]);
     }
     const defaultPackage = this.findPackage((packageDir) => packageDir.default === true);
     return defaultPackage ?? this.getPackageDirectories()[0];

--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -687,6 +687,8 @@ export const restoreContext = (testContext: TestContext): void => {
   testContext.configStubs = {};
   // Give each test run a clean StateAggregator
   StateAggregator.clearInstance();
+  // @ts-expect-error accessing a private property
+  SfProject.instances.clear();
   // Allow each test to have their own config aggregator
   // @ts-ignore clear for testing.
   delete ConfigAggregator.instance;

--- a/test/unit/projectTest.ts
+++ b/test/unit/projectTest.ts
@@ -8,10 +8,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 
 import { join, sep } from 'path';
-import { expect } from 'chai';
+import { expect, assert } from 'chai';
 
 import { env } from '@salesforce/kit';
-import { Messages, NamedPackageDir } from '../../src/exported';
+import { Messages, NamedPackageDir, SfError } from '../../src/exported';
 import { SfProject, SfProjectJson } from '../../src/sfProject';
 import { shouldThrow, shouldThrowSync, TestContext } from '../../src/testSetup';
 
@@ -430,6 +430,21 @@ describe('SfProject', () => {
         default: true,
       };
       expect(actual).to.deep.equal(expected);
+    });
+
+    it('defaultPackage should error when no package dirs', async () => {
+      $$.setConfigStubContents('SfProjectJson', {
+        contents: { packageDirectories: [] },
+      });
+      const project = await SfProject.resolve();
+
+      try {
+        shouldThrowSync(() => project.getDefaultPackage());
+      } catch (e) {
+        assert(e instanceof SfError);
+        expect(e.name).to.equal('NoPackageDirectories');
+        expect(e.actions).to.have.length.greaterThan(0);
+      }
     });
 
     it('should error when one package is defined and set to default=false', async () => {


### PR DESCRIPTION
### What does this PR do?
1. `sfProject/getDefaultPackage` error will say what file it's looking in but not finding a default
2.  TestSetup clears the SfProject instances, similar to wht we do for ConfigAggregator instances, so that subsequent use of `$$.setConfigStubContents('SfdxProjectJson')` aren't ignored

### What issues does this PR fix or reference?
[skip-validate-pr]