### PR TITLE
fix: make typescript a regular dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ In your plugin or library,
 ```json
 {
   ...
-  "plugins": [{ "transform": "@salesforce/core", "import": "messageTransformer" }]
+  "plugins": [{ "transform": "@salesforce/core/lib/messageTransformer", "import": "messageTransformer" }]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "jsonwebtoken": "9.0.0",
     "jszip": "3.10.1",
     "proper-lockfile": "^4.1.2",
-    "ts-retry-promise": "^0.7.0"
+    "ts-retry-promise": "^0.7.0",
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@salesforce/dev-config": "^4.0.1",
@@ -88,7 +89,6 @@
     "sinon": "^14.0.2",
     "ts-node": "^10.4.0",
     "ttypescript": "^1.5.15",
-    "typescript": "^4.9.5",
     "wireit": "^0.9.5"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
     "jsonwebtoken": "9.0.0",
     "jszip": "3.10.1",
     "proper-lockfile": "^4.1.2",
-    "ts-retry-promise": "^0.7.0",
-    "typescript": "^4.9.5"
+    "ts-retry-promise": "^0.7.0"
   },
   "devDependencies": {
     "@salesforce/dev-config": "^4.0.1",
@@ -89,6 +88,7 @@
     "sinon": "^14.0.2",
     "ts-node": "^10.4.0",
     "ttypescript": "^1.5.15",
+    "typescript": "^4.9.5",
     "wireit": "^0.9.5"
   },
   "repository": {

--- a/src/exported.ts
+++ b/src/exported.ts
@@ -10,7 +10,6 @@ import { Messages } from './messages';
 Messages.importMessagesDirectory(__dirname);
 
 export { OAuth2Config } from 'jsforce';
-export { messageTransformer } from './messageTransformer';
 export { ConfigFile } from './config/configFile';
 
 export { TTLConfig } from './config/ttlConfig';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2676,7 +2676,7 @@ is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
-is-core-module@^2.11.0, is-core-module@^2.5.0, is-core-module@^2.9.0:
+is-core-module@^2.11.0, is-core-module@^2.5.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
   integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
@@ -3990,11 +3990,11 @@ resolve-global@1.0.0, resolve-global@^1.0.0:
     global-dirs "^0.1.1"
 
 resolve@>=1.9.0, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.22.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
-  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.2.tgz#0ed0943d4e301867955766c9f3e1ae6d01c6845f"
+  integrity sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==
   dependencies:
-    is-core-module "^2.9.0"
+    is-core-module "^2.11.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 


### PR DESCRIPTION
### What does this PR do?
because the messageTransformer uses TS, that needs to be a regular (nonDev) dep

### What issues does this PR fix or reference?
https://github.com/salesforcecli/plugin-deploy-retrieve/actions/runs/5257572625/jobs/9500678747?pr=659