### PR TITLE
feat(W-18653307): use mutex to make ConfigAgg and StateAgg thread safe

### DIFF
--- a/src/config/configAggregator.ts
+++ b/src/config/configAggregator.ts
@@ -116,28 +116,6 @@ export class ConfigAggregator extends AsyncOptionalCreatable<ConfigAggregator.Op
 
   // Use typing from AsyncOptionalCreatable to support extending ConfigAggregator.
   // We really don't want ConfigAggregator extended but typescript doesn't support a final.
-  // public static async create<P extends ConfigAggregator.Options, T extends AsyncOptionalCreatable<P>>(
-  //   this: new (options?: P) => T,
-  //   options?: P
-  // ): Promise<T> {
-  //   let config = ConfigAggregator.instance as ConfigAggregator | undefined;
-  //   if (!config) {
-  //     config = ConfigAggregator.instance = new this(options) as unknown as ConfigAggregator;
-  //     await config.init();
-  //   }
-
-  //   if (ConfigAggregator.encrypted) {
-  //     await config.loadProperties();
-  //   }
-
-  //   if (options?.customConfigMeta) {
-  //     Config.addAllowedProperties(options.customConfigMeta);
-  //   }
-
-  //   // console.log(ConfigAggregator.instance);
-  //   return ConfigAggregator.instance as T;
-  // }
-
   public static async create<P extends ConfigAggregator.Options, T extends AsyncOptionalCreatable<P>>(
     this: new (options?: P) => T,
     options?: P

--- a/src/util/mutex.ts
+++ b/src/util/mutex.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Simple mutex implementation using promises
+ */
+export class Mutex {
+  private mutex = Promise.resolve();
+
+  public async lock<T>(fn: () => Promise<T> | T): Promise<T> {
+    const unlock = await this.acquire();
+    try {
+      return await fn();
+    } finally {
+      unlock();
+    }
+  }
+
+  private async acquire(): Promise<() => void> {
+    let release: () => void;
+    const promise = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const currentMutex = this.mutex;
+    this.mutex = this.mutex.then(() => promise);
+
+    await currentMutex;
+    return release!;
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Use a mutex to ensure thread-safety when getting or delete instances of ConfigAggregator or StateAggregator

### What issues does this PR fix or reference?
@W-18653307@