### PR TITLE
feat: improved sfError

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -363,14 +363,14 @@ export class Messages<T extends string> {
     }
 
     if (!packageName) {
-      const errMessage = `Invalid or missing package.json file at '${moduleMessagesDirPath}'. If not using a package.json, pass in a packageName.`;
+      const message = `Invalid or missing package.json file at '${moduleMessagesDirPath}'. If not using a package.json, pass in a packageName.`;
       try {
         packageName = asString(ensureJsonMap(Messages.readFile(path.join(moduleMessagesDirPath, 'package.json'))).name);
         if (!packageName) {
-          throw new NamedError('MissingPackageName', errMessage);
+          throw SfError.create({ message, name: 'MissingPackageName' });
         }
       } catch (err) {
-        throw new NamedError('MissingPackageName', errMessage, err as Error);
+        throw SfError.create({ message, name: 'MissingPackageName', cause: err });
       }
     }
 

--- a/src/sfError.ts
+++ b/src/sfError.ts
@@ -123,12 +123,16 @@ export class SfError<T extends ErrorDataProperties = ErrorDataProperties> extend
     const sfError =
       err instanceof Error
         ? // a basic error with message and name.  We make it the cause to preserve any other properties
-          new SfError<T>(err.message, err.name, undefined, err)
+          SfError.create<T>({
+            message: err.message,
+            name: err.name,
+            cause: err,
+          })
         : // ok, something was throws that wasn't error or string.  Convert it to an Error that preserves the information as the cause and wrap that.
-          SfError.wrap<T>(
-            new TypeError(`SfError.wrap received type ${typeof err} but expects type Error or string`, { cause: err })
-          );
-
+          SfError.create<T>({
+            message: `SfError.wrap received type ${typeof err} but expects type Error or string`,
+            cause: err,
+          });
     // If the original error has a code, use that instead of name.
     if (hasString(err, 'code')) {
       sfError.code = err.code;

--- a/src/sfError.ts
+++ b/src/sfError.ts
@@ -14,7 +14,7 @@ export type SfErrorOptions<T extends ErrorDataProperties = ErrorDataProperties> 
   data?: T;
   cause?: Error;
   context?: string;
-  actions: string[];
+  actions?: string[];
 };
 
 type ErrorDataProperties = AnyJson;

--- a/src/sfError.ts
+++ b/src/sfError.ts
@@ -129,10 +129,10 @@ export class SfError<T extends ErrorDataProperties = ErrorDataProperties> extend
             cause: err,
           })
         : // ok, something was throws that wasn't error or string.  Convert it to an Error that preserves the information as the cause and wrap that.
-          SfError.create<T>({
-            message: `SfError.wrap received type ${typeof err} but expects type Error or string`,
-            cause: err,
-          });
+          SfError.wrap<T>(
+            new Error(`SfError.wrap received type ${typeof err} but expects type Error or string`, { cause: err })
+          );
+
     // If the original error has a code, use that instead of name.
     if (hasString(err, 'code')) {
       sfError.code = err.code;

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -5,6 +5,10 @@
     "noEmit": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES2022"
   }
 }

--- a/test/unit/org/scratchOrgInfoApiTest.ts
+++ b/test/unit/org/scratchOrgInfoApiTest.ts
@@ -192,7 +192,7 @@ describe('requestScratchOrgCreation', () => {
         expect.fail('should have thrown SfError');
       }
       expect(error).to.exist;
-      expect(error).to.have.keys(['cause', 'name', 'actions', 'exitCode']);
+      expect(error).to.include.keys(['cause', 'name', 'actions', 'exitCode']);
       expect((error as Error).toString()).to.include('SignupDuplicateSettingsSpecifiedError');
     }
   });
@@ -216,7 +216,7 @@ describe('requestScratchOrgCreation', () => {
         expect.fail('should have thrown SfError');
       }
       expect(error).to.exist;
-      expect(error).to.have.keys(['cause', 'name', 'actions', 'exitCode']);
+      expect(error).to.include.keys(['cause', 'name', 'actions', 'exitCode']);
       expect((error as Error).toString()).to.include(messages.getMessage('DeprecatedPrefFormat'));
     }
   });

--- a/test/unit/sfErrorTest.ts
+++ b/test/unit/sfErrorTest.ts
@@ -243,4 +243,87 @@ describe('SfError', () => {
       });
     });
   });
