### PR TITLE
fix: non-reference clone of transferred listeners

### DIFF
--- a/src/lifecycleEvents.ts
+++ b/src/lifecycleEvents.ts
@@ -15,9 +15,9 @@ import { Logger } from './logger/logger';
 
 // Data of any type can be passed to the callback. Can be cast to any type that is given in emit().
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type callback = (data: any) => Promise<void>;
+export type callback = (data: any) => Promise<void>;
 type ListenerMap = Map<string, callback>;
-type UniqueListenerMap = Map<string, ListenerMap>;
+export type UniqueListenerMap = Map<string, ListenerMap>;
 
 declare const global: {
   salesforceCoreLifecycle?: Lifecycle;
@@ -51,7 +51,7 @@ export class Lifecycle {
 
   private constructor(
     private readonly listeners: Dictionary<callback[]> = {},
-    private readonly uniqueListeners: Map<string, Map<string, callback>> = new Map<string, Map<string, callback>>()
+    private readonly uniqueListeners: UniqueListenerMap = new Map<string, Map<string, callback>>()
   ) {}
 
   /**
@@ -238,5 +238,5 @@ export class Lifecycle {
 }
 
 const cloneListeners: (listeners: ListenerMap) => ListenerMap = (listeners) => new Map(Array.from(listeners.entries()));
-const cloneUniqueListeners = (uniqueListeners: UniqueListenerMap): UniqueListenerMap =>
+export const cloneUniqueListeners = (uniqueListeners: UniqueListenerMap): UniqueListenerMap =>
   new Map(Array.from(uniqueListeners.entries()).map(([key, value]) => [key, cloneListeners(value)]));


### PR DESCRIPTION
### What does this PR do?
scenario: 
1. you build a plugin with an "early" hook (think `init` or `prerun`) which instantiates lifecycle and subscribes a listener with an uniqueId.
2. your plugin uses an older version of this library than the CLI it's installed into
3. when the "main" CLI loads Lifecycle, it tries to transfer the listeners.
4. the map of unique listeners is passed in to the new Lifecycle and deleted from the old one
5. because it was passed by ref, the delete of listeners from the old Lifecycle also deletes them from the new one
6. non-unique listeners were protected from ref-mutation bug by the spread operator (see existing code comment)

This PR adds a cloning step for the map of unique listeners and some UT to verify ref-breaking

the native `structuredClone` can't be used because the `callback` value in the maps is a function and can't be cloneable.
  
### What issues does this PR fix or reference?
[skip-validate-pr]