### PR TITLE
fix: ensure that colored logs are on by default

### DIFF
--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -458,7 +458,9 @@ const getWriteStream = (level = 'warn'): pino.TransportSingleOptions => {
     return {
       target: 'pino-pretty',
       options: {
-        colorize: env.getBoolean('SF_LOG_COLORIZE') ?? true,
+        // NOTE: env.getBoolean() defaults to false if the env var is not set
+        // so it's important to use `||` instead of `??`
+        colorize: env.getBoolean('SF_LOG_COLORIZE') || true,
         destination: env.getBoolean('SF_LOG_STDERR') ? 2 : 1,
       },
     };


### PR DESCRIPTION
### What does this PR do?

Fix env var logic so that logs are colored by default. Only way to disable is to set `SF_LOG_COLORIZE=false`

### What issues does this PR fix or reference?
[skip-validate-pr]