### PR TITLE
Wr/debug delay W-17774689

### DIFF
--- a/src/logger/transformStream.ts
+++ b/src/logger/transformStream.ts
@@ -28,8 +28,10 @@ export default function (): Transform {
           cb();
         },
       });
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
+
+      // Set up pipeline with proper error handling
       pipeline(source, myTransportStream, () => {});
+
       return myTransportStream;
     },
     {
@@ -38,8 +40,7 @@ export default function (): Transform {
     }
   );
 }
-
-/** if the DEBUG= is set, see if that matches the logger name.  If not, we don't want to keep going */
+// Cache for debug regex to avoid recreating it on every message
 let cachedDebugRegex: RegExp | null = null;
 let lastDebugPattern: string | null = null;
 

--- a/src/logger/transformStream.ts
+++ b/src/logger/transformStream.ts
@@ -40,16 +40,19 @@ export default function (): Transform {
 }
 
 /** if the DEBUG= is set, see if that matches the logger name.  If not, we don't want to keep going */
+let cachedDebugRegex: RegExp | null = null;
+let lastDebugPattern: string | null = null;
+
 const debugAllows = (chunk: Record<string, unknown>): boolean => {
   if (!process.env.DEBUG || process.env.DEBUG === '*') return true;
   if (typeof chunk.name !== 'string') return true;
-  // turn wildcard patterns into regexes
-  const regexFromDebug = new RegExp(process.env.DEBUG.replace(/\*/g, '.*'));
-  if (!regexFromDebug.test(chunk.name)) {
-    // console.log(`no match : ${chunk.name} for ${process.env.DEBUG}`);
-    return false;
-  } else {
-    // console.log(`match : ${chunk.name} for ${process.env.DEBUG}`);
-    return true;
+
+  // Only create a new regex if the DEBUG pattern has changed
+  if (process.env.DEBUG !== lastDebugPattern) {
+    lastDebugPattern = process.env.DEBUG;
+    cachedDebugRegex = new RegExp(process.env.DEBUG.replace(/\*/g, '.*'));
   }
+
+  // Use the cached regex for pattern matching
+  return cachedDebugRegex!.test(chunk.name);
 };


### PR DESCRIPTION
### What does this PR do?
caches regexes to avoid creating a new one per debug line

after building, copy the .js into installed CLI location / node_moduules/ @salesforce / core / lib/logger/

much similar times when using `--dev-debug` vs not
![image](https://github.com/user-attachments/assets/8ec95497-7b0b-47d6-b26d-9b72cc7e7b2d)


### What issues does this PR fix or reference?
@W-17774689@