### PR TITLE
fix: set stack to fullStack if set

### DIFF
--- a/src/sfError.ts
+++ b/src/sfError.ts
@@ -72,6 +72,9 @@ export class SfError extends NamedError {
     } else {
       this.exitCode = 1;
     }
+    if (this.fullStack) {
+      this.stack = this.fullStack;
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
### What does this PR do?
`SfError.fullStack` is unknown by most (if not all) consumers of it.  The reason for creating an SfError with a caused by error is to add the cause error stack to the new stack.  Not sure what other reason there would be.  This change sets the `SfError.stack` to be the same as `SfError.fullStack`

[skip-validate-pr]