### PR TITLE
fix: re-enable code challenge support

### DIFF
--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -333,8 +333,10 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
    * @param options The options to generate the URL.
    */
   public static getAuthorizationUrl(options: JwtOAuth2Config & { scope?: string }, oauth2?: OAuth2): string {
-    // Always use a verifier for enhanced security
-    options.useVerifier = true;
+    // Unless explicitly turned off, use a code verifier for enhanced security
+    if (options.useVerifier !== false) {
+      options.useVerifier = true;
+    }
     const oauth2Verifier = oauth2 ?? new OAuth2(options);
 
     // The state parameter allows the redirectUri callback listener to ignore request

--- a/src/webOAuthServer.ts
+++ b/src/webOAuthServer.ts
@@ -141,6 +141,8 @@ export class WebOAuthServer extends AsyncCreatable<WebOAuthServer.Options> {
     if (!this.oauthConfig.clientId) this.oauthConfig.clientId = DEFAULT_CONNECTED_APP_INFO.clientId;
     if (!this.oauthConfig.loginUrl) this.oauthConfig.loginUrl = AuthInfo.getDefaultInstanceUrl();
     if (!this.oauthConfig.redirectUri) this.oauthConfig.redirectUri = `http://localhost:${port}/OauthRedirect`;
+    // Unless explicitly turned off, use a code verifier as a best practice
+    if (this.oauthConfig.useVerifier !== false) this.oauthConfig.useVerifier = true;
 
     this.webServer = await WebServer.create({ port });
     this.oauth2 = new OAuth2(this.oauthConfig);
@@ -237,6 +239,7 @@ export class WebOAuthServer extends AsyncCreatable<WebOAuthServer.Options> {
       this.logger.debug(`oauthConfig.loginUrl: ${this.oauthConfig.loginUrl}`);
       this.logger.debug(`oauthConfig.clientId: ${this.oauthConfig.clientId}`);
       this.logger.debug(`oauthConfig.redirectUri: ${this.oauthConfig.redirectUri}`);
+      this.logger.debug(`oauthConfig.useVerifier: ${this.oauthConfig.useVerifier}`);
       return authCode;
     }
     return null;


### PR DESCRIPTION
### What does this PR do?
CLI auth should default to using code challenges and code verifiers for PKCE.  This used to be the case but somehow it was disabled.  This adds it back and also adds unit tests to ensure it stays that way.

### What issues does this PR fix or reference?
@W-15198289@

QA:
All auth that happens as part of NUTs will verify that it doesn't break anything.  To ensure that it works with an org that has PKCE set, open your org, to to setup, search for "oauth", click on "OAuth and OpenID Connect Settings", toggle the "Require Proof Key for Code Exchange (PKCE) Extension" on.  Then do `sf org login web` targeting that org.