### PR TITLE
refactor: configStore `get` can be undefined

### DIFF
--- a/src/config/configStore.ts
+++ b/src/config/configStore.ts
@@ -20,8 +20,8 @@ import { ConfigContents, ConfigEntry, ConfigValue, Key } from './configStackType
 export interface ConfigStore<P extends ConfigContents = ConfigContents> {
   // Map manipulation methods
   entries(): ConfigEntry[];
-  get<K extends Key<P>>(key: K, decrypt: boolean): P[K];
-  get<T extends ConfigValue>(key: string, decrypt: boolean): T;
+  get<K extends Key<P>>(key: K, decrypt: boolean): P[K] | undefined;
+  get<T extends ConfigValue>(key: string, decrypt: boolean): T | undefined;
   getKeysByValue(value: ConfigValue): Array<Key<P>>;
   has(key: string): boolean;
   keys(): Array<Key<P>>;
@@ -88,9 +88,9 @@ export abstract class BaseConfigStore<
    * @param decrypt If it is an encrypted key, decrypt the value.
    * If the value is an object, a clone will be returned.
    */
-  public get<K extends Key<P>>(key: K, decrypt?: boolean): P[K];
-  public get<V = ConfigValue>(key: string, decrypt?: boolean): V;
-  public get<K extends Key<P>>(key: K | string, decrypt = false): P[K] | ConfigValue {
+  public get<K extends Key<P>>(key: K, decrypt?: boolean): P[K] | undefined;
+  public get<V = ConfigValue>(key: string, decrypt?: boolean): V | undefined;
+  public get<K extends Key<P>>(key: K | string, decrypt = false): P[K] | ConfigValue | undefined {
     const rawValue = this.contents.get(key as K);
 
     if (this.hasEncryption() && decrypt) {

--- a/src/config/configStore.ts
+++ b/src/config/configStore.ts
@@ -20,8 +20,10 @@ import { ConfigContents, ConfigEntry, ConfigValue, Key } from './configStackType
 export interface ConfigStore<P extends ConfigContents = ConfigContents> {
   // Map manipulation methods
   entries(): ConfigEntry[];
-  get<K extends Key<P>>(key: K, decrypt: boolean): P[K] | undefined;
-  get<T extends ConfigValue>(key: string, decrypt: boolean): T | undefined;
+  // NEXT_RELEASE: update types to specify return can be P[K] | undefined
+  get<K extends Key<P>>(key: K, decrypt: boolean): P[K];
+  // NEXT_RELEASE: update types to specify return can be T | undefined
+  get<T extends ConfigValue>(key: string, decrypt: boolean): T;
   getKeysByValue(value: ConfigValue): Array<Key<P>>;
   has(key: string): boolean;
   keys(): Array<Key<P>>;
@@ -88,9 +90,13 @@ export abstract class BaseConfigStore<
    * @param decrypt If it is an encrypted key, decrypt the value.
    * If the value is an object, a clone will be returned.
    */
-  public get<K extends Key<P>>(key: K, decrypt?: boolean): P[K] | undefined;
-  public get<V = ConfigValue>(key: string, decrypt?: boolean): V | undefined;
-  public get<K extends Key<P>>(key: K | string, decrypt = false): P[K] | ConfigValue | undefined {
+  // NEXT_RELEASE: update types to specify return can be  | undefined
+  public get<K extends Key<P>>(key: K, decrypt?: boolean): P[K];
+  // NEXT_RELEASE: update types to specify return can be  | undefined
+  // NEXT_RELEASE: consider getting rid of ConfigValue and letting it just use the Key<> approach
+  public get<V = ConfigValue>(key: string, decrypt?: boolean): V;
+  // NEXT_RELEASE: update types to specify return can be  | undefined
+  public get<K extends Key<P>>(key: K | string, decrypt = false): P[K] | ConfigValue {
     const rawValue = this.contents.get(key as K);
 
     if (this.hasEncryption() && decrypt) {
@@ -100,6 +106,7 @@ export abstract class BaseConfigStore<
         return this.decrypt(rawValue) as P[K] | ConfigValue;
       }
     }
+    // NEXT_RELEASE: update types to specify return can be  | undefined
     return rawValue as P[K] | ConfigValue;
   }
 

--- a/src/org/scratchOrgCreate.ts
+++ b/src/org/scratchOrgCreate.ts
@@ -110,9 +110,12 @@ export const scratchOrgResume = async (jobId: string): Promise<ScratchOrgCreateR
     emit({ stage: 'send request' }),
   ]);
   logger.debug(`resuming scratch org creation for jobId: ${jobId}`);
-  if (!cache.has(jobId)) {
+  const cached = cache.get(jobId);
+
+  if (!cached) {
     throw messages.createError('CacheMissError', [jobId]);
   }
+
   const {
     hubUsername,
     apiVersion,
@@ -122,7 +125,7 @@ export const scratchOrgResume = async (jobId: string): Promise<ScratchOrgCreateR
     alias,
     setDefault,
     tracksSource,
-  } = cache.get(jobId);
+  } = cached;
 
   const hubOrg = await Org.create({ aliasOrUsername: hubUsername });
   const soi = await queryScratchOrgInfo(hubOrg, jobId);

--- a/test/unit/config/ttlConfigTest.ts
+++ b/test/unit/config/ttlConfigTest.ts
@@ -85,14 +85,14 @@ describe('TTLConfig', () => {
     it('should return true if timestamp is older than TTL', async () => {
       const config = await TestConfig.create();
       config.set('1', { one: 'one' });
-      const isExpired = config.isExpired(new Date().getTime() + Duration.days(7).milliseconds, config.get('1'));
+      const isExpired = config.isExpired(new Date().getTime() + Duration.days(7).milliseconds, config.get('1')!);
       expect(isExpired).to.be.true;
     });
 
     it('should return false if timestamp is not older than TTL', async () => {
       const config = await TestConfig.create();
       config.set('1', { one: 'one' });
-      const isExpired = config.isExpired(new Date().getTime(), config.get('1'));
+      const isExpired = config.isExpired(new Date().getTime(), config.get('1')!);
       expect(isExpired).to.be.false;
     });
   });


### PR DESCRIPTION
### What does this PR do?
typings are wrong for ConfigStore--`get` can return `undefined`

fixes a few things that correct typing will break, and makes notes to do this in the next major

### What issues does this PR fix or reference?
found during, but not required for [@W-14800653@](https://gus.lightning.force.com/a07EE00001hzzuKYAQ)