### PR TITLE
W-17972181 - fix: create .sfdx if necessary for alias file

### DIFF
--- a/src/stateAggregator/accessors/aliasAccessor.ts
+++ b/src/stateAggregator/accessors/aliasAccessor.ts
@@ -169,7 +169,7 @@ export class AliasAccessor extends AsyncOptionalCreatable {
     try {
       this.aliasStore = fileContentsRawToAliasStore(await readFile(this.fileLocation, 'utf-8'));
     } catch (e) {
-      if (e instanceof Error && 'code' in e && e.code === 'ENOENT') {
+      if (e instanceof Error && 'code' in e && typeof e.code === 'string' && ['ENOENT', 'ENOTDIR'].includes(e.code)) {
         this.aliasStore = new Map<string, string>();
         await mkdir(dirname(this.fileLocation), { recursive: true });
         await this.saveAliasStoreToFile();


### PR DESCRIPTION
### What does this PR do?
edge case: if the `.sfdx` dir doesn't exist, it'll be created to house the newly created `alias.json` file

### What issues does this PR fix or reference?
@W-17972181@