### PR TITLE
Sm/no-capital-enforcement-on-plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "benchmark": "^2.1.4",
     "ts-node": "^10.9.2",
     "ts-patch": "^3.2.0",
-    "typescript": "^5.4.5"
+    "typescript": "5.4.5"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -75,13 +75,11 @@
     "@salesforce/dev-scripts": "^10.1.1",
     "@salesforce/ts-sinon": "^1.4.22",
     "@types/benchmark": "^2.1.5",
-    "@types/chai-string": "^1.4.5",
     "@types/fast-levenshtein": "^0.0.4",
     "@types/jsonwebtoken": "9.0.6",
     "@types/proper-lockfile": "^4.1.4",
     "@types/semver": "^7.5.8",
     "benchmark": "^2.1.4",
-    "chai-string": "^1.5.0",
     "ts-node": "^10.9.2",
     "ts-patch": "^3.2.0",
     "typescript": "^5.4.5"

--- a/src/sfProject.ts
+++ b/src/sfProject.ts
@@ -59,7 +59,7 @@ export type ProjectJson = ConfigContents & ProjectJsonSchema;
  */
 export class SfProjectJson extends ConfigFile<ConfigFile.Options, ProjectJson> {
   /** json properties that are uppercase, or allow uppercase keys inside them */
-  public static BLOCKLIST = ['packageAliases'];
+  public static BLOCKLIST = ['packageAliases', 'plugins'];
 
   public static getFileName(): string {
     return SFDX_PROJECT_JSON;

--- a/test/unit/projectTest.ts
+++ b/test/unit/projectTest.ts
@@ -27,19 +27,38 @@ describe('SfProject', () => {
   });
 
   describe('json', () => {
-    it('allows uppercase packaging aliases on write', async () => {
-      const json = await SfProjectJson.create();
-      json.set('packageAliases', { MyName: 'somePackage' });
-      await json.write();
-      // @ts-expect-error possibly undefined
-      expect($$.getConfigStubContents('SfProjectJson').packageAliases['MyName']).to.equal('somePackage');
+    describe('allowed uppercase', () => {
+      describe('packageAliases', () => {
+        it('allows uppercase packaging aliases on write', async () => {
+          const json = await SfProjectJson.create();
+          json.set('packageAliases', { MyName: 'somePackage' });
+          await json.write();
+          // @ts-expect-error possibly undefined
+          expect($$.getConfigStubContents('SfProjectJson').packageAliases['MyName']).to.equal('somePackage');
+        });
+        it('allows uppercase packaging aliases on read', async () => {
+          $$.setConfigStubContents('SfProjectJson', { contents: { packageAliases: { MyName: 'somePackage' } } });
+          const json = await SfProjectJson.create();
+          // @ts-expect-error possibly undefined
+          expect(json.get('packageAliases')['MyName']).to.equal('somePackage');
+        });
+      });
+      describe('plugins', () => {
+        const pluginsContent = { SomePlugin: 'value', SomeOtherPlugin: { NestedCap: true } };
+        it('allows uppercase packaging aliases on write', async () => {
+          const json = await SfProjectJson.create();
+          json.set('plugins', pluginsContent);
+          await json.write();
+          expect($$.getConfigStubContents('SfProjectJson').plugins).to.deep.equal(pluginsContent);
+        });
+        it('allows uppercase packaging aliases on read', async () => {
+          $$.setConfigStubContents('SfProjectJson', { contents: { plugins: pluginsContent } });
+          const json = await SfProjectJson.create();
+          expect(json.get('plugins')).to.deep.equal(pluginsContent);
+        });
+      });
     });
-    it('allows uppercase packaging aliases on read', async () => {
-      $$.setConfigStubContents('SfProjectJson', { contents: { packageAliases: { MyName: 'somePackage' } } });
-      const json = await SfProjectJson.create();
-      // @ts-expect-error possibly undefined
-      expect(json.get('packageAliases')['MyName']).to.equal('somePackage');
-    });
+
     it('getPackageDirectories should transform packageDir paths to have path separators that match the OS', async () => {
       let defaultPP: string;
       let transformedDefaultPP: string;

--- a/test/unit/projectTest.ts
+++ b/test/unit/projectTest.ts
@@ -45,13 +45,13 @@ describe('SfProject', () => {
       });
       describe('plugins', () => {
         const pluginsContent = { SomePlugin: 'value', SomeOtherPlugin: { NestedCap: true } };
-        it('allows uppercase packaging aliases on write', async () => {
+        it('allows uppercase keys in plugins on write', async () => {
           const json = await SfProjectJson.create();
           json.set('plugins', pluginsContent);
           await json.write();
           expect($$.getConfigStubContents('SfProjectJson').plugins).to.deep.equal(pluginsContent);
         });
-        it('allows uppercase packaging aliases on read', async () => {
+        it('allows uppercase keys in plugins on read', async () => {
           $$.setConfigStubContents('SfProjectJson', { contents: { plugins: pluginsContent } });
           const json = await SfProjectJson.create();
           expect(json.get('plugins')).to.deep.equal(pluginsContent);

--- a/test/unit/util/directoryWriterTest.ts
+++ b/test/unit/util/directoryWriterTest.ts
@@ -8,13 +8,8 @@ import * as os from 'node:os';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { Readable } from 'node:stream';
-import * as chai from 'chai';
-import chaiString from 'chai-string';
+import { expect } from 'chai';
 import { DirectoryWriter } from '../../../src/util/directoryWriter';
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { expect } = chai;
-chai.use(chaiString);
 
 function validateFileContents(filePath: string, expectedContents: string): void {
   const fileContents = fs.readFileSync(filePath, 'utf8');
@@ -32,7 +27,7 @@ describe('DirectoryWriter', () => {
   });
   it('addToStore - string', async () => {
     const contents = 'my-contents';
-    expect(directoryPath).to.startWith(os.tmpdir());
+    expect(directoryPath.startsWith(os.tmpdir())).to.be.true;
     await directoryWriter.addToStore(contents, filename);
     await directoryWriter.finalize();
     expect(fs.existsSync(path.join(directoryPath, filename))).to.be.true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -681,14 +681,7 @@
   resolved "https://registry.yarnpkg.com/@types/benchmark/-/benchmark-2.1.5.tgz#940c1850c18fdfdaee3fd6ed29cd92ae0d445b45"
   integrity sha512-cKio2eFB3v7qmKcvIHLUMw/dIx/8bhWPuzpzRT4unCPRTD8VdA9Zb0afxpcxOqR4PixRS7yT42FqGS8BYL8g1w==
 
-"@types/chai-string@^1.4.5":
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@types/chai-string/-/chai-string-1.4.5.tgz#988ff37526386e9c354219b163d7ecf81bab8d2d"
-  integrity sha512-IecXRMSnpUvRnTztdpSdjcmcW7EdNme65bfDCQMi7XrSEPGmyDYYTEfc5fcactWDA6ioSm8o7NUqg9QxjBCCEw==
-  dependencies:
-    "@types/chai" "*"
-
-"@types/chai@*", "@types/chai@^4.3.14":
+"@types/chai@^4.3.14":
   version "4.3.16"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.16.tgz#b1572967f0b8b60bf3f87fe1d854a5604ea70c82"
   integrity sha512-PatH4iOdyh3MyWtmHVFXLWCCIhUbopaltqddG9BzB+gMIzee2MJrvd+jouii9Z3wzQJruGWAm7WOMjgfG8hQlQ==
@@ -1289,11 +1282,6 @@ capital-case@^1.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
     upper-case-first "^2.0.2"
-
-chai-string@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/chai-string/-/chai-string-1.5.0.tgz#0bdb2d8a5f1dbe90bc78ec493c1c1c180dd4d3d2"
-  integrity sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw==
 
 chai@^4.3.10:
   version "4.4.1"
@@ -4691,16 +4679,7 @@ srcset@^5.0.0:
   resolved "https://registry.yarnpkg.com/srcset/-/srcset-5.0.1.tgz#e660a728f195419e4afa95121099bc9efb7a1e36"
   integrity sha512-/P1UYbGfJVlxZag7aABNRrulEXAwCSDo7fklafOQrantuPTDmYgijJMks2zusPCVzgW9+4P69mq7w6pYuZpgxw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4760,14 +4739,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5066,9 +5038,9 @@ typedoc@^0.25.13:
     shiki "^0.14.7"
 
 "typescript@^4.6.4 || ^5.2.2", typescript@^5.4.3, typescript@^5.4.5:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
+  integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"
@@ -5264,7 +5236,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5277,15 +5249,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5037,7 +5037,12 @@ typedoc@^0.25.13:
     minimatch "^9.0.3"
     shiki "^0.14.7"
 
-"typescript@^4.6.4 || ^5.2.2", typescript@^5.4.3, typescript@^5.4.5:
+typescript@5.4.5:
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
+  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+
+"typescript@^4.6.4 || ^5.2.2", typescript@^5.4.3:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
   integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==


### PR DESCRIPTION
### What does this PR do?

sfdx-project.json has a 3PP prop called `plugins`.  Allow capital-case keys there.

pin ts to avoid 5.5 until https://github.com/nonara/ts-patch/pull/161 is in for ts-patch

drop a dev-dep that was pulled in for a single UT assertion

### What issues does this PR fix or reference?
@W-5571825@
