### PR TITLE
fix: add oauth options data to auth code exchange errors

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           cache: yarn
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
+        with:
+          ignore-scripts: true
       - run: yarn build
       - run: npm run test:perf | tee test/perf/output.txt
 

--- a/src/logger/filters.ts
+++ b/src/logger/filters.ts
@@ -35,6 +35,7 @@ const FILTERED_KEYS: FilteredKeyDefinition[] = [
   // Any json attribute that contains the words "refresh" and "token" will have the attribute/value hidden
   { name: 'refresh_token', regex: 'refresh[^\'"]*token' },
   { name: 'clientsecret' },
+  { name: 'authcode' },
 ];
 
 const FILTERED_KEYS_FOR_PROCESSING: FilteredKeyForProcessing[] = FILTERED_KEYS.map((key) => ({

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -1106,8 +1106,20 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
       this.logger.info(`Exchanging auth code for access token using loginUrl: ${options.loginUrl}`);
       authFields = await oauth2.requestToken(ensure(options.authCode));
     } catch (err) {
-      const error = SfError.wrap(err);
-      error.message = messages.getMessage('authCodeExchangeError', [error.message]);
+      let error: SfError;
+      let errorMsg: string;
+      if (err instanceof Error) {
+        errorMsg = `${err.name}::${err.message}`;
+        error = SfError.create({
+          message: errorMsg,
+          name: 'AuthCodeExchangeError',
+          cause: err,
+        });
+      } else {
+        error = SfError.wrap(err);
+        errorMsg = error.message;
+      }
+      error.message = messages.getMessage('authCodeExchangeError', [errorMsg]);
       error.setData(getRedactedErrData(options));
       throw error;
     }

--- a/test/unit/logger/filterTest.ts
+++ b/test/unit/logger/filterTest.ts
@@ -19,6 +19,7 @@ describe('filters', () => {
   })}`;
   const obj1 = { accessToken: `${sid}`, refreshToken: `${sid}` };
   const obj2 = { key: 'Access Token', value: `${sid}` };
+  const obj3 = { authCode: 'authcode value' };
   const arr1 = [
     { key: 'ACCESS token ', value: `${sid}` },
     { key: 'refresh  TOKEN', value: `${sid}` },
@@ -57,6 +58,14 @@ describe('filters', () => {
     const bigString = JSON.stringify(result);
     expect(bigString).to.not.contain(sid);
     expect(bigString).to.contain('REDACTED ACCESS TOKEN');
+  });
+
+  it('filters obj3 correctly', () => {
+    const result = getUnwrapped(obj3);
+    assert(result);
+    const bigString = JSON.stringify(result);
+    expect(bigString).to.not.contain('authCode value');
+    expect(bigString).to.contain('authcode - HIDDEN');
   });
 
   it('filters arr1 correctly', () => {


### PR DESCRIPTION
### What does this PR do?
Adds oauth options data to auth code exchange errors, redacting sensitive information, to improve telemetry.

### What issues does this PR fix or reference?
@W-15758926@