### PR TITLE
Add message specifier

### DIFF
--- a/messages/encryption.md
+++ b/messages/encryption.md
@@ -56,7 +56,7 @@ The service and account specified in %s do not match the version of the toolbelt
 
 # genericKeychainInvalidPermsError
 
-Invalid file permissions for secret file %s
+Invalid file permissions for secret file: %s
 
 # genericKeychainInvalidPermsError.actions
 

--- a/messages/encryption.md
+++ b/messages/encryption.md
@@ -56,7 +56,7 @@ The service and account specified in %s do not match the version of the toolbelt
 
 # genericKeychainInvalidPermsError
 
-Invalid file permissions for secret file
+Invalid file permissions for secret file %s
 
 # genericKeychainInvalidPermsError.actions
 


### PR DESCRIPTION
### What does this PR do?
We will be changing how `util.format` works when formatting messages. 
Specifiers (eg `%s`) will be required for the data to be rendered. As is, it appends data if no matching specifier is found.

### What issues does this PR fix or reference?
More info here: https://github.com/forcedotcom/sfdx-core/pull/1099
[@W-16197665@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-16197665)
