### PR TITLE
feat(W-18724886): add env vars for debug logger

### DIFF
--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -452,11 +452,15 @@ export class Logger {
 
 /** return various streams that the logger could send data to, depending on the options and env  */
 const getWriteStream = (level = 'warn'): pino.TransportSingleOptions => {
+  const env = new Env();
   // used when debug mode, writes to stdout (colorized)
   if (process.env.DEBUG) {
     return {
       target: 'pino-pretty',
-      options: { colorize: true },
+      options: {
+        colorize: env.getBoolean('SF_LOG_COLORIZE') ?? true,
+        destination: env.getBoolean('SF_LOG_STDERR') ? 2 : 1,
+      },
     };
   }
 
@@ -466,7 +470,7 @@ const getWriteStream = (level = 'warn'): pino.TransportSingleOptions => {
     ['1h', new Date().toISOString().split(':').slice(0, 1).join('-')],
     ['1d', new Date().toISOString().split('T')[0]],
   ]);
-  const logRotationPeriod = new Env().getString('SF_LOG_ROTATION_PERIOD') ?? '1d';
+  const logRotationPeriod = env.getString('SF_LOG_ROTATION_PERIOD') ?? '1d';
 
   return {
     // write to a rotating file


### PR DESCRIPTION
### What does this PR do?

- Adds `SF_LOG_COLORIZE` to allow users to disable colored logs, defaults to true
- Adds `SF_LOG_STDERR` to allow users to send logs to stderr, defaults to false (meaning logs will go to stdout by default)

Having these two env vars allows us to successfully emit logs from the MCP server. Cursor and vscode seem to expect stringified JSON-RPC to be sent to stdout but not for stderr. They also don't render the ansi sequences into colors. So for simplicity's sake we're going to enable these two env vars whenever users enable logging on the MCP server

### What issues does this PR fix or reference?
@W-18724886@