### PR TITLE
feat(scratch): add `org-capitalize-record-types`

### DIFF
--- a/messages/config.md
+++ b/messages/config.md
@@ -151,6 +151,10 @@ A valid repository URL or directory for the custom org metadata templates.
 
 A valid repository URL or directory for the custom org metadata templates.
 
+# org-capitalize-record-types
+
+Whether record types are capitalized on scrach org creation.
+
 # invalidId
 
 The given id %s is not a valid 15 or 18 character Salesforce ID.

--- a/messages/config.md
+++ b/messages/config.md
@@ -153,7 +153,7 @@ A valid repository URL or directory for the custom org metadata templates.
 
 # org-capitalize-record-types
 
-Whether record types are capitalized on scrach org creation.
+Whether record types are capitalized on scratch org creation.
 
 # invalidId
 

--- a/messages/envVars.md
+++ b/messages/envVars.md
@@ -314,4 +314,4 @@ Your environment has both variables populated, and with different values. The va
 
 # sfCapitalizeRecordTypes
 
-Whether record types are capitalized on scrach org creation.
+Whether record types are capitalized on scratch org creation.

--- a/messages/envVars.md
+++ b/messages/envVars.md
@@ -311,3 +311,7 @@ Deprecated environment variable: %s. Please use %s instead.
 Deprecated environment variable: %s. Please use %s instead.
 
 Your environment has both variables populated, and with different values. The value from %s will be used.
+
+# sfCapitalizeRecordTypes
+
+Boolean indicating whether or not to capitalize object settings.

--- a/messages/envVars.md
+++ b/messages/envVars.md
@@ -314,4 +314,4 @@ Your environment has both variables populated, and with different values. The va
 
 # sfCapitalizeRecordTypes
 
-Boolean indicating whether or not to capitalize object settings.
+Whether record types are capitalized on scrach org creation.

--- a/messages/scratchOrgSettingsGenerator.md
+++ b/messages/scratchOrgSettingsGenerator.md
@@ -1,0 +1,4 @@
+# noCapitalizeRecordTypeConfigVar
+
+Record types defined in the scratch org definition file will stop being capitalized by default in a future release.
+Set the `org-capitalize-record-types` config var to `true` to enforce capitalization.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/core",
-  "version": "6.4.7",
+  "version": "6.4.8-dev.0",
   "description": "Core libraries to interact with SFDX projects, orgs, and APIs.",
   "main": "lib/exported",
   "types": "lib/exported.d.ts",

--- a/src/config/envVars.ts
+++ b/src/config/envVars.ts
@@ -91,6 +91,7 @@ export enum EnvironmentVariable {
   'SF_UPDATE_INSTRUCTIONS' = 'SF_UPDATE_INSTRUCTIONS',
   'SF_INSTALLER' = 'SF_INSTALLER',
   'SF_ENV' = 'SF_ENV',
+  'SF_CAPITALIZE_RECORD_TYPES' = 'SF_CAPITALIZE_RECORD_TYPES',
 }
 type EnvMetaData = {
   description: string;
@@ -415,6 +416,10 @@ export const SUPPORTED_ENV_VARS: EnvType = {
   },
   [EnvironmentVariable.SF_ENV]: {
     description: getMessage(EnvironmentVariable.SF_ENV),
+    synonymOf: null,
+  },
+  [EnvironmentVariable.SF_CAPITALIZE_RECORD_TYPES]: {
+    description: getMessage(EnvironmentVariable.SF_CAPITALIZE_RECORD_TYPES),
     synonymOf: null,
   },
 };