+
+  describe('create', () => {
+    it('message only sets the default error name', () => {
+      const message = 'its a trap!';
+      const error = SfError.create({ message });
+      expect(error.message).to.equal(message);
+      expect(error.name).to.equal('SfError');
+    });
+    it('sets name', () => {
+      const message = 'its a trap!';
+      const name = 'BadError';
+      const error = SfError.create({ message, name });
+      expect(error.message).to.equal(message);
+      expect(error.name).to.equal(name);
+    });
+    it('sets cause', () => {
+      const cause = new Error('cause');
+      const error = SfError.create({ message: 'its a trap!', cause });
+      expect(error.cause).to.equal(cause);
+    });
+    it('sets exit code', () => {
+      const message = 'its a trap!';
+      const exitCode = 100;
+      const error = SfError.create({ message, exitCode });
+      expect(error.message).to.equal(message);
+      expect(error.exitCode).to.equal(exitCode);
+    });
+    it('sets actions', () => {
+      const message = 'its a trap!';
+      const actions = ['do the opposite'];
+      const error = SfError.create({ message, actions });
+      expect(error.message).to.equal(message);
+      expect(error.actions).to.equal(actions);
+    });
+    it('sets data', () => {
+      const message = 'its a trap!';
+      const data = { foo: 'pity the foo' };
+      const error = SfError.create({ message, data });
+      expect(error.message).to.equal(message);
+      expect(error.data).to.equal(data);
+    });
+    it('sets data (typed)', () => {
+      const message = 'its a trap!';
+      const data = { foo: 'pity the foo' };
+      const error = SfError.create<{ foo: string }>({ message, data });
+      expect(error.message).to.equal(message);
+      expect(error.data).to.equal(data);
+    });
+    it('sets context', () => {
+      const message = 'its a trap!';
+      const context = 'TestContext1';
+      const error = SfError.create({ message, context });
+      expect(error.message).to.equal(message);
+      expect(error.context).to.equal(context);
+    });
+    it('all the things', () => {
+      const message = 'its a trap!';
+      const name = 'BadError';
+      const actions = ['do the opposite'];
+      const cause = new Error('cause');
+      const exitCode = 100;
+      const context = 'TestContext1';
+      const data = { foo: 'pity the foo' };
+
+      const error = SfError.create({
+        message,
+        name,
+        actions,
+        cause,
+        exitCode,
+        context,
+        data,
+      });
+
+      expect(error.message).to.equal(message);
+      expect(error.name).to.equal(name);
+      expect(error.actions).to.equal(actions);
+      expect(error.cause).to.equal(cause);
+      expect(error.exitCode).to.equal(exitCode);
+      expect(error.context).to.equal(context);
+      expect(error.data).to.equal(data);
+    });
+  });
 });

