### PR TITLE
fix: remove slash char from error message

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2023, Salesforce.com, Inc.
+Copyright (c) 2024, Salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/src/webOAuthServer.ts
+++ b/src/webOAuthServer.ts
@@ -213,7 +213,7 @@ export class WebOAuthServer extends AsyncCreatable<WebOAuthServer.Options> {
   private parseAuthCodeFromRequest(response: http.ServerResponse, request: WebOAuthServer.Request): Nullable<string> {
     if (!this.validateState(request)) {
       const error = new SfError('urlStateMismatch');
-      this.webServer.sendError(400, `${error.message}\n`, response);
+      this.webServer.sendError(400, error.message, response);
       this.closeRequest(request);
       this.logger.warn('urlStateMismatchAttempt detected.');
       if (!get(this.webServer.server, 'urlStateMismatchAttempt')) {


### PR DESCRIPTION
### What does this PR do?
`ServerResponse.writeHead()` does not like slash characters so just remove it.

### What issues does this PR fix or reference?
@W-14756275@