--- a/src/org/orgConfigProperties.ts
+++ b/src/org/orgConfigProperties.ts
@@ -57,7 +57,7 @@ export enum OrgConfigProperties {
 export const ORG_CONFIG_ALLOWED_PROPERTIES = [
   {
     key: OrgConfigProperties.ORG_CAPITALIZE_RECORD_TYPES,
-    description: messages.getMessage(OrgConfigProperties.ORG_CUSTOM_METADATA_TEMPLATES),
+    description: messages.getMessage(OrgConfigProperties.ORG_CAPITALIZE_RECORD_TYPES),
   },
   {
     key: OrgConfigProperties.ORG_CUSTOM_METADATA_TEMPLATES,

--- a/src/org/orgConfigProperties.ts
+++ b/src/org/orgConfigProperties.ts
@@ -48,9 +48,17 @@ export enum OrgConfigProperties {
    * The url for the debugger configuration.
    */
   ORG_ISV_DEBUGGER_URL = 'org-isv-debugger-url',
+  /**
+   * Capitalize record types when deploying scratch org settings
+   */
+  ORG_CAPITALIZE_RECORD_TYPES = 'org-capitalize-record-types',
 }
 
 export const ORG_CONFIG_ALLOWED_PROPERTIES = [
+  {
+    key: OrgConfigProperties.ORG_CAPITALIZE_RECORD_TYPES,
+    description: messages.getMessage(OrgConfigProperties.ORG_CUSTOM_METADATA_TEMPLATES),
+  },
   {
     key: OrgConfigProperties.ORG_CUSTOM_METADATA_TEMPLATES,
     description: messages.getMessage(OrgConfigProperties.ORG_CUSTOM_METADATA_TEMPLATES),

--- a/src/org/scratchOrgCreate.ts
+++ b/src/org/scratchOrgCreate.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Duration } from '@salesforce/kit';
+import { Duration, toBoolean } from '@salesforce/kit';
 import { ensureString } from '@salesforce/ts-types';
 import { Messages } from '../messages';
 import { Logger } from '../logger/logger';
@@ -229,7 +229,12 @@ export const scratchOrgCreate = async (options: ScratchOrgCreateOptions): Promis
   });
 
   // gets the scratch org settings (will use in both signup paths AND to deploy the settings)
-  const settingsGenerator = new SettingsGenerator();
+  const settingsGenerator = new SettingsGenerator({
+    capitalizeRecordTypes: toBoolean(
+      (await ConfigAggregator.create()).getInfo('org-capitalize-record-types').value ?? true
+    ),
+  });
+
   const settings = await settingsGenerator.extract(scratchOrgInfo);
   logger.debug(`the scratch org def file has settings: ${settingsGenerator.hasSettings()}`);
 

--- a/src/org/scratchOrgCreate.ts
+++ b/src/org/scratchOrgCreate.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Duration } from '@salesforce/kit';
+import { Duration, toBoolean } from '@salesforce/kit';
 import { ensureString } from '@salesforce/ts-types';
 import { Messages } from '../messages';
 import { Logger } from '../logger/logger';
@@ -341,5 +341,10 @@ const getSignupTargetLoginUrl = async (): Promise<string | undefined> => {
 
 async function getCapitalizeRecordTypesConfig(): Promise<boolean | undefined> {
   const configAgg = await ConfigAggregator.create();
-  return configAgg.getInfo('org-capitalize-record-types').value as boolean | undefined;
+  const value = configAgg.getInfo('org-capitalize-record-types').value as string | undefined;
+
+  if (value !== undefined) return toBoolean(value);
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  return value as undefined;
 }

--- a/src/org/scratchOrgSettingsGenerator.ts
+++ b/src/org/scratchOrgSettingsGenerator.ts
@@ -82,13 +82,19 @@ export const createObjectFileContent = ({
   return { ...output, ...{ version: apiVersion } };
 };
 
-const calculateBusinessProcess = (objectName: string, defaultRecordType: string): Array<string | null> => {
+const calculateBusinessProcess = (
+  objectName: string,
+  defaultRecordType: string,
+  capitalizeBusinessProcess: boolean
+): Array<string | null> => {
   let businessProcessName = null;
   let businessProcessPicklistVal = null;
   // These four objects require any record type to specify a "business process"--
   // a restricted set of items from a standard picklist on the object.
   if (['Case', 'Lead', 'Opportunity', 'Solution'].includes(objectName)) {
-    businessProcessName = upperFirst(defaultRecordType) + 'Process';
+    businessProcessName = capitalizeBusinessProcess
+      ? `${upperFirst(defaultRecordType)}Process`
+      : `${defaultRecordType}Process`;
     switch (objectName) {
       case 'Case':
         businessProcessPicklistVal = 'New';
@@ -110,7 +116,8 @@ export const createRecordTypeAndBusinessProcessFileContent = (
   objectName: string,
   json: Record<string, unknown>,
   allRecordTypes: string[],
-  allBusinessProcesses: string[]
+  allBusinessProcesses: string[],
+  capitalizeRecordTypes: boolean
 ): JsonMap => {
   let output = {
     '@': {
@@ -126,15 +133,23 @@ export const createRecordTypeAndBusinessProcessFileContent = (
     };
   }
 
-  const defaultRecordType = json.defaultRecordType;
+  const defaultRecordType = capitalizeRecordTypes
+    ? upperFirst(json.defaultRecordType as string)
+    : json.defaultRecordType;
+
   if (typeof defaultRecordType === 'string') {
     // We need to keep track of these globally for when we generate the package XML.
-    allRecordTypes.push(`${name}.${upperFirst(defaultRecordType)}`);
-    const [businessProcessName, businessProcessPicklistVal] = calculateBusinessProcess(name, defaultRecordType);
+    allRecordTypes.push(`${name}.${defaultRecordType}`);
+    const [businessProcessName, businessProcessPicklistVal] = calculateBusinessProcess(
+      name,
+      defaultRecordType,
+      capitalizeRecordTypes
+    );
+
     // Create the record type
     const recordTypes = {
-      fullName: upperFirst(defaultRecordType),
-      label: upperFirst(defaultRecordType),
+      fullName: defaultRecordType,
+      label: defaultRecordType,
       active: true,
     };
 
@@ -186,9 +201,16 @@ export default class SettingsGenerator {
   private allBusinessProcesses: string[] = [];
   private readonly shapeDirName: string;
   private readonly packageFilePath: string;
+  private readonly capitalizeRecordTypes: boolean;
 
-  public constructor(options?: { mdApiTmpDir?: string; shapeDirName?: string; asDirectory?: boolean }) {
+  public constructor(options?: {
+    mdApiTmpDir?: string;
+    shapeDirName?: string;
+    asDirectory?: boolean;
+    capitalizeRecordTypes?: boolean;
+  }) {
     this.logger = Logger.childFromRoot('SettingsGenerator');
+    this.capitalizeRecordTypes = options?.capitalizeRecordTypes ?? false;
     // If SFDX_MDAPI_TEMP_DIR is set, copy settings to that dir for people to inspect.
     const mdApiTmpDir = options?.mdApiTmpDir ?? env.getString('SFDX_MDAPI_TEMP_DIR');
     this.shapeDirName = options?.shapeDirName ?? `shape_${Date.now()}`;
@@ -344,7 +366,8 @@ export default class SettingsGenerator {
             item,
             value,
             allRecordTypes,
-            allbusinessProcesses
+            allbusinessProcesses,
+            this.capitalizeRecordTypes
           );
           const xml = js2xmlparser.parse('CustomObject', fileContent);
           return this.writer.addToStore(xml, path.join(objectsDir, upperFirst(item) + '.object'));

--- a/src/org/scratchOrgSettingsGenerator.ts
+++ b/src/org/scratchOrgSettingsGenerator.ts
@@ -16,6 +16,7 @@ import { StatusResult } from '../status/types';
 import { PollingClient } from '../status/pollingClient';
 import { ZipWriter } from '../util/zipWriter';
 import { DirectoryWriter } from '../util/directoryWriter';
+import { Lifecycle } from '../lifecycleEvents';
 import { ScratchOrgInfo, ObjectSetting } from './scratchOrgTypes';
 import { Org } from './org';
 
@@ -210,7 +211,14 @@ export default class SettingsGenerator {
     capitalizeRecordTypes?: boolean;
   }) {
     this.logger = Logger.childFromRoot('SettingsGenerator');
-    this.capitalizeRecordTypes = options?.capitalizeRecordTypes ?? false;
+    if (options?.capitalizeRecordTypes === undefined) {
+      void Lifecycle.getInstance().emitWarning(
+        'record types will stop being capitalized by default in a future release.'
+      );
+      this.capitalizeRecordTypes = true;
+    } else {
+      this.capitalizeRecordTypes = options.capitalizeRecordTypes;
+    }
     // If SFDX_MDAPI_TEMP_DIR is set, copy settings to that dir for people to inspect.
     const mdApiTmpDir = options?.mdApiTmpDir ?? env.getString('SFDX_MDAPI_TEMP_DIR');
     this.shapeDirName = options?.shapeDirName ?? `shape_${Date.now()}`;

--- a/src/org/scratchOrgSettingsGenerator.ts
+++ b/src/org/scratchOrgSettingsGenerator.ts
@@ -17,8 +17,11 @@ import { PollingClient } from '../status/pollingClient';
 import { ZipWriter } from '../util/zipWriter';
 import { DirectoryWriter } from '../util/directoryWriter';
 import { Lifecycle } from '../lifecycleEvents';
+import { Messages } from '../messages';
 import { ScratchOrgInfo, ObjectSetting } from './scratchOrgTypes';
 import { Org } from './org';
+
+Messages.importMessagesDirectory(__dirname);
 
 export enum RequestStatus {
   Pending = 'Pending',
@@ -212,9 +215,8 @@ export default class SettingsGenerator {
   }) {
     this.logger = Logger.childFromRoot('SettingsGenerator');
     if (options?.capitalizeRecordTypes === undefined) {
-      void Lifecycle.getInstance().emitWarning(
-        'record types will stop being capitalized by default in a future release.'
-      );
+      const messages = Messages.loadMessages('@salesforce/core', 'scratchOrgSettingsGenerator');
+      void Lifecycle.getInstance().emitWarning(messages.getMessage('noCapitalizeRecordTypeConfigVar'));
       this.capitalizeRecordTypes = true;
     } else {
       this.capitalizeRecordTypes = options.capitalizeRecordTypes;

--- a/test/unit/org/scratchOrgSettingsGeneratorTest.ts
+++ b/test/unit/org/scratchOrgSettingsGeneratorTest.ts
@@ -639,13 +639,38 @@ describe('scratchOrgSettingsGenerator', () => {
         'account',
         objectSettingsData.account,
         allRecordTypes,
-        allbusinessProcesses
+        allbusinessProcesses,
+        true
       );
       expect(recordTypeAndBusinessProcessFileContent).to.deep.equal({
         '@': { xmlns: 'http://soap.sforce.com/2006/04/metadata' },
         recordTypes: { fullName: 'PersonAccount', label: 'PersonAccount', active: true },
       });
       expect(allRecordTypes).to.deep.equal(['Account.PersonAccount']);
+      expect(allbusinessProcesses).to.deep.equal([]);
+    });
+
+    it('createRecordTypeAndBusinessProcessFileContent with account type, not capitalized', () => {
+      const objectSettingsDataLowercaseRecordType = {
+        account: {
+          defaultRecordType: 'personAccount',
+        },
+      };
+
+      const allRecordTypes: string[] = [];
+      const allbusinessProcesses: string[] = [];
+      const recordTypeAndBusinessProcessFileContent = createRecordTypeAndBusinessProcessFileContent(
+        'account',
+        objectSettingsDataLowercaseRecordType.account,
+        allRecordTypes,
+        allbusinessProcesses,
+        false
+      );
+      expect(recordTypeAndBusinessProcessFileContent).to.deep.equal({
+        '@': { xmlns: 'http://soap.sforce.com/2006/04/metadata' },
+        recordTypes: { fullName: 'personAccount', label: 'personAccount', active: true },
+      });
+      expect(allRecordTypes).to.deep.equal(['Account.personAccount']);
       expect(allbusinessProcesses).to.deep.equal([]);
     });
 
@@ -656,7 +681,8 @@ describe('scratchOrgSettingsGenerator', () => {
         'opportunity',
         objectSettingsData.opportunity,
         allRecordTypes,
-        allbusinessProcesses
+        allbusinessProcesses,
+        true
       );
       expect(recordTypeAndBusinessProcessFileContent).to.deep.equal({
         '@': { xmlns: 'http://soap.sforce.com/2006/04/metadata' },
@@ -686,7 +712,8 @@ describe('scratchOrgSettingsGenerator', () => {
         'case',
         objectSettingsData.case,
         allRecordTypes,
-        allbusinessProcesses
+        allbusinessProcesses,
+        true
       );
       expect(recordTypeAndBusinessProcessFileContent).to.deep.equal({
         '@': { xmlns: 'http://soap.sforce.com/2006/04/metadata' },
@@ -708,6 +735,44 @@ describe('scratchOrgSettingsGenerator', () => {
       });
       expect(allRecordTypes).to.deep.equal(['Case.Default']);
       expect(allbusinessProcesses).to.deep.equal(['Case.DefaultProcess']);
+    });
+
+    it('createRecordTypeAndBusinessProcessFileContent with case values, not capitalized', () => {
+      const objectSettingsDataLowercaseRecordType = {
+        case: {
+          defaultRecordType: 'default',
+          sharingModel: 'private',
+        },
+      };
+      const allRecordTypes: string[] = [];
+      const allbusinessProcesses: string[] = [];
+      const recordTypeAndBusinessProcessFileContent = createRecordTypeAndBusinessProcessFileContent(
+        'case',
+        objectSettingsDataLowercaseRecordType.case,
+        allRecordTypes,
+        allbusinessProcesses,
+        false
+      );
+      expect(recordTypeAndBusinessProcessFileContent).to.deep.equal({
+        '@': { xmlns: 'http://soap.sforce.com/2006/04/metadata' },
+        sharingModel: 'Private',
+        recordTypes: {
+          fullName: 'default',
+          label: 'default',
+          active: true,
+          businessProcess: 'defaultProcess',
+        },
+        businessProcesses: {
+          fullName: 'defaultProcess',
+          isActive: true,
+          values: {
+            fullName: 'New',
+            default: true,
+          },
+        },
+      });
+      expect(allRecordTypes).to.deep.equal(['Case.default']);
+      expect(allbusinessProcesses).to.deep.equal(['Case.defaultProcess']);
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

Adds a new `org-capitalize-record-types` config var to allow to users to choose whether to capitalize record types defined in a scratch org definition file when creating the org.

If the config var isn't set it will still capitalize record types but will emit a warning for users to set the config var to true (we'll stop capitalization in a next major release of sfdx-core, will sync with CLI deprecation policy).


### Testing

## Expected behaviour:
* no config var: emit warning and capitalize record types
* org-capitalize-record-types=false: no warning, don't capitalize
* org-capitalize-record-types=true: no warning, capitalize.

also, try making `org create scratch` timeout when org is ready but before it deploy settings to confirm `sf org resume scratch` also respects the config var.

## Setup
1) Checkout this branch and `yarn link` it into `plugin-org` and `plugin-settings`
2) clone dreamhouse and update the org def. file with this:
```json
{
    "orgName": "Dreamhouse",
    "edition": "Developer",
    "features": ["Walkthroughs", "EnableSetPasswordInApi"],
    "objectSettings": {
      "case": {
        "defaultRecordType": "svc_Technical_Support",
        "sharingModel": "private"
      }
    },
    "settings": {
        "lightningExperienceSettings": {
            "enableS1DesktopEnabled": true
        },
        "mobileSettings": {
            "enableS1EncryptedStoragePref2": false
        }
    }
}
```

## Turn off record type capitalization
1) set config var: `sf config set org-capitalize-record-types=false -g`
2) create org: `sf org create scratch -d -f config/project-scratch-def.json -a dreamhouse --duration-days 1`
3) check that `svc_Technical_Support` record type isn't capitalized:
**UI**
`sf org open --path lightning/setup/ObjectManager/Case/RecordTypes/view`:

![Screenshot 2024-01-18 at 12 51 12](https://github.com/forcedotcom/sfdx-core/assets/6853656/b6a62791-defc-4b55-823e-15680b694f3d)

**CLI**
`sf sobject describe --sobject Case --json | jq '.result.recordTypeInfos'`
```jsonc
[
  {
    "active": true,
    "available": false,
    "defaultRecordTypeMapping": false,
    "developerName": "svc_Technical_Support", // HERE
    "master": false,
    "name": "svc_Technical_Support",
    "recordTypeId": "012DE000008EWEVYA4",
    "urls": {
      "layout": "/services/data/v59.0/sobjects/Case/describe/layouts/012DE000008EWEVYA4"
    }
  },
  {
    "active": true,
    "available": true,
    "defaultRecordTypeMapping": true,
    "developerName": "Master",
    "master": true,
    "name": "Master",
    "recordTypeId": "012000000000000AAA",
    "urls": {
      "layout": "/services/data/v59.0/sobjects/Case/describe/layouts/012000000000000AAA"
    }
  }
]
```

## NUTs
There are some NUTs in plugin-org:
https://github.com/salesforcecli/plugin-org/pull/935

a few try to run `config unset org-capitalize-record-types` using the global `sf` installed in the NUT job, so those will fail until:

1) this PR gets merged
2) `plugin-org` and `plugin-settings` get sfdx-core bumped to include this change
3) both plugins are included in the `nightly` channel (NUT jobs get nightly sf).

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2633
@W-14750427@