### PR TITLE
fix: remove namespace if nonamespace option is set

### DIFF
--- a/src/org/scratchOrgInfoGenerator.ts
+++ b/src/org/scratchOrgInfoGenerator.ts
@@ -37,7 +37,7 @@ export type ScratchOrgInfoPayload = {
   package2AncestorIds: string;
   features: string | string[];
   connectedAppConsumerKey: string;
-  namespace: string;
+  namespace?: string;
   connectedAppCallbackUrl: string;
   durationDays: number;
 } & PartialScratchOrgInfo;
@@ -216,12 +216,16 @@ export const generateScratchOrgInfo = async ({
     // project is not required
   }
 
+  const { namespace: originalNamespace, ...payload } = scratchOrgInfoPayload;
+
+  const namespace = originalNamespace ?? sfProject?.get('namespace');
+
   return {
-    ...scratchOrgInfoPayload,
+    ...payload,
     orgName: scratchOrgInfoPayload.orgName ?? 'Company',
     // we already have the info, and want to get rid of configApi, so this doesn't use that
     connectedAppCallbackUrl: `http://localhost:${await WebOAuthServer.determineOauthPort()}/OauthRedirect`,
-    ...(!nonamespace && sfProject?.get('namespace') ? { namespace: sfProject.get('namespace') as string } : {}),
+    ...(!nonamespace && namespace ? { namespace } : {}),
     // Use the Hub org's client ID value, if one wasn't provided to us, or the default
     connectedAppConsumerKey:
       scratchOrgInfoPayload.connectedAppConsumerKey ??

--- a/test/unit/org/scratchOrgInfoGeneratorTest.ts
+++ b/test/unit/org/scratchOrgInfoGeneratorTest.ts
@@ -734,7 +734,7 @@ describe('scratchOrgInfoGenerator', () => {
     });
   });
 
-  describe('generateScratchOrgInfo no nonamespace', () => {
+  describe('generateScratchOrgInfo with nonamespace', () => {
     const sandbox = sinon.createSandbox();
     beforeEach(() => {
       stubMethod(sandbox, Org, 'create').resolves(Org.prototype);
@@ -753,7 +753,7 @@ describe('scratchOrgInfoGenerator', () => {
     after(() => {
       sandbox.restore();
     });
-    it('calls generateScratchOrgInfo with no nonamespace but SfProjectJson.get("name") is true', async () => {
+    it('calls generateScratchOrgInfo with nonamespace=false but SfProjectJson.get("namespace") returns a value', async () => {
       expect(
         await generateScratchOrgInfo({
           hubOrg: await Org.create({}),
@@ -764,6 +764,43 @@ describe('scratchOrgInfoGenerator', () => {
       ).to.deep.equal({
         orgName: 'Company',
         namespace: 'my-namespace',
+        package2AncestorIds: '',
+        connectedAppConsumerKey: '1234',
+        connectedAppCallbackUrl: 'http://localhost:1717/OauthRedirect',
+      });
+    });
+
+    it('calls generateScratchOrgInfo with nonamespace=false with provided namespace and SfProjectJson.get("namespace") returns a value', async () => {
+      expect(
+        await generateScratchOrgInfo({
+          hubOrg: await Org.create({}),
+          scratchOrgInfoPayload: {
+            namespace: 'this-namespace-should-win',
+          } as ScratchOrgInfoPayload,
+          nonamespace: false,
+          ignoreAncestorIds: false,
+        })
+      ).to.deep.equal({
+        orgName: 'Company',
+        namespace: 'this-namespace-should-win',
+        package2AncestorIds: '',
+        connectedAppConsumerKey: '1234',
+        connectedAppCallbackUrl: 'http://localhost:1717/OauthRedirect',
+      });
+    });
+
+    it('calls generateScratchOrgInfo with nonamespace=true but a namespace is provided in payload', async () => {
+      expect(
+        await generateScratchOrgInfo({
+          hubOrg: await Org.create({}),
+          scratchOrgInfoPayload: {
+            namespace: 'my-namespace',
+          } as ScratchOrgInfoPayload,
+          nonamespace: true,
+          ignoreAncestorIds: false,
+        })
+      ).to.deep.equal({
+        orgName: 'Company',
         package2AncestorIds: '',
         connectedAppConsumerKey: '1234',
         connectedAppCallbackUrl: 'http://localhost:1717/OauthRedirect',


### PR DESCRIPTION
### What does this PR do?

Remove `namespace` from ScratchOrgInfo payload if the `nonamespace` option is true

### What issues does this PR fix or reference?
@W-15675379@
https://github.com/forcedotcom/cli/issues/2855