### PR TITLE
util.format list issue

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -588,8 +588,16 @@ export class Messages<T extends string> {
     }
     const messages = ensureArray(msg);
     return messages.map((message) => {
-      ensureString(message);
-      return util.format(message, ...tokens);
+      const msgStr = ensureString(message);
+      // If the message does not contain a specifier, util.format still appends the token to the end.
+      // The 'markdownLoader' automatically splits bulleted lists into arrays.
+      // This causes the token to be appended to each line regardless of the presence of a specifier.
+      // Here we check for the presence of a specifier and only format the message if one is present.
+      // https://nodejs.org/api/util.html#utilformatformat-args
+      // https://regex101.com/r/8Hf8Z6/1
+      const specifierRegex = new RegExp('%[sdifjoO]{1}', 'gm');
+
+      return specifierRegex.test(msgStr) ? util.format(msgStr, ...tokens) : msgStr;
     });
   }
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -12,6 +12,7 @@ import * as util from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { AnyJson, asString, ensureJsonMap, ensureString, isJsonMap, isObject } from '@salesforce/ts-types';
 import { ensureArray, upperFirst } from '@salesforce/kit';
+import { Lifecycle } from './lifecycleEvents';
 import { SfError } from './sfError';
 
 export type Tokens = Array<string | boolean | number | null | undefined>;
@@ -597,7 +598,22 @@ export class Messages<T extends string> {
       // https://regex101.com/r/8Hf8Z6/1
       const specifierRegex = new RegExp('%[sdifjoO]{1}', 'gm');
 
-      return specifierRegex.test(msgStr) ? util.format(msgStr, ...tokens) : msgStr;
+      // NOTE: This is a temporary telemetry event to track down missing specifiers in messages.
+      //       Once we have enough data and correct missing specifiers, we can remove this.
+      //       The followup work is outlined in: W-16197665
+      if (!specifierRegex.test(msgStr) && tokens.length > 0) {
+        void Lifecycle.getInstance().emitTelemetry({
+          eventName: 'missing_message_specifier',
+          library: 'sfdx-core',
+          function: 'getMessageWithMap',
+          messagesLength: messages.length,
+          message: msgStr,
+          tokensLength: tokens.length,
+        });
+      }
+
+      // return specifierRegex.test(msgStr) ? util.format(msgStr, ...tokens) : msgStr;
+      return util.format(msgStr, ...tokens);
     });
   }
 }

--- a/test/unit/messagesTest.ts
+++ b/test/unit/messagesTest.ts
@@ -67,14 +67,14 @@ describe('Messages', () => {
 
     it('should return single string from array of messages', () => {
       expect(messages.getMessage('manyMsgs', ['blah', 864])).to.equal(
-        `hello${EOL}world${EOL}test message 2 blah and 864`
+        `hello blah 864${EOL}world blah 864${EOL}test message 2 blah and 864`
       );
     });
 
     it('should return multiple string from array of messages', () => {
       expect(messages.getMessages('manyMsgs', ['blah', 864])).to.deep.equal([
-        'hello',
-        'world',
+        'hello blah 864',
+        'world blah 864',
         'test message 2 blah and 864',
       ]);
     });

--- a/test/unit/messagesTest.ts
+++ b/test/unit/messagesTest.ts
@@ -67,14 +67,14 @@ describe('Messages', () => {
 
     it('should return single string from array of messages', () => {
       expect(messages.getMessage('manyMsgs', ['blah', 864])).to.equal(
-        `hello blah 864${EOL}world blah 864${EOL}test message 2 blah and 864`
+        `hello${EOL}world${EOL}test message 2 blah and 864`
       );
     });
 
     it('should return multiple string from array of messages', () => {
       expect(messages.getMessages('manyMsgs', ['blah', 864])).to.deep.equal([
-        'hello blah 864',
-        'world blah 864',
+        'hello',
+        'world',
         'test message 2 blah and 864',
       ]);
     });


### PR DESCRIPTION
### What does this PR do?

> [!NOTE]
> We decided to postpone this change to collect information via telemetry. Once all missing specifiers have been corrected, we will enforce them. Follow up work will be completed in [@W-16197665@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-16197665)

> [!CAUTION]
> This is technically a breaking change. If we have a message somewhere that is missing a specifier, the tokens will no longer be rendered. This is a difficult thing to validate across our codebase. We could do a few things:
> - Wait until the next major release of `sfdx-core`
> - Add telemetry for when a specifier is missing and monitor it over the coming weeks
> - Only skip formatting if `messages` has a length greater than `1`

This is a solution to prevent tokens from being rendered in a message when a specifier (e.g. `%s`) does not exist

If the message does not contain a specifier, node's `util.format` still appends the token to the end ([docs](https://nodejs.org/api/util.html#utilformatformat-args:~:text=If%20there%20are%20more%20arguments%20passed%20to%20the%20util.format()%20method%20than%20the%20number%20of%20specifiers%2C%20the%20extra%20arguments%20are%20concatenated%20to%20the%20returned%20string%2C%20separated%20by%20spaces))

This issue was discovered in `sf whatsnew --help` where the token for the specifier `%s` was being rendered at the end of each example. This was happening because the `markdownLoader` automatically splits bulleted lists into arrays.

 We now check for the presence of a specifier and only format the message if one is present.

### BEFORE:
<img width="1381" alt="Screenshot 2024-07-09 at 11 08 10 AM" src="https://github.com/forcedotcom/sfdx-core/assets/1715111/f86431df-069e-4e9f-a1e5-244212be9a1d">

### AFTER:
<img width="1380" alt="Screenshot 2024-07-09 at 11 08 39 AM" src="https://github.com/forcedotcom/sfdx-core/assets/1715111/daaeaeb2-2c43-4c01-a744-bf8b5f5638ee">

### Testing
- Pull branch
- `yarn build`
- `yarn link`
- `cd` to plugin-info
- `yarn link @salesforce/core`
- `bin/run.js whatsnew --help`


### What issues does this PR fix or reference?
[@W-16188160@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-16188160)