### PR TITLE
fix: wrap-error-like-objects

### DIFF
--- a/src/sfError.ts
+++ b/src/sfError.ts
@@ -191,6 +191,12 @@ const fromBasicError = <T extends ErrorDataProperties>(err: unknown): SfError<T>
 
 /* an object that is the result of spreading an Error or SfError  */
 const fromErrorLikeObject = <T extends ErrorDataProperties>(err: unknown): SfError<T> | undefined => {
+  if (!err || typeof err !== 'object') {
+    return undefined;
+  }
+  if (!('message' in err)) {
+    return undefined;
+  }
   try {
     return SfError.create<T>(err as Error);
   } catch {

--- a/test/unit/sfErrorTest.ts
+++ b/test/unit/sfErrorTest.ts
@@ -162,21 +162,7 @@ describe('SfError', () => {
         assert(mySfError.cause instanceof Error);
         expect(mySfError.cause.cause).to.equal(wrapMe);
       });
-      it('an object', () => {
-        const wrapMe = { a: 2 };
-        const mySfError = SfError.wrap(wrapMe);
-        expect(mySfError).to.be.an.instanceOf(SfError);
-        assert(mySfError.cause instanceof Error);
-        expect(mySfError.cause.cause).to.equal(wrapMe);
-      });
-      it('an object that has a code', () => {
-        const wrapMe = { a: 2, code: 'foo' };
-        const mySfError = SfError.wrap(wrapMe);
-        expect(mySfError).to.be.an.instanceOf(SfError);
-        assert(mySfError.cause instanceof Error);
-        expect(mySfError.cause.cause).to.equal(wrapMe);
-        expect(mySfError.code).to.equal('foo');
-      });
+
       it('an array', () => {
         const wrapMe = [1, 5, 6];
         const mySfError = SfError.wrap(wrapMe);
@@ -190,6 +176,44 @@ describe('SfError', () => {
         expect(mySfError).to.be.an.instanceOf(SfError);
         assert(mySfError.cause instanceof Error);
         expect(mySfError.cause.cause).to.equal(wrapMe);
+      });
+      describe('objects', () => {
+        describe('error-like', () => {
+          it('an object with only a message', () => {
+            const wrapMe = { message: 'foo' };
+            const mySfError = SfError.wrap(wrapMe);
+            expect(mySfError).to.be.an.instanceOf(SfError);
+            expect(mySfError.message).to.equal('foo');
+            expect(mySfError.exitCode).to.equal(1);
+            expect(mySfError.name).to.equal('SfError');
+          });
+          it('an object with several props and code', () => {
+            const wrapMe = { message: 'foo', name: 'bar', code: 'baz', exitCode: 100 };
+            const mySfError = SfError.wrap(wrapMe);
+            expect(mySfError).to.be.an.instanceOf(SfError);
+            expect(mySfError.message).to.equal('foo');
+            expect(mySfError.exitCode).to.equal(100);
+            expect(mySfError.name).to.equal('bar');
+            expect(mySfError.code).to.equal('baz');
+          });
+        });
+        describe('not error-like', () => {
+          it('an object', () => {
+            const wrapMe = { a: 2 };
+            const mySfError = SfError.wrap(wrapMe);
+            expect(mySfError).to.be.an.instanceOf(SfError);
+            assert(mySfError.cause instanceof Error);
+            expect(mySfError.cause.cause).to.equal(wrapMe);
+          });
+          it('an object that has a code', () => {
+            const wrapMe = { a: 2, code: 'foo' };
+            const mySfError = SfError.wrap(wrapMe);
+            expect(mySfError).to.be.an.instanceOf(SfError);
+            assert(mySfError.cause instanceof Error);
+            expect(mySfError.cause.cause).to.equal(wrapMe);
+            expect(mySfError.code).to.equal('foo');
+          });
+        });
       });
     });
   });

--- a/test/unit/sfErrorTest.ts
+++ b/test/unit/sfErrorTest.ts
@@ -205,6 +205,13 @@ describe('SfError', () => {
             assert(mySfError.cause instanceof Error);
             expect(mySfError.cause.cause).to.equal(wrapMe);
           });
+          it('empty object', () => {
+            const wrapMe = {};
+            const mySfError = SfError.wrap(wrapMe);
+            expect(mySfError).to.be.an.instanceOf(SfError);
+            assert(mySfError.cause instanceof Error);
+            expect(mySfError.cause.cause).to.equal(wrapMe);
+          });
           it('an object that has a code', () => {
             const wrapMe = { a: 2, code: 'foo' };
             const mySfError = SfError.wrap(wrapMe);


### PR DESCRIPTION
### What does this PR do?
spreading an error, like https://github.com/salesforcecli/plugin-deploy-retrieve/blob/af41a48180f944e01f1c5e0b8ad79148b89c90c2/src/commands/project/deploy/quick.ts#L132 will pass a param that is not an instance of SfError which cause SfError.wrap to wrap it in another error.  The human output doesn't show the wrapped error, which makes it harder for users to know what's wrong.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2962
@W-16297490@