### PR TITLE
fix: add console logs to config file writes for troubleshooting plugin-org NUTs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/core",
-  "version": "7.3.2",
+  "version": "7.3.3-dev.0",
   "description": "Core libraries to interact with SFDX projects, orgs, and APIs.",
   "main": "lib/index",
   "types": "lib/index.d.ts",

--- a/src/config/configFile.ts
+++ b/src/config/configFile.ts
@@ -236,6 +236,7 @@ export class ConfigFile<
   public async write(): Promise<P> {
     const lockResponse = await lockInit(this.getPath());
     if (this.getPath().endsWith('sandbox-create-cache.json')) {
+      // eslint-disable-next-line no-console
       console.log('(async) time before write:', performance.now());
     }
 
@@ -250,9 +251,11 @@ export class ConfigFile<
     // write the merged LWWMap to file
     await lockResponse.writeAndUnlock(JSON.stringify(this.getContents(), null, 2));
     if (this.getPath().endsWith('sandbox-create-cache.json')) {
+      /* eslint-disable no-console */
       console.log('(async) time after write:', performance.now());
       console.dir(this.getContents(), { depth: 8 });
       console.log('--------------------------------------');
+      /* eslint-enable no-console */
     }
 
     return this.getContents();
@@ -267,6 +270,7 @@ export class ConfigFile<
   public writeSync(): P {
     const lockResponse = lockInitSync(this.getPath());
     if (this.getPath().endsWith('sandbox-create-cache.json')) {
+      // eslint-disable-next-line no-console
       console.log('(sync) time before write:', performance.now());
     }
     try {
@@ -282,9 +286,11 @@ export class ConfigFile<
     // write the merged LWWMap to file
     lockResponse.writeAndUnlock(JSON.stringify(this.getContents(), null, 2));
     if (this.getPath().endsWith('sandbox-create-cache.json')) {
+      /* eslint-disable no-console */
       console.log('(sync) time after write:', performance.now());
       console.dir(this.getContents(), { depth: 8 });
       console.log('--------------------------------------');
+      /* eslint-enable no-console */
     }
 
     return this.getContents();


### PR DESCRIPTION
Changes for a dev release of this library only.  Adds console output for config file writing, specifically the sandbox cache file.

[skip-validate-pr]