### PR TITLE
fix: deploy org settings with REST API if set in config - W-18577583

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -609,7 +609,7 @@ export class Messages<T extends string> {
         const relevantTokens = tokens.slice(tokenCur, tokenCur + tokenCount);
         tokenCur += tokenCount;
         return util.format(msgStr, ...relevantTokens);
-      } else {
+      } else if (tokens.length > 0) {
         const logger = Logger.childFromRoot('core:messages');
         logger.warn(
           `Unable to render tokens in message. Ensure a specifier (e.g. %s) exists in the message:\n${msgStr}`

--- a/test/unit/messages.test.ts
+++ b/test/unit/messages.test.ts
@@ -15,6 +15,7 @@ import { SinonStub } from 'sinon';
 import { Messages } from '../../src/messages';
 import { SfError } from '../../src/sfError';
 import { shouldThrowSync, TestContext } from '../../src/testSetup';
+import { Logger } from '../../src/logger/logger';
 
 describe('Messages', () => {
   const $$ = new TestContext();
@@ -335,6 +336,7 @@ describe('Messages', () => {
 
   describe('createError', () => {
     it('creates error with actions', () => {
+      const loggerWarnStub = $$.SANDBOX.stub(Logger.prototype, 'warn');
       const messages = new Messages('myBundle', Messages.getLocale(), msgMap);
       const error = messages.createError('msg1');
 
@@ -346,6 +348,17 @@ describe('Messages', () => {
       } else {
         throw new Error('error.actions should not be undefined');
       }
+      expect(loggerWarnStub.callCount, 'expected no warnings to be logged').to.equal(0);
+    });
+
+    it('should log a warning if no tokens are found in the message', () => {
+      const loggerWarnStub = $$.SANDBOX.stub(Logger.prototype, 'warn');
+      const messages = new Messages('myBundle', Messages.getLocale(), msgMap);
+      messages.createError('msg1', ['token1', 'token2']);
+      expect(loggerWarnStub.callCount, 'expected a warning to be logged').to.equal(1);
+      expect(loggerWarnStub.firstCall.args[0]).to.equal(
+        `Unable to render tokens in message. Ensure a specifier (e.g. %s) exists in the message:\n${testMessages.msg1}`
+      );
     });
 
     it('should handle error messages with multiple tokens in actions', () => {


### PR DESCRIPTION
### What does this PR do?
1. when the project should use the REST API for deployments (either set as a config var or env var) is now also applies when deploying org settings to a scratch org during scratch org creation.
2. only log a warning during message tokenization when tokens were sent to a message that does not have anything to tokenize.  With recent code changes, the warnings were being displayed with debug logging whenever a message had nothing to tokenize and was causing clutter and incorrect warnings.

### What issues does this PR fix or reference?
@W-18577583@