### PR TITLE
Sm/handle http error responses

### DIFF
--- a/messages/org.md
+++ b/messages/org.md
@@ -74,4 +74,4 @@ Unexpected response from the platform
 
 - Check that the instance URL is correct and the org still exists.
 
-See what's at the URL that's causing the problem: %s.
+- See what's at the URL that's causing the problem: %s.

--- a/messages/org.md
+++ b/messages/org.md
@@ -65,3 +65,13 @@ We found more than one SandboxProcess with the SandboxName %s.
 # sandboxNotResumable
 
 The sandbox %s cannot resume with status of %s.
+
+# UnexpectedResponse
+
+Unexpected response from the platform
+
+# UnexpectedResponse.actions
+
+- Check that the instance URL is correct and the org still exists.
+
+See what's at the URL that's causing the problem: %s.

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -705,15 +705,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
       // an html error page like https://computing-connect-6970-dev-ed.scratch.my.salesforce.com/services/data/v50.0
       // where the message is an entire html page
       if (e instanceof Error && (e.name.includes('ERROR_HTTP') || e.message.includes('<html '))) {
-        throw new SfError(
-          'Unexpected response from the platform',
-          'UnexpectedResponse',
-          [
-            'Check that the instance URL is correct and the org still exists.',
-            `See what's at the URL that's causing the problem: ${conn.baseUrl()}`,
-          ],
-          e
-        );
+        throw messages.createError('UnexpectedResponse', [], [conn.baseUrl()], e);
       }
       throw e;
     }

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -699,7 +699,24 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
       method: 'GET',
     };
     const conn = this.getConnection();
-    await conn.request(requestInfo);
+    try {
+      await conn.request(requestInfo);
+    } catch (e) {
+      // an html error page like https://computing-connect-6970-dev-ed.scratch.my.salesforce.com/services/data/v50.0
+      // where the message is an entire html page
+      if (e instanceof Error && (e.name.includes('ERROR_HTTP') || e.message.includes('<html '))) {
+        throw new SfError(
+          'Unexpected response from the platform',
+          'UnexpectedResponse',
+          [
+            'Check that the instance URL is correct and the org still exists.',
+            `See what's at the URL that's causing the problem: ${conn.baseUrl()}`,
+          ],
+          e
+        );
+      }
+      throw e;
+    }
   }
 
   /**


### PR DESCRIPTION
### What does this PR do?
this does NOT require the corresponding jsforce change to be merged, and should work with no changes to jsforce
https://github.com/jsforce/jsforce/pull/1376

handles html responses from expired/deleted orgs where the 420 error page is now present
https://computing-connect-6970-dev-ed.scratch.my.salesforce.com/services/data/v50.0

before
<img width="633" alt="Screenshot 2023-11-09 at 9 42 59 AM" src="https://github.com/forcedotcom/sfdx-core/assets/4261788/a1e7c998-af05-4567-a06c-534cf5449dcc">

after
<img width="1282" alt="Screenshot 2023-11-09 at 9 54 21 AM" src="https://github.com/forcedotcom/sfdx-core/assets/4261788/e88c0f0b-e2a9-4dce-8251-05a93165d8df">

QA:
create org
delete org
sf org open -o deletedOrg

### What issues does this PR fix or reference?
[@W-14454889@](https://gus.lightning.force.com/a07EE00001e6yycYAA)