### PR TITLE
add properties for PS/PSL package metadata access to package dir

### DIFF
--- a/src/sfProject.ts
+++ b/src/sfProject.ts
@@ -39,6 +39,10 @@ export type PackageDir = {
   dependencies?: PackageDirDependency[];
   includeProfileUserLicenses?: boolean;
   package?: string;
+  packageMetadataAccess?:  {
+     permissionSets: string | string[];
+     permissionSetLicenses: string | string[];
+  };
   path: string;
   postInstallScript?: string;
   postInstallUrl?: string;


### PR DESCRIPTION
### What does this PR do?
Update PackageDir to include packageMetadataAccess properties that can be set in sfdx-project.json to allow a package developer to assign permission sets and permission set licenses to the build org user.

The equivalent schema change was made in PR: 
https://github.com/forcedotcom/schemas/pull/82

### What issues does this PR fix or reference?
@W-14842023@
