### PR TITLE
fix: use EnvVar class for audience url and domain retry env vars

### DIFF
--- a/test/unit/util/getJwtAudienceUrlTest.ts
+++ b/test/unit/util/getJwtAudienceUrlTest.ts
@@ -25,6 +25,7 @@ describe('getJwtAudienceUrl', () => {
 
   afterEach(() => {
     env.unset('SFDX_AUDIENCE_URL');
+    env.unset('SF_AUDIENCE_URL');
   });
 
   it('return the correct jwt audience for undefined loginUrl', async () => {
@@ -53,9 +54,16 @@ describe('getJwtAudienceUrl', () => {
   });
 
   it('should use the correct audience URL for SFDX_AUDIENCE_URL env var', async () => {
-    env.setString('SFDX_AUDIENCE_URL', 'http://authInfoTest/audienceUrl/test');
+    env.setString('SFDX_AUDIENCE_URL', 'http://authInfoTest-sfdx/audienceUrl/test');
     const url = new SfdcUrl('https://login.salesforce.com');
     const response = await url.getJwtAudienceUrl();
     expect(response).to.be.equal(process.env.SFDX_AUDIENCE_URL);
+  });
+
+  it('should use the correct audience URL for SF_AUDIENCE_URL env var', async () => {
+    env.setString('SF_AUDIENCE_URL', 'http://authInfoTest-sf/audienceUrl/test');
+    const url = new SfdcUrl('https://login.salesforce.com');
+    const response = await url.getJwtAudienceUrl();
+    expect(response).to.be.equal(process.env.SF_AUDIENCE_URL);
   });
 });

--- a/test/unit/util/sfdcUrlTest.ts
+++ b/test/unit/util/sfdcUrlTest.ts
@@ -261,6 +261,7 @@ describe('util/sfdcUrl', () => {
 
     afterEach(() => {
       env.unset('SFDX_AUDIENCE_URL');
+      env.unset('SF_AUDIENCE_URL');
     });
 
     it('should use the correct audience URL for createdOrgInstance beginning with "gs1"', async () => {
@@ -278,10 +279,25 @@ describe('util/sfdcUrl', () => {
     });
 
     it('should use the correct audience URL for SFDX_AUDIENCE_URL env var', async () => {
-      env.setString('SFDX_AUDIENCE_URL', 'http://authInfoTest/audienceUrl/test');
+      env.setString('SFDX_AUDIENCE_URL', 'http://authInfoTest-sfdx/audienceUrl/test');
       const url = new SfdcUrl('https://login.salesforce.com');
       const response = await url.getJwtAudienceUrl();
       expect(response).to.be.equal(process.env.SFDX_AUDIENCE_URL);
+    });
+
+    it('should use the correct audience URL for SF_AUDIENCE_URL env var', async () => {
+      env.setString('SF_AUDIENCE_URL', 'http://authInfoTest-sf/audienceUrl/test');
+      const url = new SfdcUrl('https://login.salesforce.com');
+      const response = await url.getJwtAudienceUrl();
+      expect(response).to.be.equal(process.env.SF_AUDIENCE_URL);
+    });
+
+    it('should use the correct audience URL for SF_AUDIENCE_URL and SFDX_AUDIENCE_URL env vars', async () => {
+      env.setString('SFDX_AUDIENCE_URL', 'http://authInfoTest-sfdx/audienceUrl/test');
+      env.setString('SF_AUDIENCE_URL', 'http://authInfoTest-sf/audienceUrl/test');
+      const url = new SfdcUrl('https://login.salesforce.com');
+      const response = await url.getJwtAudienceUrl();
+      expect(response).to.be.equal(process.env.SF_AUDIENCE_URL);
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
Changes `SfdcUrl.getJwtAudienceUrl()` to use and prefer the `SF_AUDIENCE_URL` over `SFDX_AUDIENCE_URL`.  Same for the `SF_DOMAIN_RETRY` and `SFDX_DOMAIN_RETRY` env vars.

### What issues does this PR fix or reference?
@W-16277316@