### PR TITLE
fix: include status of the scratch creation in intimeout  error message W-18895089

### DIFF
--- a/test/unit/org/scratchOrgErrorCodes.test.ts
+++ b/test/unit/org/scratchOrgErrorCodes.test.ts
@@ -114,7 +114,7 @@ describe('validateScratchOrgInfoForResume - timeout validation', () => {
     }
   });
 
-  it.only('should enhance timeout error message with last known status', async () => {
+  it('should enhance timeout error message with last known status', async () => {
     const scratchOrgInfo = { ...baseOrgInfo, Status: 'Creating', Id: 'test-job-id' };
     stubMethod($$.SANDBOX, scratchOrgInfoApi, 'queryScratchOrgInfo').resolves(scratchOrgInfo);
 


### PR DESCRIPTION
### What does this PR do?
Includes the last known status of the _create scratch_ job when the poll client fails due to timeout.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/3322
[@W-18895089@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002GtVTGYA3/view)