### PR TITLE
fix: handle multiple sandbox processes in resumable state

### DIFF
--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -1346,9 +1346,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
     let waitingOnAuth = false;
     const pollingClient = await PollingClient.create({
       poll: async (): Promise<StatusResult> => {
-        const sandboxProcessObj = await this.querySandboxProcessBySandboxInfoId(
-          options.sandboxProcessObj.SandboxInfoId
-        );
+        const sandboxProcessObj = await this.querySandboxProcessById(options.sandboxProcessObj.Id);
         // check to see if sandbox can authenticate via sandboxAuth endpoint
         const sandboxInfo = await this.sandboxSignupComplete(sandboxProcessObj);
         if (sandboxInfo) {


### PR DESCRIPTION
### What does this PR do?
handle multiple sandbox processes in resumable state.  The error that happens has the SandboxProcesses added to err.data , and a resume lifecycle event is fired with that data for consumers to act on.

### What issues does this PR fix or reference?
@W-13635704@