--- a/test/unit/sfErrorTest.ts
+++ b/test/unit/sfErrorTest.ts
@@ -106,42 +106,44 @@ describe('SfError', () => {
   });
 
   describe('wrap', () => {
-    it('should return a wrapped error', () => {
-      const myErrorMsg = 'yikes! What did you do?';
-      const myErrorName = 'OhMyError';
-      const myError = new Error(myErrorMsg);
-      myError.name = myErrorName;
-      const mySfError = SfError.wrap(myError);
-      expect(mySfError).to.be.an.instanceOf(SfError);
-      expect(mySfError.message).to.equal(myErrorMsg);
-      expect(mySfError.name).to.equal(myErrorName);
-      expect(mySfError.cause).to.equal(myError);
-      expect(inspect(mySfError)).to.contain(causeDelimiter).and.contain(myErrorMsg);
-    });
+    describe('happy path', () => {
+      it('should return a wrapped error', () => {
+        const myErrorMsg = 'yikes! What did you do?';
+        const myErrorName = 'OhMyError';
+        const myError = new Error(myErrorMsg);
+        myError.name = myErrorName;
+        const mySfError = SfError.wrap(myError);
+        expect(mySfError).to.be.an.instanceOf(SfError);
+        expect(mySfError.message).to.equal(myErrorMsg);
+        expect(mySfError.name).to.equal(myErrorName);
+        expect(mySfError.cause).to.equal(myError);
+        expect(inspect(mySfError)).to.contain(causeDelimiter).and.contain(myErrorMsg);
+      });
 
-    it('should return a wrapped error with a code', () => {
-      class CodeError extends Error {
-        public code?: string;
-      }
-      const myErrorCode = 'OhMyError';
-      const myError = new CodeError('test');
-      myError.code = myErrorCode;
-      const mySfError = SfError.wrap(myError);
-      expect(mySfError).to.be.an.instanceOf(SfError);
-      expect(mySfError.code).to.equal(myErrorCode);
-    });
+      it('should return a wrapped error with a code', () => {
+        class CodeError extends Error {
+          public code?: string;
+        }
+        const myErrorCode = 'OhMyError';
+        const myError = new CodeError('test');
+        myError.code = myErrorCode;
+        const mySfError = SfError.wrap(myError);
+        expect(mySfError).to.be.an.instanceOf(SfError);
+        expect(mySfError.code).to.equal(myErrorCode);
+      });
 
-    it('should return a new error with just a string', () => {
-      const mySfError = SfError.wrap('test');
-      expect(mySfError).to.be.an.instanceOf(SfError);
-      expect(mySfError.message).to.equal('test');
-    });
+      it('should return a new error with just a string', () => {
+        const mySfError = SfError.wrap('test');
+        expect(mySfError).to.be.an.instanceOf(SfError);
+        expect(mySfError.message).to.equal('test');
+      });
 
-    it('should return the error if already a SfError', () => {
-      const existingSfError = new SfError('test');
-      const mySfError = SfError.wrap(existingSfError);
-      expect(mySfError).to.be.an.instanceOf(SfError);
-      expect(mySfError).to.equal(existingSfError);
+      it('should return the error if already a SfError', () => {
+        const existingSfError = new SfError('test');
+        const mySfError = SfError.wrap(existingSfError);
+        expect(mySfError).to.be.an.instanceOf(SfError);
+        expect(mySfError).to.equal(existingSfError);
+      });
     });
 
     describe('handling "other" stuff that is not Error', () => {
@@ -149,31 +151,29 @@ describe('SfError', () => {
         const wrapMe = undefined;
         const mySfError = SfError.wrap(wrapMe);
         expect(mySfError).to.be.an.instanceOf(SfError);
-        expect(mySfError.message === 'An unexpected error occurred');
-        expect(mySfError.name === 'TypeError');
-        assert(mySfError.cause instanceof TypeError);
-        expect(mySfError.cause.message === 'An unexpected error occurred');
+        expect(mySfError.message).to.include('SfError.wrap received type ');
+        assert(mySfError.cause instanceof Error);
         expect(mySfError.cause.cause).to.equal(wrapMe);
       });
       it('a number', () => {
         const wrapMe = 2;
         const mySfError = SfError.wrap(wrapMe);
         expect(mySfError).to.be.an.instanceOf(SfError);
-        assert(mySfError.cause instanceof TypeError);
+        assert(mySfError.cause instanceof Error);
         expect(mySfError.cause.cause).to.equal(wrapMe);
       });
       it('an object', () => {
         const wrapMe = { a: 2 };
         const mySfError = SfError.wrap(wrapMe);
         expect(mySfError).to.be.an.instanceOf(SfError);
-        assert(mySfError.cause instanceof TypeError);
+        assert(mySfError.cause instanceof Error);
         expect(mySfError.cause.cause).to.equal(wrapMe);
       });
       it('an object that has a code', () => {
         const wrapMe = { a: 2, code: 'foo' };
         const mySfError = SfError.wrap(wrapMe);
         expect(mySfError).to.be.an.instanceOf(SfError);
-        assert(mySfError.cause instanceof TypeError);
+        assert(mySfError.cause instanceof Error);
         expect(mySfError.cause.cause).to.equal(wrapMe);
         expect(mySfError.code).to.equal('foo');
       });
@@ -181,14 +181,14 @@ describe('SfError', () => {
         const wrapMe = [1, 5, 6];
         const mySfError = SfError.wrap(wrapMe);
         expect(mySfError).to.be.an.instanceOf(SfError);
-        assert(mySfError.cause instanceof TypeError);
+        assert(mySfError.cause instanceof Error);
         expect(mySfError.cause.cause).to.equal(wrapMe);
       });
       it('a class', () => {
         const wrapMe = new (class Test {})();
         const mySfError = SfError.wrap(wrapMe);
         expect(mySfError).to.be.an.instanceOf(SfError);
-        assert(mySfError.cause instanceof TypeError);
+        assert(mySfError.cause instanceof Error);
         expect(mySfError.cause.cause).to.equal(wrapMe);
       });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "outDir": "./lib",
     "resolveJsonModule": true,
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES2022",
     "rootDir": "./src",
     "plugins": [{ "transform": "./src/messageTransformer.ts" }],
     "esModuleInterop": true

--- a/typedocExamples/tsconfig.json
+++ b/typedocExamples/tsconfig.json
@@ -5,6 +5,10 @@
     "noEmit": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES2022"
   }
 }


### PR DESCRIPTION
### What does this PR do?
- bump tsconfig target/lib/etc for es2022 so we get native error.cause
- sfError extends Error instead of kit/NamedError
  - adds the `name` property  
  - adds the fullStack method...which now operates on stack of `error.cause` by recursing through them to build its "caused by" 
  - add a new `.create` method that's less painful than the 5-prop overloaded constructor and which supports the `context` and `data` properties
  - wrap method takes an `unknown` so you can wrap things in a `catch` block without having to worry about their type (previously only supported `string | Error | SfError`).  Will wrap any "other" things in an error to preserve its info in the new error's `cause`  
  - the constructor (arg5) and the new `.create` also allow `cause` to be `unknown` and will narrow it to an error (and otherwise throw) for that same convenience in catch blocks.
  - `code` property always returns a string [it's either code (which can only be a string) or name (also required, string)] and now the types say that

### What issues does this PR fix or reference?
@W-14507125@
