### PR TITLE
fix: use SF prefixed env vars, add UTs

### DIFF
--- a/src/status/myDomainResolver.ts
+++ b/src/status/myDomainResolver.ts
@@ -73,8 +73,9 @@ export class MyDomainResolver extends AsyncOptionalCreatable<MyDomainResolver.Op
    * executing the dns loookup.
    */
   public async resolve(): Promise<string> {
-    if (new Env().getBoolean('SFDX_DISABLE_DNS_CHECK', false)) {
-      this.logger.debug('SFDX_DISABLE_DNS_CHECK set to true. Skipping DNS check...');
+    const env = new Env();
+    if (env.getBoolean('SF_DISABLE_DNS_CHECK', env.getBoolean('SFDX_DISABLE_DNS_CHECK', false))) {
+      this.logger.debug('SF_DISABLE_DNS_CHECK set to true. Skipping DNS check...');
       return this.options.url.host;
     }
 

--- a/test/unit/status/myDomainResolverTest.ts
+++ b/test/unit/status/myDomainResolverTest.ts
@@ -50,9 +50,9 @@ describe('myDomainResolver', () => {
     it('should return host if SFDX_DISABLE_DNS_CHECK is set to true', async () => {
       expect(env.getBoolean('SFDX_DISABLE_DNS_CHECK')).to.be.false;
       expect(env.getBoolean('SF_DISABLE_DNS_CHECK')).to.be.false;
-      env.setBoolean('SF_DISABLE_DNS_CHECK', true);
-      expect(env.getBoolean('SF_DISABLE_DNS_CHECK')).to.be.true;
-      expect(env.getBoolean('SFDX_DISABLE_DNS_CHECK')).to.be.false;
+      env.setBoolean('SFDX_DISABLE_DNS_CHECK', true);
+      expect(env.getBoolean('SFDX_DISABLE_DNS_CHECK')).to.be.true;
+      expect(env.getBoolean('SF_DISABLE_DNS_CHECK')).to.be.false;
       const options: MyDomainResolver.Options = {
         url: new URL(`http://${POSITIVE_HOST}`),
         timeout: Duration.milliseconds(50),

--- a/test/unit/status/myDomainResolverTest.ts
+++ b/test/unit/status/myDomainResolverTest.ts
@@ -48,7 +48,11 @@ describe('myDomainResolver', () => {
   describe('disable dns check', () => {
     const env = new Env();
     it('should return host if SFDX_DISABLE_DNS_CHECK is set to true', async () => {
-      env.setBoolean('SFDX_DISABLE_DNS_CHECK', true);
+      expect(env.getBoolean('SFDX_DISABLE_DNS_CHECK')).to.be.false;
+      expect(env.getBoolean('SF_DISABLE_DNS_CHECK')).to.be.false;
+      env.setBoolean('SF_DISABLE_DNS_CHECK', true);
+      expect(env.getBoolean('SF_DISABLE_DNS_CHECK')).to.be.true;
+      expect(env.getBoolean('SFDX_DISABLE_DNS_CHECK')).to.be.false;
       const options: MyDomainResolver.Options = {
         url: new URL(`http://${POSITIVE_HOST}`),
         timeout: Duration.milliseconds(50),
@@ -58,6 +62,27 @@ describe('myDomainResolver', () => {
       const ip = await resolver.resolve();
       expect(ip).to.be.equal(POSITIVE_HOST);
       expect(lookupAsyncSpy.callCount).to.be.equal(0);
+      env.unset('SFDX_DISABLE_DNS_CHECK');
+      env.unset('SF_DISABLE_DNS_CHECK');
+    });
+
+    it('should return host if SF_DISABLE_DNS_CHECK is set to true', async () => {
+      expect(env.getBoolean('SFDX_DISABLE_DNS_CHECK')).to.be.false;
+      expect(env.getBoolean('SF_DISABLE_DNS_CHECK')).to.be.false;
+      env.setBoolean('SF_DISABLE_DNS_CHECK', true);
+      expect(env.getBoolean('SF_DISABLE_DNS_CHECK')).to.be.true;
+      expect(env.getBoolean('SFDX_DISABLE_DNS_CHECK')).to.be.false;
+      const options: MyDomainResolver.Options = {
+        url: new URL(`http://${POSITIVE_HOST}`),
+        timeout: Duration.milliseconds(50),
+        frequency: Duration.milliseconds(10),
+      };
+      const resolver: MyDomainResolver = await MyDomainResolver.create(options);
+      const ip = await resolver.resolve();
+      expect(ip).to.be.equal(POSITIVE_HOST);
+      expect(lookupAsyncSpy.callCount).to.be.equal(0);
+      env.unset('SFDX_DISABLE_DNS_CHECK');
+      env.unset('SF_DISABLE_DNS_CHECK');
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
adds a `SF_` equivalent env var
adds fall back to `SFDX_`

### What issues does this PR fix or reference?
@W-13171024@