### PR TITLE
fix: write safety and valid typing for sfProject

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ts-retry-promise": "^0.7.1"
   },
   "devDependencies": {
-    "@salesforce/dev-scripts": "^6.0.3",
+    "@salesforce/dev-scripts": "^6.0.4",
     "@salesforce/ts-sinon": "^1.4.19",
     "@types/benchmark": "^2.1.3",
     "@types/chai-string": "^1.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -516,21 +516,21 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@salesforce/dev-config@^4.0.1":
+"@salesforce/dev-config@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@salesforce/dev-config/-/dev-config-4.1.0.tgz#e529576466d074e7a5f1441236510fef123da01e"
   integrity sha512-2iDDepiIwjXHS5IVY7pwv8jMo4xWosJ7p/UTj+lllpB/gnJiYLhjJPE4Z3FCGFKyvfg5jGaimCd8Ca6bLGsCQA==
 
-"@salesforce/dev-scripts@^6.0.3":
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/@salesforce/dev-scripts/-/dev-scripts-6.0.3.tgz#6cf4504fd0ec8b4685e729b26685eed60f9c8b26"
-  integrity sha512-WLl1N07oNeRywdypwUrebX/kCkSm3IzmAQpUt4q4Sk8r4vTWv5b6F0pHLv0pGS8/QWNJT7xWGZDF1lgJBHOsmA==
+"@salesforce/dev-scripts@^6.0.4":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/dev-scripts/-/dev-scripts-6.0.4.tgz#0043b8ef4b970f8c2f945cc74eada3b1db52fa9a"
+  integrity sha512-/kdl99bHaNeCoVwfeQhIaKzorcmgpe/nZhlT7ru+If+18NRvBgW5OGmh++Q/NsraaYbsQ/0cDcGNz1dnQ11weA==
   dependencies:
     "@commitlint/cli" "^17.1.2"
     "@commitlint/config-conventional" "^17.1.0"
-    "@salesforce/dev-config" "^4.0.1"
+    "@salesforce/dev-config" "^4.1.0"
     "@salesforce/prettier-config" "^0.0.3"
-    "@types/chai" "^4.2.11"
+    "@types/chai" "^4.3.9"
     "@types/mocha" "^10.0.3"
     "@types/node" "^18"
     "@types/sinon" "^10.0.20"
@@ -670,10 +670,15 @@
   dependencies:
     "@types/chai" "*"
 
-"@types/chai@*", "@types/chai@^4.2.11":
+"@types/chai@*":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.1.tgz#e2c6e73e0bdeb2521d00756d099218e9f5d90a04"
   integrity sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==
+
+"@types/chai@^4.3.9":
+  version "4.3.10"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.10.tgz#2ad2959d1767edee5b0e4efb1a0cd2b500747317"
+  integrity sha512-of+ICnbqjmFCiixUnqRulbylyXQrPqIGf/B3Jax1wIF3DvSheysQxAWvqHhZiW3IQrycvokcLcFQlveGp+vyNg==
 
 "@types/json-schema@^7.0.12":
   version "7.0.15"


### PR DESCRIPTION
### What does this PR do?
use a Type for SfProject (the existing type extended ConfigContents so it's pretty open already).

modify `addPackageDirectory` to use `set` instead of relying on side-effect-mutations to the result of getContents so that the update matches the CRDT pattern.
- this was missed because, though getContents is ReadOnly, the operation was modifying mutable stuff within the object.  

### What issues does this PR fix or reference?
@W-14085765@