### PR TITLE
fix: actionTokens error message - W-17099874

### DIFF
--- a/test/unit/messages.test.ts
+++ b/test/unit/messages.test.ts
@@ -23,6 +23,7 @@ describe('Messages', () => {
     msg1: 'test message 1',
     msg2: 'test message 2 %s and %s',
     manyMsgs: ['hello', 'world', 'test message 2 %s and %s'],
+    action1: ['test action1 %s and %s', 'test action2 %s and %s'],
   };
 
   const msgMap = new Map();
@@ -32,6 +33,7 @@ describe('Messages', () => {
   msgMap.set('msg3', structuredClone(testMessages));
   msgMap.get('msg3').msg3 = structuredClone(testMessages);
   msgMap.set('manyMsgs', testMessages.manyMsgs);
+  msgMap.set('action1', testMessages.action1);
 
   describe('getMessage', () => {
     const messages = new Messages('myBundle', Messages.getLocale(), msgMap);
@@ -344,6 +346,24 @@ describe('Messages', () => {
       } else {
         throw new Error('error.actions should not be undefined');
       }
+    });
+
+    it('should handle error messages with multiple tokens in actions', () => {
+      const messages = new Messages('myBundle', Messages.getLocale(), msgMap);
+
+      expect(messages.getMessages('action1', ['token1', 'token2', 'token3', 'token4'])).to.deep.equal([
+        'test action1 token1 and token2',
+        'test action2 token3 and token4',
+      ]);
+    });
+
+    it('should not repeat tokens in error messages', () => {
+      const messages = new Messages('myBundle', Messages.getLocale(), msgMap);
+      const error = messages.createError('msg2', ['token1', 'token2']);
+
+      expect(error.message).to.equal('test message 2 token1 and token2');
+      expect(error.message).to.not.include('token1 token1');
+      expect(error.message).to.not.include('token2 token2');
     });
 
     it('creates error with removed error prefix', () => {


### PR DESCRIPTION
### What does this PR do?
actionTokens get printed outside the error message. Fix the format so it doesn't get printed twice.

**Example:**
```
  actions: [
    'Get the job results by running: "sf data bulk results -o john@acme.com --job-id 12345". ben@acme.com 56789',
    `View the job in the org: "sf org open -o john@acme.com --path '/lightning/setup/AsyncApiJobStatus/page?address=%2F12345'". ben@acme.com 56789`
  ]
```
**Expected:**
```
 actions: [
    'Get the job results by running: "sf data bulk results -o john@acme.com --job-id 12345".',
    `View the job in the org: "sf org open -o ben@acme.com --path '/lightning/setup/AsyncApiJobStatus/page?address=%2F56789'".`
  ]
```
### What issues does this PR fix or reference?
@W-17099874@