### PR TITLE
chore: set the default node version in bundle publishing flow [skip validate pr]

### DIFF
--- a/.github/workflows/esbuild-publish.yml
+++ b/.github/workflows/esbuild-publish.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ inputs.branch }}
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ inputs.nodeVersion }}
+          node-version: ${{ inputs.nodeVersion || 'lts/*' }}
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main


### PR DESCRIPTION
@W-0000@
see if providing a default value for node version fixes the bundle publishing workflow