### PR TITLE
feat(generateScratchOrgInfo): allow shema key

### DIFF
--- a/src/org/scratchOrgInfoGenerator.ts
+++ b/src/org/scratchOrgInfoGenerator.ts
@@ -322,6 +322,8 @@ const parseDefinitionFile = async (definitionFile: string): Promise<Record<strin
   try {
     const fileData = await fs.readFile(definitionFile, 'utf8');
     const defFileContents = parseJson(fileData) as Record<string, unknown>;
+    // remove key '$schema' from the definition file
+    delete defFileContents['$schema'];
     return defFileContents;
   } catch (err) {
     const error = err as Error;

--- a/test/unit/org/scratchOrgInfoGenerator.test.ts
+++ b/test/unit/org/scratchOrgInfoGenerator.test.ts
@@ -1026,5 +1026,25 @@ describe('scratchOrgInfoGenerator', () => {
         expect(err).to.exist;
       }
     });
+    it('Remove $schema key if it exist', async () => {
+      sandbox.restore();
+      stubMethod(sandbox, fs.promises, 'readFile')
+        .withArgs('./my-file.json', 'utf8')
+        .resolves(
+          '{ "$schema": "https://forcedotcom.github.io/schemas/project-scratch-def.json/project-scratch-def.schema.json" }'
+        );
+      expect(
+        await getScratchOrgInfoPayload({
+          durationDays: 1,
+          definitionfile: './my-file.json',
+        })
+      ).to.deep.equal({
+        scratchOrgInfoPayload: {
+          durationDays: 1,
+        },
+        ignoreAncestorIds: false,
+        warnings: [],
+      });
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?

This pr remove $schema key from parsed scratchorg definition. allowing to pass check `scratchOrgInfoPayload must be heads down camelcase.` and so preventing `InvalidJsonCasing` exceptions

### What issues does this PR fix or reference?

`InvalidJsonCasing` are raised if definition file contains `$schema` key (from [documentation](https://forcedotcom.github.io/schemas/))