### PR TITLE
fix: update error message for sfdx auth url

### DIFF
--- a/messages/core.md
+++ b/messages/core.md
@@ -34,6 +34,10 @@ Errors encountered:
 
 Error authenticating with the refresh token due to: %s
 
+# invalidSfdxAuthUrlError
+
+Invalid SFDX auth URL. Must be in the format "force://<clientId>:<clientSecret>:<refreshToken>@<instanceUrl>". Note that the "instanceUrl" inside the SFDX auth URL doesn\'t include a protocol ("https://").
+
 # orgDataNotAvailableError
 
 An attempt to refresh the authentication token failed with a 'Data Not Found Error'. The org identified by username %s does not appear to exist. Likely cause is that the org was deleted by another user or has expired.

--- a/messages/core.md
+++ b/messages/core.md
@@ -36,7 +36,7 @@ Error authenticating with the refresh token due to: %s
 
 # invalidSfdxAuthUrlError
 
-Invalid SFDX auth URL. Must be in the format "force://<clientId>:<clientSecret>:<refreshToken>@<instanceUrl>". Note that the "instanceUrl" inside the SFDX auth URL doesn\'t include a protocol ("https://").
+Invalid SFDX authorization URL. Must be in the format "force://<clientId>:<clientSecret>:<refreshToken>@<instanceUrl>". Note that the "instanceUrl" inside the SFDX authorization URL doesn\'t include the protocol ("https://"). Run "org display --target-org" on an org to see an example of an SFDX authorization URL. 
 
 # orgDataNotAvailableError
 

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -367,10 +367,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     );
 
     if (!match) {
-      throw new SfError(
-        'Invalid SFDX auth URL. Must be in the format "force://<clientId>:<clientSecret>:<refreshToken>@<instanceUrl>".  Note that the SFDX auth URL uses the "force" protocol, and not "http" or "https".  Also note that the "instanceUrl" inside the SFDX auth URL doesn\'t include the protocol ("https://").',
-        'INVALID_SFDX_AUTH_URL'
-      );
+      throw new SfError(messages.getMessage('invalidSfdxAuthUrlError'), 'INVALID_SFDX_AUTH_URL');
     }
     const [, clientId, clientSecret, refreshToken, loginUrl] = match;
     return {
@@ -1073,8 +1070,9 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     let authFieldsBuilder: TokenResponse;
     try {
       authFieldsBuilder = await oauth2.refreshToken(ensure(fullOptions.refreshToken));
-    } catch (err) {
-      throw messages.createError('refreshTokenAuthError', [(err as Error).message]);
+    } catch (err: unknown) {
+      const cause = err instanceof Error ? err : SfError.wrap(err);
+      throw messages.createError('refreshTokenAuthError', [cause.message], undefined, cause);
     }
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
### What does this PR do?
The error message in sfdx-core needs to be updated so that the "force://" protocol language is clearer.

Also updated the `buildRefreshTokenConfig()` method to properly wrap and throw the original error.

### What issues does this PR fix or reference?
@W-16726261@