### PR TITLE
fix: use `fs.promises.stat` for async `traverse.forFile`

### DIFF
--- a/src/util/internal.ts
+++ b/src/util/internal.ts
@@ -79,7 +79,7 @@ export const traverse = {
   forFile: async (dir: string, file: string): Promise<Optional<string>> => {
     let foundProjectDir: Optional<string>;
     try {
-      fs.statSync(join(dir, file));
+      await fs.promises.stat(join(dir, file));
       foundProjectDir = dir;
     } catch (err) {
       if (err && (err as SfError).code === 'ENOENT') {


### PR DESCRIPTION
### What does this PR do?

`traverse.forFile` uses `fs.statSync` instead of `fs.promises.stat`

I wonder if the reason why `traverse.forFile` uses `fs.statSync` is because of performance as stated [here](https://github.com/nodejs/node/issues/38006)
If it is the case and it is really really important then I can improve this PR by discarding the changes and just add a comment explaining this.
If it is not the case then we can consider the change proposed here.
