### PR TITLE
fix: handle alias file with no `orgs` prop

### DIFF
--- a/src/stateAggregator/accessors/aliasAccessor.ts
+++ b/src/stateAggregator/accessors/aliasAccessor.ts
@@ -281,11 +281,8 @@ const fileContentsRawToAliasStore = (contents: string): Map<string, string> => {
     [DEFAULT_GROUP]: { [alias: string]: string };
   };
 
-  // old alias file may not have `orgs` prop
-  if (!fileContents[DEFAULT_GROUP]) {
-    fileContents[DEFAULT_GROUP] = {};
-  }
-  return new Map(Object.entries(fileContents[DEFAULT_GROUP]));
+  // handle when alias file exists but is missing the org property
+  return new Map(Object.entries(fileContents[DEFAULT_GROUP] ?? {}));
 };
 
 const aliasStoreToRawFileContents = (aliasStore: Map<string, string>): string =>

--- a/src/stateAggregator/accessors/aliasAccessor.ts
+++ b/src/stateAggregator/accessors/aliasAccessor.ts
@@ -281,6 +281,10 @@ const fileContentsRawToAliasStore = (contents: string): Map<string, string> => {
     [DEFAULT_GROUP]: { [alias: string]: string };
   };
 
+  // old alias file may not have `orgs` prop
+  if (!fileContents[DEFAULT_GROUP]) {
+    fileContents[DEFAULT_GROUP] = {};
+  }
   return new Map(Object.entries(fileContents[DEFAULT_GROUP]));
 };
 


### PR DESCRIPTION
### What does this PR do?
makes the alias accessor handle alias files that don't have the `orgs property (we got 2 reports happening where they get a alias file with `{}` as the content, should also fix users on the old key:value alias file format).

## repro:
write `{}` to your alias file (~/.sfdx/alias.json)
run `SF_ENV=development sf alias list`, see error

then if you link this branch of core into plugin-settings, with the same alias file you shouldn't get the error.

### expected 
sfdx-core handles bad alias file, returns "no alias found"

### actual result
```
*** Internal Diagnostic ***

TypeError: Cannot convert undefined or null to object
    at Function.entries (<anonymous>)
    at fileContentsRawToAliasStore (/Users/cdominguez/.nvm/versions/node/v18.17.0/lib/node_modules/@salesforce/c
li/node_modules/@salesforce/core/lib/stateAggregator/accessors/aliasAccessor.js:245:27)
    at AliasAccessor.readFileToAliasStore (/Users/cdominguez/.nvm/versions/node/v18.17.0/lib/node_modules/@sales
force/cli/node_modules/@salesforce/core/lib/stateAggregator/accessors/aliasAccessor.js:187:31)
    at async AliasAccessor.init (/Users/cdominguez/.nvm/versions/node/v18.17.0/lib/node_modules/@salesforce/cli/
node_modules/@salesforce/core/lib/stateAggregator/accessors/aliasAccessor.js:176:9)
    at async AliasAccessor.create (/Users/cdominguez/.nvm/versions/node/v18.17.0/lib/node_modules/@salesforce/cl
i/node_modules/@salesforce/kit/lib/creatable.js:57:9)
    at async StateAggregator.init (/Users/cdominguez/.nvm/versions/node/v18.17.0/lib/node_modules/@salesforce/cl
i/node_modules/@salesforce/core/lib/stateAggregator/stateAggregator.js:40:24)
    at async StateAggregator.create (/Users/cdominguez/.nvm/versions/node/v18.17.0/lib/node_modules/@salesforce/
cli/node_modules/@salesforce/kit/lib/creatable.js:57:9)
    at async StateAggregator.getInstance (/Users/cdominguez/.nvm/versions/node/v18.17.0/lib/node_modules/@salesf
orce/cli/node_modules/@salesforce/core/lib/stateAggregator/stateAggregator.js:24:66)
    at async AliasList.run (/Users/cdominguez/.nvm/versions/node/v18.17.0/lib/node_modules/@salesforce/cli/node_
modules/@salesforce/plugin-settings/lib/commands/alias/list.js:17:33)
    at async AliasList._run (/Users/cdominguez/.nvm/versions/node/v18.17.0/lib/node_modules/@salesforce/cli/node
_modules/@salesforce/plugin-settings/node_modules/@oclif/core/lib/command.js:117:22)
******
```

### What issues does this PR fix or reference?
@W-14365013@