### PR TITLE
Enforce specifiers in messages 

### DIFF
--- a/test/unit/messages.test.ts
+++ b/test/unit/messages.test.ts
@@ -67,14 +67,14 @@ describe('Messages', () => {
 
     it('should return single string from array of messages', () => {
       expect(messages.getMessage('manyMsgs', ['blah', 864])).to.equal(
-        `hello blah 864${EOL}world blah 864${EOL}test message 2 blah and 864`
+        `hello${EOL}world${EOL}test message 2 blah and 864`
       );
     });
 
     it('should return multiple string from array of messages', () => {
       expect(messages.getMessages('manyMsgs', ['blah', 864])).to.deep.equal([
-        'hello blah 864',
-        'world blah 864',
+        'hello',
+        'world',
         'test message 2 blah and 864',
       ]);
     });


### PR DESCRIPTION
### What does this PR do?
Specifiers (eg %s) will be required for the data to be rendered. As is, it appends data if no matching specifier is found.

Much more information can be found here: https://github.com/forcedotcom/sfdx-core/pull/1099
That PR also includes the testing instructions.

### What issues does this PR fix or reference?
[@W-16197665@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-16197665)