### PR TITLE
Wr/unset alias config

### DIFF
--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -1140,9 +1140,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
 
       // unset any configs referencing this org
       const config = await Config.create();
-      [...existingAliases, username]
-        .map((name) => config.getKeysByValue(name))
-        .map((keys) => keys.map((k) => config.unset(k)));
+      [...existingAliases, username].flatMap((name) => config.getKeysByValue(name)).map((key) => config.unset(key));
       await config.write();
 
       const activeScratchOrgRecordId = (


### PR DESCRIPTION
### What does this PR do?
when `Org.delete` is called, it will now unset any config values that reference the org (username or alias) and will unset an alias keys that are set to the org's username
### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2237
@W-13644800@