### PR TITLE
fix: dns lookup doesn't include port

### DIFF
--- a/src/status/myDomainResolver.ts
+++ b/src/status/myDomainResolver.ts
@@ -83,24 +83,24 @@ export class MyDomainResolver extends AsyncOptionalCreatable<MyDomainResolver.Op
     const self: MyDomainResolver = this;
     const pollingOptions: PollingClient.Options = {
       async poll(): Promise<StatusResult> {
-        const { host } = self.options.url;
+        const { hostname } = self.options.url;
         let dnsResult: { address: string };
         try {
-          self.logger.debug(`Attempting to resolve url: ${host}`);
+          self.logger.debug(`Attempting to resolve url: ${hostname}`);
           if (new SfdcUrl(self.options.url).isLocalUrl()) {
             return {
               completed: true,
               payload: '127.0.0.1',
             };
           }
-          dnsResult = await promisify(lookup)(host);
-          self.logger.debug(`Successfully resolved host: ${host} result: ${JSON.stringify(dnsResult)}`);
+          dnsResult = await promisify(lookup)(hostname);
+          self.logger.debug(`Successfully resolved host: ${hostname} result: ${JSON.stringify(dnsResult)}`);
           return {
             completed: true,
             payload: dnsResult.address,
           };
         } catch (e) {
-          self.logger.debug(`An error occurred trying to resolve: ${host}`);
+          self.logger.debug(`An error occurred trying to resolve: ${hostname}`);
           self.logger.debug(`Error: ${(e as Error).message}`);
           self.logger.debug('Re-trying dns lookup again....');
           return {

--- a/src/util/sfdcUrl.ts
+++ b/src/util/sfdcUrl.ts
@@ -135,7 +135,7 @@ export class SfdcUrl extends URL {
       '.stm.salesforce.ms',
       '.pc-rnd.force.com',
       '.pc-rnd.salesforce.com',
-      '.wc.crm.dev', // workspaces container
+      '.crm.dev', // workspaces container
     ];
     return (
       this.origin.startsWith('https://gs1.') ||

--- a/test/unit/status/myDomainResolver.test.ts
+++ b/test/unit/status/myDomainResolver.test.ts
@@ -20,7 +20,8 @@ describe('myDomainResolver', () => {
   const TEST_IP = '1.1.1.1';
   const CALL_COUNT = 3;
 
-  let lookupAsyncSpy: { callCount: number };
+  let lookupAsyncSpy: sinon.SinonStub;
+
   beforeEach(() => {
     lookupAsyncSpy = $$.SANDBOX.stub(dns, 'lookup').callsFake((host: string, callback: AnyFunction) => {
       const isDefaultHost = host === MyDomainResolver.DEFAULT_DOMAIN.host;
@@ -43,6 +44,17 @@ describe('myDomainResolver', () => {
     const ip = await resolver.resolve();
     expect(ip).to.be.equal(TEST_IP);
     expect(lookupAsyncSpy.callCount).to.be.equal(CALL_COUNT);
+  });
+
+  it('should do lookup without port', async () => {
+    const options: MyDomainResolver.Options = {
+      url: new URL(`https://${POSITIVE_HOST}:6101`),
+    };
+    const resolver: MyDomainResolver = await MyDomainResolver.create(options);
+    const ip = await resolver.resolve();
+    expect(ip).to.be.equal(TEST_IP);
+    // verify that it uses hostname (without port) not host
+    expect(lookupAsyncSpy.args[0][0]).to.be.equal(POSITIVE_HOST);
   });
 
   describe('disable dns check', () => {

--- a/test/unit/util/sfdcUrl.test.ts
+++ b/test/unit/util/sfdcUrl.test.ts
@@ -180,9 +180,16 @@ describe('util/sfdcUrl', () => {
       expect(url.isLocalUrl()).to.equal(true);
     });
     it('workspaces with port is internal but not local', () => {
-      const url = new SfdcUrl('https://dev.salesforce-com.shane-mclaughlin-0lrfx7zp3l121.wc.crm.dev:6101/');
-      expect(url.isInternalUrl()).to.equal(true);
-      expect(url.isLocalUrl()).to.equal(false);
+      const urls = [
+        'https://dev.salesforce-com.shane-mclaughlin-0lrfx7zp3l121.wc.crm.dev:6101/',
+        'https://dev.salesforce-com.shane-mclaughlin-0lrfx7zp3l121.wb.crm.dev:6101/',
+        'https://dev.salesforce-com.shane-mclaughlin-0lrfx7zp3l121.wa.crm.dev:6101/',
+      ].map((u) => new SfdcUrl(u));
+
+      urls.map((url) => {
+        expect(url.isInternalUrl()).to.equal(true);
+        expect(url.isLocalUrl()).to.equal(false);
+      });
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
this works fine in "normal" user land with normal instanceUrls
for weird internal, the DNS lookup fails because of the port being in the url

https://nodejs.org/api/url.html#urlhostname
hostname has no port (and dns.lookup is fine)
host has the port (and dns.lookup fails)

also, workspaces url have changed (was previously `wc.dev.crm` but lately seing more `wb.dev.crm` 🤷🏻 

### What issues does this PR fix or reference?
[@W-17167313@](https://gus.lightning.force.com/a07EE00002563cnYAA)
and also the issue where internals have to add `SF_DISABLE_DNS_CHECK:true` to avoid the port issue.