### PR TITLE
feat: save namespacePrefix in auth file

### DIFF
--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -963,6 +963,7 @@ export class MockTestOrgData {
   public isScratchOrg?: boolean;
   public isExpired?: boolean | 'unknown';
   public password?: string;
+  public namespacePrefix?: string;
 
   public constructor(id: string = uniqid(), options?: { username: string }) {
     this.testId = id;
@@ -977,6 +978,7 @@ export class MockTestOrgData {
     this.accessToken = `${this.testId}/accessToken`;
     this.refreshToken = `${this.testId}/refreshToken`;
     this.redirectUri = 'http://localhost:1717/OauthRedirect';
+    this.namespacePrefix = `acme_${this.testId}`;
   }
 
   /**

--- a/test/unit/org/authInfoTest.ts
+++ b/test/unit/org/authInfoTest.ts
@@ -1114,6 +1114,7 @@ describe('AuthInfo', () => {
         accessToken: '',
       });
       stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
+      stubMethod($$.SANDBOX, AuthInfo.prototype, 'getNamespacePrefix').resolves();
 
       await AuthInfo.create({
         username: testOrg.username,

--- a/test/unit/org/authInfoTest.ts
+++ b/test/unit/org/authInfoTest.ts
@@ -19,7 +19,7 @@ import { expect } from 'chai';
 import { Transport } from 'jsforce/lib/transport';
 
 import { OAuth2 } from 'jsforce';
-import { SinonSpy, SinonStub } from 'sinon';
+import { SinonSpy, SinonStub, match } from 'sinon';
 import { JwtOAuth2Config } from '../../../src/org/authInfo';
 import { AuthFields, AuthInfo } from '../../../src/org';
 import { MockTestOrgData, shouldThrow, shouldThrowSync, TestContext } from '../../../src/testSetup';
@@ -47,6 +47,7 @@ class AuthInfoMockOrg extends MockTestOrgData {
       privateKey: this.privateKey,
       username: this.username,
       orgId: this.orgId,
+      namespacePrefix: this.namespacePrefix,
     };
   }
 }
@@ -1408,6 +1409,61 @@ describe('AuthInfo', () => {
     it('should return true', async () => {
       await $$.stubAuths(testOrg);
       expect(await AuthInfo.hasAuthentications()).to.be.true;
+    });
+  });
+  describe('getNamespacePrefix', () => {
+    it('should get the namespace associated to the org', async () => {
+      $$.setConfigStubContents('AuthInfoConfig', { contents: await testOrg.getConfig() });
+
+      stubMethod($$.SANDBOX, Transport.prototype, 'httpRequest')
+        .withArgs(
+          match({
+            url: `${testOrg.instanceUrl}//services/data/v51.0/query?q=Select%20Namespaceprefix%20FROM%20Organization`,
+          })
+        )
+        .resolves({
+          statusCode: 200,
+          body: JSON.stringify({
+            records: [
+              {
+                NamespacePrefix: `acme_${testOrg.testId}`,
+              },
+            ],
+          }),
+        });
+      const authInfo = await AuthInfo.create({ username: testOrg.username });
+      // @ts-expect-error because private method
+      expect(await authInfo.getNamespacePrefix(testOrg.instanceUrl, testOrg.accessToken)).to.equal(
+        `acme_${testOrg.testId}`
+      );
+
+      expect(authInfo.getFields().namespacePrefix).to.equal(`acme_${testOrg.testId}`);
+    });
+    it('should not set namespace prop if org doesn not have one', async () => {
+      const orgConfig = await testOrg.getConfig();
+      orgConfig.namespacePrefix = undefined;
+      $$.setConfigStubContents('AuthInfoConfig', { contents: orgConfig });
+
+      stubMethod($$.SANDBOX, Transport.prototype, 'httpRequest')
+        .withArgs(
+          match({
+            url: `${testOrg.instanceUrl}//services/data/v51.0/query?q=Select%20Namespaceprefix%20FROM%20Organization`,
+          })
+        )
+        .resolves({
+          statusCode: 200,
+          body: JSON.stringify({
+            records: [
+              {
+                NamespacePrefix: null,
+              },
+            ],
+          }),
+        });
+      const authInfo = await AuthInfo.create({ username: testOrg.username });
+      // @ts-expect-error because private method
+      expect(await authInfo.getNamespacePrefix(testOrg.instanceUrl, testOrg.accessToken)).to.be.undefined;
+      expect(authInfo.getFields().namespacePrefix).to.be.undefined;
     });
   });
 

--- a/test/unit/org/userTest.ts
+++ b/test/unit/org/userTest.ts
@@ -182,6 +182,7 @@ describe('User Tests', () => {
           'auto-approve-user': '789101',
         },
       });
+      stubMethod($$.SANDBOX, AuthInfo.prototype, 'getNamespacePrefix').resolves();
 
       const org = await Org.create({
         connection: await Connection.create({


### PR DESCRIPTION
### What does this PR do?
Save the namespace prefix of an org in its auth file.
When creating an instance of `AuthInfo`, sfdx-core will query the namespace prefix of an org and save it as `namespacePrefix`.

`Organization` object:
https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_organization.htm

### What issues does this PR fix or reference?
@W-12709731@
@W-12709714@