### PR TITLE
fix: prevent validations on encrypted values

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -420,16 +420,6 @@ export class Config extends ConfigFile<ConfigFile.Options, ConfigProperties> {
     return keyBy(Config.allowedProperties, 'key');
   }
 
-  private static findProperty(key: string): ConfigPropertyMeta {
-    const property = Config.allowedProperties.find((allowedProp) => allowedProp.key === key);
-
-    if (!property) {
-      throw messages.createError('unknownConfigKey', [key]);
-    }
-
-    return property;
-  }
-
   /**
    * Read, assign, and return the config contents.
    */
@@ -503,8 +493,11 @@ export class Config extends ConfigFile<ConfigFile.Options, ConfigProperties> {
    * @param value The value of the property.
    */
   public set<K extends Key<ConfigProperties>>(key: K, value: ConfigProperties[K]): ConfigProperties {
-    const property = Config.findProperty(key);
+    const property = Config.allowedProperties.find((allowedProp) => allowedProp.key === key);
 
+    if (!property) {
+      throw messages.createError('unknownConfigKey', [key]);
+    }
     if (property.deprecated && property.newKey) {
       // you're trying to set a deprecated key, but we'll set the new key instead
       void Lifecycle.getInstance().emitWarning(messages.getMessage('deprecatedConfigKey', [key, property.newKey]));
@@ -597,30 +590,10 @@ export class Config extends ConfigFile<ConfigFile.Options, ConfigProperties> {
 
       this.forEach((key, value) => {
         if (this.getPropertyConfig(key).encrypted && isString(value)) {
-          if (encrypt) {
-            this.setEncryptedProperty(key, ensure(crypto.encrypt(value)));
-          } else {
-            this.set(key, ensure(crypto.decrypt(value)));
-          }
+          super.set(key, ensure(encrypt ? crypto.encrypt(value) : crypto.decrypt(value)));
         }
       });
     }
-  }
-
-  /**
-   * Set an encrypted property without rerunning the validator. Should only be used by `cryptProperties` method.
-   */
-  private setEncryptedProperty<K extends Key<ConfigProperties>>(key: K, value: ConfigProperties[K]): ConfigProperties {
-    const property = Config.findProperty(key);
-
-    if (property.deprecated && property.newKey) {
-      // you're trying to set a deprecated key, but we'll set the new key instead
-      void Lifecycle.getInstance().emitWarning(messages.getMessage('deprecatedConfigKey', [key, property.newKey]));
-      return this.set(property.newKey, value);
-    }
-
-    super.set(property.key, value);
-    return this.getContents();
   }
 }
 

--- a/test/unit/config/configTest.ts
+++ b/test/unit/config/configTest.ts
@@ -290,7 +290,8 @@ describe('Config', () => {
       beforeEach(() => {
         // @ts-expect-error because allowedProperties is protected
         originalAllowedProperties = Config.allowedProperties;
-        (Config as any).allowedProperties = [];
+        // @ts-expect-error because allowedProperties is protected
+        Config.allowedProperties = [];
       });
 
       afterEach(() => {
@@ -335,7 +336,8 @@ describe('Config', () => {
     beforeEach(() => {
       // @ts-expect-error because allowedProperties is protected
       originalAllowedProperties = Config.allowedProperties;
-      (Config as any).allowedProperties = [];
+      // @ts-expect-error because allowedProperties is protected
+      Config.allowedProperties = [];
     });
 
     afterEach(() => {


### PR DESCRIPTION
### What does this PR do?

Prevent validation from being re-run on encrypted values

**Testing**

Create a plugin using `sf dev generate plugin` and add this command: 

```typescript
import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
import { Config } from '@salesforce/core';

// eslint-disable-next-line sf-plugin/command-example
export default class StoreToken extends SfCommand<void> {
  // eslint-disable-next-line sf-plugin/no-hardcoded-messages-commands
  public static readonly summary = 'Programmatically set a token in the global config';

  public static readonly flags = {
    token: Flags.string({
      required: true,
      // eslint-disable-next-line sf-plugin/no-hardcoded-messages-flags
      summary: 'a token to store',
    }),
  };

  public async run(): Promise<void> {
    const { flags } = await this.parse(StoreToken);

    const config = await Config.create({ isGlobal: true, encryptedKeys: ['local-web-server-identity-token'] });
    Config.addAllowedProperties([
      {
        key: 'local-web-server-identity-token',
        description: 'Token for local web server identity',
        encrypted: true,
        input: {
          validator: (value): boolean => typeof value === 'string' && value.startsWith('123'),
          failedMessage: 'Token must start with 123',
        },
      },
    ]);
    config.set('local-web-server-identity-token', flags.token);

    await config.write();

    this.log('Done!');
  }
}
```

Without this change, it will fail validation since the `validator` is rerun during write (which calls `this.cryptProperties(true)`, which calls `set`, which is was calls all the validators)

With the change, the validator is called just once during the initial set for encrypted properties

### What issues does this PR fix or reference?
@W-16049112@