### PR TITLE
fix: add generateApiName method to utils W-18394863

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,8 @@ export { SfdcUrl } from './util/sfdcUrl';
 
 export { getJwtAudienceUrl } from './util/getJwtAudienceUrl';
 
+export { generateApiName } from './util/generateApiName';
+
 export { Fields, FieldValue, LoggerLevel, LoggerLevelValue, LogLine, LoggerOptions, Logger } from './logger/logger';
 
 export { Messages, StructuredMessage } from './messages';

--- a/src/util/generateApiName.ts
+++ b/src/util/generateApiName.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { Logger } from '../logger/logger';
+
+/**
+ * Generate an API name from a string. Matches what the UI does.
+ *
+ * @param name - name to be converted into a valid api name
+ * @returns a valid api name
+ */
+export const generateApiName = (name: string): string => {
+  const maxLength = 255;
+  let apiName = name;
+  apiName = apiName.replace(/[\W_]+/g, '_');
+  if (apiName.charAt(0).match(/_/i)) {
+    apiName = apiName.slice(1);
+  }
+  apiName = apiName
+    .replace(/(^\d+)/, 'X$1')
+    .slice(0, maxLength)
+    .replace(/_$/, '');
+  Logger.childFromRoot('').debug(`Generated API name: [${apiName}] from name: [${name}]`);
+  return apiName;
+};

--- a/test/unit/util/generateApiName.test.ts
+++ b/test/unit/util/generateApiName.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from 'chai';
+import { generateApiName } from '../../../src';
+
+describe('generateApiName', () => {
+  it('should create valid API name with spaces', () => {
+    expect(generateApiName('My Test Agent')).to.equal('My_Test_Agent');
+  });
+  it('should create valid API name with no spaces', () => {
+    expect(generateApiName('MyTestAgent')).to.equal('MyTestAgent');
+  });
+  it('should create valid API name with beginning underscore', () => {
+    expect(generateApiName('_My Test Agent')).to.equal('My_Test_Agent');
+  });
+  it('should create valid API name with multiple beginning underscores', () => {
+    expect(generateApiName('___My Test Agent')).to.equal('My_Test_Agent');
+  });
+  it('should create valid API name with special characters', () => {
+    expect(generateApiName('My ()*&^$% Test @!""; Agent')).to.equal('My_Test_Agent');
+  });
+  it('should create valid API name with weird spacing', () => {
+    expect(generateApiName(' My   Test Agent  ')).to.equal('My_Test_Agent');
+  });
+});


### PR DESCRIPTION
### What does this PR do?
moves a method from `agents` to `core` to be used by more 

### What issues does this PR fix or reference?
@W-18394863@