### PR TITLE
Allow padding on id and secret

### DIFF
--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -362,7 +362,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     sfdxAuthUrl: string
   ): Pick<AuthFields, 'clientId' | 'clientSecret' | 'refreshToken' | 'loginUrl'> {
     const match = sfdxAuthUrl.match(
-      /^force:\/\/([a-zA-Z0-9._-]+):([a-zA-Z0-9._-]*):([a-zA-Z0-9._-]+={0,2})@([a-zA-Z0-9._-]+)/
+      /^force:\/\/([a-zA-Z0-9._-]+={0,2}):([a-zA-Z0-9._-]*={0,2}):([a-zA-Z0-9._-]+={0,2})@([a-zA-Z0-9._-]+)/
     );
 
     if (!match) {

--- a/test/unit/org/authInfoTest.ts
+++ b/test/unit/org/authInfoTest.ts
@@ -1669,16 +1669,18 @@ describe('AuthInfo', () => {
       expect(options.loginUrl).to.equal('https://test.my.salesforce.com');
     });
 
-    it('should parse the token that includes = for padding', () => {
+    it('should parse an id, secret, and token that include = for padding', () => {
       const options = AuthInfo.parseSfdxAuthUrl(
-        'force://PlatformCLI::5Aep861_OKMvio5gy8xCNsXxybPdupY9fVEZyeVOvb4kpOZx5Z1QLB7k7n5flEqEWKcwUQEX1I.O5DCFwjlYU==@test.my.salesforce.com'
+        'force://3MVG9SemV5D80oBfPBCgboxuJ9cOMLWNM1DDOZ8zgvJGsz13H3J66coUBCFF3N0zEgLYijlkqeWk4ot_Q2.4o=:438437816653243682==:5Aep861_OKMvio5gy8xCNsXxybPdupY9fVEZyeVOvb4kpOZx5Z1QLB7k7n5flEqEWKcwUQEX1I.O5DCFwjlYU==@test.my.salesforce.com'
       );
 
       expect(options.refreshToken).to.equal(
         '5Aep861_OKMvio5gy8xCNsXxybPdupY9fVEZyeVOvb4kpOZx5Z1QLB7k7n5flEqEWKcwUQEX1I.O5DCFwjlYU=='
       );
-      expect(options.clientId).to.equal('PlatformCLI');
-      expect(options.clientSecret).to.equal('');
+      expect(options.clientId).to.equal(
+        '3MVG9SemV5D80oBfPBCgboxuJ9cOMLWNM1DDOZ8zgvJGsz13H3J66coUBCFF3N0zEgLYijlkqeWk4ot_Q2.4o='
+      );
+      expect(options.clientSecret).to.equal('438437816653243682==');
       expect(options.loginUrl).to.equal('https://test.my.salesforce.com');
     });
 


### PR DESCRIPTION
### What does this PR do?
We had a report of a generated clientID including base64 padding. When the customer manually modified this regex, they were able to auth correctly

https://salesforce-internal.slack.com/archives/C01LKDT1P6J/p1696536487642619?thread_ts=1696521310.500989&cid=C01LKDT1P6J

### What issues does this PR fix or reference?
[@W-14250048@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14250048)
