### PR TITLE
fix: improved scratch org create authentication

### DIFF
--- a/src/config/ttlConfig.ts
+++ b/src/config/ttlConfig.ts
@@ -44,6 +44,11 @@ export class TTLConfig<T extends TTLConfig.Options, P extends JsonMap> extends C
   }
 
   protected async init(): Promise<void> {
+    // Normally, this is done in super.init() but we don't call it to prevent
+    // redundant read() calls.
+    if (this.hasEncryption()) {
+      await this.initCrypto();
+    }
     const contents = await this.read(this.options.throwOnNotFound);
     const date = new Date().getTime();
 

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -1115,7 +1115,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     // Exchange the auth code for an access token and refresh token.
     let authFields: TokenResponse;
     try {
-      this.logger.info(`Exchanging auth code for access token using loginUrl: ${options.loginUrl}`);
+      this.logger.debug(`Exchanging auth code for access token using loginUrl: ${options.loginUrl}`);
       authFields = await oauth2.requestToken(ensure(options.authCode));
     } catch (err) {
       const msg = err instanceof Error ? `${err.name}::${err.message}` : typeof err === 'string' ? err : 'UNKNOWN';

--- a/src/org/scratchOrgCache.ts
+++ b/src/org/scratchOrgCache.ts
@@ -24,6 +24,7 @@ export type CachedOptions = {
 };
 
 export class ScratchOrgCache extends TTLConfig<TTLConfig.Options, CachedOptions> {
+  protected static readonly encryptedKeys = ['clientSecret'];
   public static getFileName(): string {
     return 'scratch-create-cache.json';
   }
@@ -34,6 +35,7 @@ export class ScratchOrgCache extends TTLConfig<TTLConfig.Options, CachedOptions>
       isState: true,
       filename: ScratchOrgCache.getFileName(),
       stateFolder: Global.SF_STATE_FOLDER,
+      encryptedKeys: ScratchOrgCache.encryptedKeys,
       ttl: Duration.days(1),
     };
   }


### PR DESCRIPTION
### What does this PR do?
1. The `signupTargetLoginUrl` override used in sfdx-project.json files was not used for scratchOrgResumes, causing auth code exchange issues during resume.  It is now used.
2. encrypts the client secret written to the scratch-create-cache.json file.
3. If the auth code exchange fails when using a loginUrl that differs from `ScratchOrgInfo.LoginUrl` another attempt is made using `ScratchOrgInfo.LoginUrl`.
4. Improves debug logging for the loginUrl used during the auth code exchange

### What issues does this PR fix or reference?
@W-16825003@

To QA:
- use a devhub with another connected app that has a consumer secret and use it to create scratch orgs.  Ensure the clientSecret value written to the cache file is encrypted.
- resume a scratch org create where the `signupTargetLoginUrl` is necessary and ensure that login URL override is used for the auth code exchange.
- check that another attempt is made if the auth code exchange fails with the first loginUrl if that loginUrl doesn't match ScratchOrgInfo.LoginUrl.