### PR TITLE
feat: set more scratch org props at creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/core",
-  "version": "6.2.2",
+  "version": "6.2.3-qa.0",
   "description": "Core libraries to interact with SFDX projects, orgs, and APIs.",
   "main": "lib/exported",
   "types": "lib/exported.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/core",
-  "version": "6.2.3-qa.1",
+  "version": "6.2.2",
   "description": "Core libraries to interact with SFDX projects, orgs, and APIs.",
   "main": "lib/exported",
   "types": "lib/exported.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/core",
-  "version": "6.2.1",
+  "version": "6.2.2-qa.0",
   "description": "Core libraries to interact with SFDX projects, orgs, and APIs.",
   "main": "lib/exported",
   "types": "lib/exported.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/core",
-  "version": "6.2.3-qa.0",
+  "version": "6.2.3-qa.1",
   "description": "Core libraries to interact with SFDX projects, orgs, and APIs.",
   "main": "lib/exported",
   "types": "lib/exported.d.ts",

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -686,8 +686,8 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
         [Org.Fields.NAME]: organization.Name,
         [Org.Fields.INSTANCE_NAME]: organization.InstanceName,
         [Org.Fields.NAMESPACE_PREFIX]: organization.NamespacePrefix,
-        [Org.Fields.IS_SANDBOX]: organization.IsSandbox && Boolean(organization.TrialExpirationDate),
-        [Org.Fields.IS_SCRATCH]: organization.IsSandbox && !organization.TrialExpirationDate,
+        [Org.Fields.IS_SANDBOX]: organization.IsSandbox && !organization.TrialExpirationDate,
+        [Org.Fields.IS_SCRATCH]: organization.IsSandbox && Boolean(organization.TrialExpirationDate),
         [Org.Fields.TRIAL_EXPIRATION_DATE]: organization.TrialExpirationDate,
       };
       const stateAggregator = await StateAggregator.getInstance();

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -721,15 +721,11 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
     const thisUsername = ensure(this.getUsername());
     const usernames: JsonArray = ensureJsonArray(contents.usernames ?? [thisUsername]);
     return Promise.all(
-      usernames.map((username) => {
-        if (username === thisUsername) {
-          return AuthInfo.create({
-            username: this.getConnection().getUsername(),
-          });
-        } else {
-          return AuthInfo.create({ username: ensureString(username) });
-        }
-      })
+      usernames.map((username) =>
+        AuthInfo.create({
+          username: username === thisUsername ? this.getConnection().getUsername() : ensureString(username),
+        })
+      )
     );
   }
 

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -1564,7 +1564,7 @@ export namespace Org {
      */
     IS_SCRATCH = 'isScratch',
     /**
-     * Is the current org a dev hub org. e.g. Organization has IsSandbox == true and TrialExpirationDate == null.
+     * Is the current org a sandbox (not a scratch org on a non-prod instance), but an actual Sandbox org). e.g. Organization has IsSandbox == true and TrialExpirationDate == null.
      */
     IS_SANDBOX = 'isSandbox',
     /**

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -669,14 +669,15 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
    * This method populates/updates the filesystem from information retrieved from the org.
    */
   public async updateLocalInformation(): Promise<
-    | {
-        name: string;
-        instanceName: string;
-        namespacePrefix: string | null;
-        isSandbox: boolean;
-        isScratch: boolean;
-        trailExpirationDate: string | null;
-      }
+    | Pick<
+        AuthFields,
+        | Org.Fields.NAME
+        | Org.Fields.INSTANCE_NAME
+        | Org.Fields.NAMESPACE_PREFIX
+        | Org.Fields.IS_SANDBOX
+        | Org.Fields.IS_SCRATCH
+        | Org.Fields.TRIAL_EXPIRATION_DATE
+      >
     | undefined
   > {
     const username = this.getUsername();

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -630,7 +630,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
   public async determineIfScratch(): Promise<boolean> {
     let cache = this.getField(Org.Fields.IS_SCRATCH);
 
-    if (!cache) {
+    if (cache === undefined) {
       await this.updateLocalInformation();
       cache = this.getField(Org.Fields.IS_SCRATCH);
     }
@@ -647,7 +647,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
   public async determineIfSandbox(): Promise<boolean> {
     let cache = this.getField(Org.Fields.IS_SANDBOX);
 
-    if (!cache) {
+    if (cache === undefined) {
       await this.updateLocalInformation();
       cache = this.getField(Org.Fields.IS_SANDBOX);
     }
@@ -877,11 +877,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
    * Returns a map of requested fields.
    */
   public getFields(keys: Org.Fields[]): JsonMap {
-    const json: JsonMap = {};
-    return keys.reduce((map, key) => {
-      map[key] = this.getField(key);
-      return map;
-    }, json);
+    return Object.fromEntries(keys.map((key) => [key, this.getField(key)]));
   }
 
   /**

--- a/src/org/scratchOrgInfoApi.ts
+++ b/src/org/scratchOrgInfoApi.ts
@@ -232,7 +232,11 @@ export const authorizeScratchOrg = async (options: {
     clientId: scratchOrgInfoComplete.ConnectedAppConsumerKey,
     createdOrgInstance: scratchOrgInfoComplete.SignupInstance,
     isDevHub: false,
-    snapshot: scratchOrgInfoComplete.Snapshot,
+    isScratch: true,
+    isSandbox: false,
+    // omit optional fields unless they are present
+    ...(scratchOrgInfoComplete.Namespace ? { namespacePrefix: scratchOrgInfoComplete.Namespace } : {}),
+    ...(scratchOrgInfoComplete.Snapshot ? { snapshot: scratchOrgInfoComplete.Snapshot } : {}),
   });
 
   return authInfo;


### PR DESCRIPTION
### What does this PR do?

1. set the isScratch/isSandox/Namespace Org props during scratch org creation, along with snapshot being omitted if null.
1. only query the server for orgs with those props missing--current code was querying in the case of `false`

### What issues does this PR fix or reference?
kinda found this doing @W-14542428@