### PR TITLE
fix: bump jsforce

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "faye": "^1.4.0",
     "form-data": "^4.0.0",
     "js2xmlparser": "^4.0.1",
-    "jsforce": "^2.0.0-beta.24",
+    "jsforce": "^2.0.0-beta.25",
     "jsonwebtoken": "9.0.0",
     "jszip": "3.10.1",
     "proper-lockfile": "^4.1.2",

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -25,7 +25,7 @@ import {
   Nullable,
   Optional,
 } from '@salesforce/ts-types';
-import { JwtOAuth2, JwtOAuth2Config, OAuth2, TokenResponse } from 'jsforce';
+import { OAuth2Config, OAuth2, TokenResponse } from 'jsforce';
 import Transport from 'jsforce/lib/transport';
 import * as jwt from 'jsonwebtoken';
 import { Config } from '../config/config';
@@ -109,6 +109,14 @@ export type AuthSideEffects = {
   setDefault: boolean;
   setDefaultDevHub: boolean;
   setTracksSource?: boolean;
+};
+
+export type JwtOAuth2Config = OAuth2Config & {
+  privateKey?: string;
+  privateKeyFile?: string;
+  authCode?: string;
+  refreshToken?: string;
+  username?: string;
 };
 
 type UserInfo = AnyJson & {
@@ -938,10 +946,14 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
       }
     );
 
-    const oauth2 = new JwtOAuth2({ loginUrl });
-    // jsforce has it types as any
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return ensureJsonMap(await oauth2.jwtAuthorize(jwtToken));
+    const oauth2 = new OAuth2({ loginUrl });
+    return ensureJsonMap(
+      await oauth2.requestToken({
+        // eslint-disable-next-line camelcase
+        grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+        assertion: jwtToken,
+      })
+    );
   }
 
   // Build OAuth config for a refresh token auth flow

--- a/src/org/scratchOrgInfoApi.ts
+++ b/src/org/scratchOrgInfoApi.ts
@@ -7,8 +7,9 @@
 
 import { env, Duration, upperFirst } from '@salesforce/kit';
 import { AnyJson } from '@salesforce/ts-types';
-import { OAuth2Config, JwtOAuth2Config, SaveResult } from 'jsforce';
+import { OAuth2Config, SaveResult } from 'jsforce';
 import { retryDecorator, RetryError } from 'ts-retry-promise';
+import { JwtOAuth2Config } from '../org/authInfo';
 import { Logger } from '../logger';
 import { Messages } from '../messages';
 import { SfError } from '../sfError';

--- a/src/org/scratchOrgLifecycleEvents.ts
+++ b/src/org/scratchOrgLifecycleEvents.ts
@@ -21,7 +21,7 @@ export const scratchOrgLifecycleStages = [
   'done',
 ] as const;
 export interface ScratchOrgLifecycleEvent {
-  stage: typeof scratchOrgLifecycleStages[number];
+  stage: (typeof scratchOrgLifecycleStages)[number];
   scratchOrgInfo?: ScratchOrgInfo;
 }
 
@@ -41,10 +41,10 @@ const postOrgCreateHookFields = [
   'username',
 ] as const;
 
-type PostOrgCreateHook = Pick<AuthFields, typeof postOrgCreateHookFields[number]>;
+type PostOrgCreateHook = Pick<AuthFields, (typeof postOrgCreateHookFields)[number]>;
 
-const isHookField = (key: string): key is typeof postOrgCreateHookFields[number] =>
-  postOrgCreateHookFields.includes(key as typeof postOrgCreateHookFields[number]);
+const isHookField = (key: string): key is (typeof postOrgCreateHookFields)[number] =>
+  postOrgCreateHookFields.includes(key as (typeof postOrgCreateHookFields)[number]);
 
 export const emitPostOrgCreate = async (authFields: AuthFields): Promise<void> => {
   await emitter.emit(

--- a/src/util/jsonXmlTools.ts
+++ b/src/util/jsonXmlTools.ts
@@ -41,7 +41,8 @@ export const writeJSONasXML = async ({
   return fs.writeFile(path, xml);
 };
 
-export const JsonAsXml = ({ json, type, options = standardOptions }: JSONasXML): string => jsToXml.parse(type, fixExistingDollarSign(json), options);
+export const JsonAsXml = ({ json, type, options = standardOptions }: JSONasXML): string =>
+  jsToXml.parse(type, fixExistingDollarSign(json), options);
 
 export const fixExistingDollarSign = (existing: WriteJSONasXMLInputs['json']): Record<string, unknown> => {
   const existingCopy = { ...existing } as Record<string, unknown>;

--- a/src/webOAuthServer.ts
+++ b/src/webOAuthServer.ts
@@ -12,7 +12,7 @@ import { parse as parseQueryString } from 'querystring';
 import { parse as parseUrl } from 'url';
 import { Socket } from 'net';
 import { EventEmitter } from 'events';
-import { JwtOAuth2Config, OAuth2 } from 'jsforce';
+import { OAuth2 } from 'jsforce';
 import { AsyncCreatable, Env, set, toNumber } from '@salesforce/kit';
 import { asString, get, Nullable } from '@salesforce/ts-types';
 import { Logger } from './logger';
@@ -20,6 +20,7 @@ import { AuthInfo, DEFAULT_CONNECTED_APP_INFO } from './org';
 import { SfError } from './sfError';
 import { Messages } from './messages';
 import { SfProjectJson } from './sfProject';
+import { JwtOAuth2Config } from './org/authInfo';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/core', 'auth');

--- a/test/unit/org/authInfoTest.ts
+++ b/test/unit/org/authInfoTest.ts
@@ -18,8 +18,9 @@ import { AnyJson, getJsonMap, JsonMap, toJsonMap } from '@salesforce/ts-types';
 import { expect } from 'chai';
 import { Transport } from 'jsforce/lib/transport';
 
-import { JwtOAuth2Config, OAuth2 } from 'jsforce';
+import { OAuth2 } from 'jsforce';
 import { SinonSpy, SinonStub } from 'sinon';
+import { JwtOAuth2Config } from '../../../src/org/authInfo';
 import { AuthFields, AuthInfo } from '../../../src/org';
 import { MockTestOrgData, shouldThrow, shouldThrowSync, TestContext } from '../../../src/testSetup';
 import { OrgConfigProperties } from '../../../src/org/orgConfigProperties';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,10 +2976,10 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-jsforce@^2.0.0-beta.24:
-  version "2.0.0-beta.24"
-  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-2.0.0-beta.24.tgz#fe054eb0f6f668eff10566e086892dd2387364f7"
-  integrity sha512-rbDC9Y054Ele3qlDyFZxFY6RRyqpH7DKPYhAwBM2TIzqOl9OG35EB4lnJLaIuv/MZVA2mvTIV/TwxVv8PiB1EA==
+jsforce@^2.0.0-beta.25:
+  version "2.0.0-beta.25"
+  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-2.0.0-beta.25.tgz#120a3999babf96ae18ab8f1232003d56588a9ca5"
+  integrity sha512-ZtzwJErI4SSJYWrGAw0mHEHPZRB4Idz0RiXHakCtEgEjEWt6JIDR4sNbWRHUzWHdEO4O61z2YSBvdOuag1hkWg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.5"


### PR DESCRIPTION
### What does this PR do?
bumps jsforce to latest beta.

the `JwtOAuth2` class was removed in favor of the `OAuth2` class in `jsforce`:
https://github.com/jsforce/jsforce/issues/1331
https://github.com/jsforce/jsforce/pull/1341

### What issues does this PR fix or reference?
[skip-validate-pr]