### PR TITLE
@W-14945321@ Deprecate CMTRecordManagedDeletion scratch org feature

### DIFF
--- a/src/org/scratchOrgFeatureDeprecation.ts
+++ b/src/org/scratchOrgFeatureDeprecation.ts
@@ -27,6 +27,7 @@ const FEATURE_TYPES = {
     'EXPANDEDSOURCETRACKING',
     'LISTCUSTOMSETTINGCREATION',
     'AppNavCapabilities',
+    'CMTRecordManagedDeletion',
     'EditInSubtab',
     'OldNewRecordFlowConsole',
     'OldNewRecordFlowStd',


### PR DESCRIPTION
### What does this PR do?
This deprecates the CMTRecordManagedDeletion scratch org feature, which allowed deletion of managed released custom metadata records. Deletion of managed released custom metadata records is now available to all ISVs with the general ability to delete released components of managed packages.

### What issues does this PR fix or reference?
@W-14945321@
https://github.com/forcedotcom/cli/issues/2957