### PR TITLE
refactor: crdt patterns on sfdxConfig

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -402,13 +402,12 @@ export class Config extends ConfigFile<ConfigFile.Options, ConfigProperties> {
    * Clear all the configured properties both local and global.
    */
   public static async clear(): Promise<void> {
-    const globalConfig = await Config.create({ isGlobal: true });
-    globalConfig.clear();
-    await globalConfig.write();
+    const [globalConfig, localConfig] = await Promise.all([Config.create({ isGlobal: true }), Config.create()]);
 
-    const localConfig = await Config.create();
+    globalConfig.clear();
     localConfig.clear();
-    await localConfig.write();
+
+    await Promise.all([globalConfig.write(), localConfig.write()]);
   }
 
   public static getPropertyConfigMeta(propertyName: string): Nullable<ConfigPropertyMeta> {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -18,7 +18,7 @@ import { ORG_CONFIG_ALLOWED_PROPERTIES, OrgConfigProperties } from '../org/orgCo
 import { Lifecycle } from '../lifecycleEvents';
 import { ConfigFile } from './configFile';
 import { ConfigContents, ConfigValue, Key } from './configStackTypes';
-import { LWWState, stateFromContents } from './lwwMap';
+import { LWWMap, LWWState, stateFromContents } from './lwwMap';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/core', 'config');
@@ -690,9 +690,13 @@ const writeToSfdx = async (path: string, contents: ConfigProperties): Promise<vo
 
 /** turn the sfdx config file into a LWWState based on its contents and its timestamp */
 const stateFromSfdxFileSync = (filePath: string, config: Config): LWWState<ConfigProperties> => {
-  const fileContents = fs.readFileSync(filePath, 'utf8');
-  const mtimeNs = fs.statSync(filePath, { bigint: true }).mtimeNs;
-  const translatedContents = translateToSf(parseJsonMap<ConfigProperties>(fileContents, filePath), config);
-  // get the file timestamp
-  return stateFromContents(translatedContents, mtimeNs);
+  try {
+    const fileContents = fs.readFileSync(filePath, 'utf8');
+    const mtimeNs = fs.statSync(filePath, { bigint: true }).mtimeNs;
+    const translatedContents = translateToSf(parseJsonMap<ConfigProperties>(fileContents, filePath), config);
+    // get the file timestamp
+    return stateFromContents(translatedContents, mtimeNs);
+  } catch (e) {
+    return {};
+  }
 };

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -18,7 +18,7 @@ import { ORG_CONFIG_ALLOWED_PROPERTIES, OrgConfigProperties } from '../org/orgCo
 import { Lifecycle } from '../lifecycleEvents';
 import { ConfigFile } from './configFile';
 import { ConfigContents, ConfigValue, Key } from './configStackTypes';
-import { LWWMap, LWWState, stateFromContents } from './lwwMap';
+import { LWWState, stateFromContents } from './lwwMap';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/core', 'config');

--- a/src/exported.ts
+++ b/src/exported.ts
@@ -104,6 +104,6 @@ export {
   scratchOrgLifecycleStages,
 } from './org/scratchOrgLifecycleEvents';
 export { ScratchOrgCache } from './org/scratchOrgCache';
+
 // Utility sub-modules
 export * from './util/sfdc';
-export * from './util/sfdcUrl';


### PR DESCRIPTION
### What does this PR do?
moves the sfdxConfig interop logic to the new CRDT pattern.
subsume sfdxConfig into some functions that Config can call 

