### PR TITLE
Sm/handle unknown federated configs

### DIFF
--- a/src/config/configAggregator.ts
+++ b/src/config/configAggregator.ts
@@ -207,9 +207,12 @@ export class ConfigAggregator extends AsyncOptionalCreatable<ConfigAggregator.Op
         }
       }
       return match;
-    } else {
-      throw messages.createError('unknownConfigKey', [key]);
     }
+    const matchFromNewKey = this.getAllowedProperties().find((element) => key === element.newKey);
+    if (matchFromNewKey) {
+      return matchFromNewKey;
+    }
+    throw messages.createError('unknownConfigKey', [key]);
   }
 
   /**

--- a/test/unit/config/configAggregatorTest.ts
+++ b/test/unit/config/configAggregatorTest.ts
@@ -9,7 +9,7 @@
 import * as fs from 'fs';
 import { assert, expect, config as chaiConfig } from 'chai';
 import { Config, ConfigProperties, SFDX_ALLOWED_PROPERTIES, SfdxPropertyKeys } from '../../../src/config/config';
-import { ConfigAggregator } from '../../../src/config/configAggregator';
+import { ConfigAggregator, ConfigInfo } from '../../../src/config/configAggregator';
 import { ConfigFile } from '../../../src/config/configFile';
 import { Messages, OrgConfigProperties, Lifecycle, ORG_CONFIG_ALLOWED_PROPERTIES } from '../../../src/exported';
 import { TestContext } from '../../../src/testSetup';
@@ -22,6 +22,8 @@ chaiConfig.truncateThreshold = 0;
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/core', 'config');
 const envMessages = Messages.loadMessages('@salesforce/core', 'envVars');
+
+const telemtryConfigFilter = (i: ConfigInfo) => i.key !== 'disable-telemetry';
 
 describe('ConfigAggregator', () => {
   let id: string;
@@ -106,7 +108,7 @@ describe('ConfigAggregator', () => {
       $$.SANDBOX.stub(fs, 'readFile').resolves({});
 
       const aggregator = await ConfigAggregator.create();
-      const info = aggregator.getConfigInfo()[0];
+      const info = aggregator.getConfigInfo().filter(telemtryConfigFilter)[0];
       expect(info.key).to.equal('target-org');
       expect(info.value).to.equal('test');
       expect(info.location).to.equal('Environment');
@@ -116,7 +118,7 @@ describe('ConfigAggregator', () => {
       $$.SANDBOX.stub(fs.promises, 'readFile').resolves('{ "invalid": "entry", "org-api-version": 49.0 }');
 
       const aggregator = await ConfigAggregator.create();
-      const info = aggregator.getConfigInfo()[0];
+      const info = aggregator.getConfigInfo().filter(telemtryConfigFilter)[0];
       expect(info.key).to.equal('org-api-version');
       expect(info.value).to.equal(49.0);
       expect(info.location).to.equal('Local');


### PR DESCRIPTION
### What does this PR do?
one config (`RestDeploy`) is only in sfdx-core under its old name, but its "new name" equivalent moved moved to PDR's ConfigMeta https://github.com/salesforcecli/plugin-deploy-retrieve/blob/9043c4e82287d8b8ed6da3d91988d80dd4fdc994/src/configMeta.ts#L22

This makes ConfigAggregator a little smarter so it can fall back and not throw when it recognizes that scenario.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2127
[@W-13189905@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001RCgi0YAD/view)

QA: use the repro from the github issue 
you can yarn link this into plugin-signups and then plugins:link plugin-signups in your CLI