### PR TITLE
Fix logging loop

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -762,8 +762,10 @@ export class Logger {
    */
   public fatal(...args: unknown[]): Logger {
     // always show fatal to stderr
-    // eslint-disable-next-line no-console
-    console.error(...args);
+    // IMPORTANT:
+    // Do not use console.error() here, if fatal() is called from the uncaughtException handler, it
+    // will be re-thrown and caught again by the uncaughtException handler, causing an infinite loop.
+    console.log(...args); // eslint-disable-line no-console
     this.bunyan.fatal(this.applyFilters(LoggerLevel.FATAL, ...args));
     return this;
   }

--- a/test/unit/loggerTest.ts
+++ b/test/unit/loggerTest.ts
@@ -280,13 +280,7 @@ describe('Logger', () => {
 
     it('should apply for log level: error', () => runTest(['error', 50]));
 
-    it('should apply for log level: fatal', async () => {
-      // logger.fatal() necessarily writes to stderr so stub it here
-      $$.SANDBOX.stub(process.stderr, 'write');
-      await runTest(['fatal', 60]);
-      // @ts-expect-error: called is a sinon spy property
-      expect(process.stderr.write['called']).to.be.true;
-    });
+    it('should apply for log level: fatal', () => runTest(['fatal', 60]));
   });
 
   describe('addField', () => {


### PR DESCRIPTION
### What does this PR do?
On rare occasions an infinitely loop was created in our Logger class. The `console.error()` was being rethrown and caught again by the `uncaughtExceptionHandler`. A simple change to use `console.log()` prevents this loop. 

### What issues does this PR fix or reference?
[@W-13038000@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13038000)
Fixes https://github.com/forcedotcom/cli/issues/1942
Fixes https://github.com/forcedotcom/cli/issues/1408