### PR TITLE
fix(oauth): bubble up new token when refreshing it

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2024, Salesforce.com, Inc.
+Copyright (c) 2025, Salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/src/org/connection.ts
+++ b/src/org/connection.ts
@@ -14,7 +14,6 @@ import { asString, ensure, isString, JsonMap, Optional } from '@salesforce/ts-ty
 import {
   Connection as JSForceConnection,
   ConnectionConfig,
-  HttpMethods,
   HttpRequest,
   QueryOptions,
   QueryResult,
@@ -414,14 +413,19 @@ export class Connection<S extends Schema = Schema> extends JSForceConnection<S> 
   }
 
   /**
-   * Executes a get request on the baseUrl to force an auth refresh
-   * Useful for the raw methods (request, requestRaw) that use the accessToken directly and don't handle refreshes
+   * Executes a HEAD request on the baseUrl to force an auth refresh.
+   * This is useful for the raw methods (request, requestRaw) that use the accessToken directly and don't handle refreshes.
+   *
+   * This method issues a request using the current access token to check if it is still valid.
+   * If the request returns 200, no refresh happens, and we keep the token.
+   * If it returns 401, jsforce will request a new token and set it in the connection instance.
    */
+
   public async refreshAuth(): Promise<void> {
     this.logger.debug('Refreshing auth for org.');
-    const requestInfo = {
+    const requestInfo: HttpRequest = {
       url: this.baseUrl(),
-      method: 'GET' as HttpMethods,
+      method: 'HEAD',
     };
     await this.request(requestInfo);
   }

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -792,13 +792,18 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
   }
 
   /**
-   * Refreshes the auth for this org's instance by calling HTTP GET on the baseUrl of the connection object.
+   * Executes a HEAD request on the baseUrl to force an auth refresh.
+   * This is useful for the raw methods (request, requestRaw) that use the accessToken directly and don't handle refreshes.
+   *
+   * This method issues a request using the current access token to check if it is still valid.
+   * If the request returns 200, no refresh happens, and we keep the token.
+   * If it returns 401, jsforce will request a new token and set it in the connection instance.
    */
   public async refreshAuth(): Promise<void> {
     this.logger.debug('Refreshing auth for org.');
     const requestInfo: HttpRequest = {
       url: this.getConnection().baseUrl(),
-      method: 'GET',
+      method: 'HEAD',
     };
 
     await this.getConnection().request(requestInfo);


### PR DESCRIPTION
### What does this PR do?

Fixes `AuthInfo.refreshFn` passing the expired access token instead of the new fresh one when refreshing the session.
Others:
* makes `Org/Connection` refreshAuth do a HEAD request (small improvement)
* add UT to cover AuthInfo.refreshFn always passing the right token.


### Context

sfdx-core sets a custom refreshFn for oauth refresh (jsforce has a default one but ours also updates the AuthInfo instance with the new token):
https://github.com/forcedotcom/sfdx-core/blob/0919f2844544983b7635f9d25eb544c2f4aa7cdd/src/org/authInfo.ts#L644

https://github.com/forcedotcom/sfdx-core/blob/0919f2844544983b7635f9d25eb544c2f4aa7cdd/src/org/authInfo.ts#L942

jsforce calls it here, expecting the callback to send back the new, refreshed token to set it in the `Connection` instance:
https://github.com/jsforce/jsforce/blob/73a6d0a174050b370b4248925e2e474bba27091d/src/session-refresh-delegate.ts#L53


`AuthInfo.refreshFn` was getting a new access token when calling `this.initAuthOptions` here:
https://github.com/forcedotcom/sfdx-core/blob/0919f2844544983b7635f9d25eb544c2f4aa7cdd/src/org/authInfo.ts#L949C1-L952C55

but it was sending back the expired access token from the previously decrypted auth fields to the callback, causing 2 refresh calls every time sfdx-core was doing a request with an expired token.

See the following examples, we expire the current token and call `api request reset` (with this PR linked: https://github.com/salesforcecli/plugin-api/pull/62) which tries to refresh the token before doing the `limits` call with `got`.

<details>

<summary>`AuthInfo.refreshFn` passes the expired AT to the callback, fires an additional refresh</summary>

```
➜  plugin-api git:(cd/refresh-token) ✗ SF_AT=$(sf org display --json | jq -r .result.accessToken) &&
echo "token=$SF_AT&token_type_hint=access_token" > token.txt &&
curl "https://customer-customization-3903-dev-ed.scratch.my.salesforce.com/services/oauth2/revoke" -d "@token.txt" -H 'Content-Type: application/x-www-form-urlencoded' -i
 && JSFORCE_LOG_LEVEL=DEBUG sf api request rest services/data/v62.0/limits
 ›   Warning: @salesforce/plugin-api is a linked ESM module and cannot be auto-transpiled. Existing compiled source will be used instead.
HTTP/2 200
...
                                                                                                                                                                          
 ›   Warning: @salesforce/plugin-api is a linked ESM module and cannot be auto-transpiled. Existing compiled source will be used instead.
Warning: This command is currently in beta. Any aspect of this command can change without advanced notice. Don't use beta commands in your scripts.
DEBUG   [http-api]  <request> method=GET, url=https://customer-customization-3903-dev-ed.scratch.my.salesforce.com/services/data/v62.0
DEBUG   [http-api]  elapsed time: 355 msec
DEBUG   [http-api]  <response> status=401, url=https://customer-customization-3903-dev-ed.scratch.my.salesforce.com/services/data/v62.0
INFO    [session-refresh-delegate]  <refresh token>
DEBUG   [session-refresh-delegate]  Connection refresh completed.
INFO    [session-refresh-delegate]  <refresh complete>
DEBUG   [http-api]  <request> method=GET, url=https://customer-customization-3903-dev-ed.scratch.my.salesforce.com/services/data/v62.0
DEBUG   [http-api]  elapsed time: 202 msec
DEBUG   [http-api]  <response> status=401, url=https://customer-customization-3903-dev-ed.scratch.my.salesforce.com/services/data/v62.0
INFO    [session-refresh-delegate]  <refresh token>
DEBUG   [session-refresh-delegate]  Connection refresh completed.
INFO    [session-refresh-delegate]  <refresh complete>
DEBUG   [http-api]  <request> method=GET, url=https://customer-customization-3903-dev-ed.scratch.my.salesforce.com/services/data/v62.0
DEBUG   [http-api]  elapsed time: 198 msec
DEBUG   [http-api]  <response> status=200, url=https://customer-customization-3903-dev-ed.scratch.my.salesforce.com/services/data/v62.0
{
  "AnalyticsExternalDataSizeMB": {
    "Max": 40960,
    "Remaining": 40960
  },
```

</details>


<details>

<summary>`AuthInfo.refreshFn` passes the new AT to the callback, next request uses it successfully</summary>

```
➜  plugin-api git:(cd/refresh-token) ✗ SF_AT=$(sf org display --json | jq -r .result.accessToken) &&
echo "token=$SF_AT&token_type_hint=access_token" > token.txt &&
curl "https://customer-customization-3903-dev-ed.scratch.my.salesforce.com/services/oauth2/revoke" -d "@token.txt" -H 'Content-Type: application/x-www-form-urlencoded' -i
 && JSFORCE_LOG_LEVEL=DEBUG sf api request rest services/data/v62.0/limits
 ›   Warning: @salesforce/plugin-api is a linked ESM module and cannot be auto-transpiled. Existing compiled source will be used instead.
HTTP/2 200
...

 ›   Warning: @salesforce/plugin-api is a linked ESM module and cannot be auto-transpiled. Existing compiled source will be used instead.
Warning: This command is currently in beta. Any aspect of this command can change without advanced notice. Don't use beta commands in your scripts.
DEBUG   [http-api]  <request> method=HEAD, url=https://customer-customization-3903-dev-ed.scratch.my.salesforce.com/services/data/v62.0
DEBUG   [http-api]  elapsed time: 329 msec
DEBUG   [http-api]  <response> status=401, url=https://customer-customization-3903-dev-ed.scratch.my.salesforce.com/services/data/v62.0
INFO    [session-refresh-delegate]  <refresh token>
DEBUG   [session-refresh-delegate]  Connection refresh completed.
INFO    [session-refresh-delegate]  <refresh complete>
DEBUG   [http-api]  <request> method=HEAD, url=https://customer-customization-3903-dev-ed.scratch.my.salesforce.com/services/data/v62.0
DEBUG   [http-api]  elapsed time: 423 msec
DEBUG   [http-api]  <response> status=200, url=https://customer-customization-3903-dev-ed.scratch.my.salesforce.com/services/data/v62.0
DEBUG   [http-api]  Failed to parse body of content-type: application/json;charset=UTF-8. Error: Unexpected end of JSON input
{
  "AnalyticsExternalDataSizeMB": {
    "Max": 40960,
    "Remaining": 40960
  },
```

</details>


### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/3176
@W-17605467@

