### PR TITLE
feat(org): add `frontdoor` methods @W-18944112@

### DIFF
--- a/messages/org.md
+++ b/messages/org.md
@@ -73,3 +73,11 @@ The sandbox %s cannot resume with status of %s.
 # FrontdoorURLError
 
 Failed to generate a frontdoor URL.
+
+# FlowIdNotFound
+
+ID not found for Flow %s.
+
+# CustomObjectIdNotFound
+
+ID not found for custom object %s.

--- a/messages/org.md
+++ b/messages/org.md
@@ -69,3 +69,7 @@ We found more than one SandboxProcess with the SandboxName %s.
 # sandboxNotResumable
 
 The sandbox %s cannot resume with status of %s.
+
+# FrontdoorURLError
+
+Failed to generate a frontdoor URL.

--- a/messages/org.md
+++ b/messages/org.md
@@ -81,3 +81,7 @@ ID not found for Flow %s.
 # CustomObjectIdNotFound
 
 ID not found for custom object %s.
+
+# ApexClassIdNotFound
+
+ID not found for Apex class %s.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "messageTransformer/messageTransformer.ts"
   ],
   "dependencies": {
-    "@jsforce/jsforce-node": "^3.8.2",
+    "@jsforce/jsforce-node": "^3.9.1",
     "@salesforce/kit": "^3.2.2",
     "@salesforce/schemas": "^1.9.0",
     "@salesforce/ts-types": "^2.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/core",
-  "version": "8.15.0",
+  "version": "8.15.1-dev.0",
   "description": "Core libraries to interact with SFDX projects, orgs, and APIs.",
   "main": "lib/index",
   "types": "lib/index.d.ts",

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -728,6 +728,8 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
 
   /**
    * Get the org front door (used for web based oauth flows)
+   *
+   * @deprecated Will be removed in the next major version. Use the `Org.getFrontDoorUrl()` method instead.
    */
   public getOrgFrontDoorUrl(): string {
     const authFields = this.getFields(true);

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -254,6 +254,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
    * Flow: open in Flow Builder
    * FlexiPage: open in Lightning App Builder
    * CustomObject: open in Object Manager
+   * ApexClass: open in Setup -> Apex Classes UI
    *
    * if you pass any other metadata type you'll get a path to Lightning App Builder
    */
@@ -305,9 +306,29 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
       }
     };
 
+    const apexClassFileNameToId = async (conn: Connection, filePath: string): Promise<string> => {
+      try {
+        const apexClass = await conn.singleRecordQuery<{ Id: string }>(
+          `SELECT Id FROM ApexClass WHERE Name = '${path.basename(filePath, '.cls')}'`,
+          {
+            tooling: true,
+          }
+        );
+        return apexClass.Id;
+      } catch (error) {
+        throw messages.createError('ApexClassIdNotFound', [filePath]);
+      }
+    };
+
     let redirectUri = '';
 
     switch (typeName) {
+      case 'ApexClass':
+        redirectUri = `lightning/setup/ApexClasses/page?address=%2F${await apexClassFileNameToId(
+          this.connection,
+          file
+        )}`;
+        break;
       case 'CustomObject':
         redirectUri = `lightning/setup/ObjectManager/${await customObjectFileNameToId(
           this.connection,

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -247,6 +247,23 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
   }
 
   /**
+   * Get a Frontdoor URL
+   *
+   * This uses the UI Bridge API to generate a single-use Frontdoor URL:
+   * https://help.salesforce.com/s/articleView?id=xcloud.frontdoor_singleaccess.htm&type=5
+   */
+  public async getFrontDoorUrl(): Promise<string> {
+    // the `singleaccess` endpoint returns 403 when using an expired token and jsforce only triggers a token refresh on 401 so we check if it's valid first
+    await this.refreshAuth();
+
+    type SingleAccessUrlRes = { frontdoor_uri: string | undefined };
+
+    const response = await this.connection.requestGet<SingleAccessUrlRes>('/services/oauth2/singleaccess');
+    if (response.frontdoor_uri) return response.frontdoor_uri;
+    throw new SfError(messages.getMessage('FrontdoorURLError')).setData(response);
+  }
+
+  /**
    * create a sandbox from a production org
    * 'this' needs to be a production org with sandbox licenses available
    *

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -259,14 +259,14 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
    * if you pass any other metadata type you'll get a path to Lightning App Builder
    *
    * @example
-   *   // use SDR resolver:
-   *   import { MetadataResolver } from '@salesforce/source-deploy-retrieve';
+   * // use SDR resolver:
+   * import { MetadataResolver } from '@salesforce/source-deploy-retrieve';
    *
-   *   const metadataResolver = new MetadataResolver();
-   *   const components = metadataResolver.getComponentsFromPath(filePath);
-   *   const typeName = components[0]?.type?.name;
+   * const metadataResolver = new MetadataResolver();
+   * const components = metadataResolver.getComponentsFromPath(filePath);
+   * const typeName = components[0]?.type?.name;
    *
-   *   const metadataBuilderUrl = await org.getMetadataUIURL(typeName, filePath);
+   * const metadataBuilderUrl = await org.getMetadataUIURL(typeName, filePath);
    *
    * @typeName Bot | ApexPage | Flow | FlexiPage | CustomObject | ApexClass
    * @file Absolute file path to the metadata file

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -6,7 +6,7 @@
  */
 /* eslint-disable class-methods-use-this */
 
-import { join as pathJoin } from 'node:path';
+import path from 'node:path';
 import * as fs from 'node:fs';
 import { AsyncOptionalCreatable, Duration } from '@salesforce/kit';
 import {
@@ -21,7 +21,6 @@ import {
   JsonMap,
   Nullable,
 } from '@salesforce/ts-types';
-import path from 'node:path';
 import { HttpRequest, SaveResult } from '@jsforce/jsforce-node';
 import { Config } from '../config/config';
 import { ConfigAggregator } from '../config/configAggregator';
@@ -1241,7 +1240,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
 
   private async getLocalDataDir(orgDataPath: Nullable<string>): Promise<string> {
     const rootFolder: string = await Config.resolveRootFolder(false);
-    return pathJoin(rootFolder, Global.SFDX_STATE_FOLDER, orgDataPath ? orgDataPath : 'orgs');
+    return path.join(rootFolder, Global.SFDX_STATE_FOLDER, orgDataPath ? orgDataPath : 'orgs');
   }
 
   /**
@@ -1744,7 +1743,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
   private async removeSourceTrackingFiles(): Promise<void> {
     try {
       const rootFolder = await Config.resolveRootFolder(false);
-      await fs.promises.rm(pathJoin(rootFolder, Global.SF_STATE_FOLDER, 'orgs', this.getOrgId()), {
+      await fs.promises.rm(path.join(rootFolder, Global.SF_STATE_FOLDER, 'orgs', this.getOrgId()), {
         recursive: true,
         force: true,
       });

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -21,6 +21,7 @@ import {
   JsonMap,
   Nullable,
 } from '@salesforce/ts-types';
+import path from 'node:path';
 import { HttpRequest, SaveResult } from '@jsforce/jsforce-node';
 import { Config } from '../config/config';
 import { ConfigAggregator } from '../config/configAggregator';
@@ -247,18 +248,93 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
   }
 
   /**
+   * Generate a Salesforce "builder" valid URL path for supported metadata types.
+   *
+   * Bot: open in Agentforce Builder
+   * ApexPage: opens page
+   * Flow: open in Flow Builder
+   * FlexiPage: open in Lightning App Builder
+   *
+   * if you pass any other metadata type you'll get a path to Lightning App Builder
+   */
+  public async getMetadataBuilderUrl(typeName: string, file: string): Promise<string> {
+    const botFileNameToId = async (conn: Connection, filePath: string): Promise<string> =>
+      (
+        await conn.singleRecordQuery<{ Id: string }>(
+          `SELECT id FROM BotDefinition WHERE DeveloperName='${path.basename(filePath, '.bot-meta.xml')}'`
+        )
+      ).Id;
+    /** query flexipage via toolingAPI to get its ID (starts with 0M0) */
+    const flexiPageFilenameToId = async (conn: Connection, filePath: string): Promise<string> =>
+      (
+        await conn.singleRecordQuery<{ Id: string }>(
+          `SELECT id FROM flexipage WHERE DeveloperName='${path.basename(filePath, '.flexipage-meta.xml')}'`,
+          { tooling: true }
+        )
+      ).Id;
+
+    /** query the rest API to turn a flow's filepath into a FlowId  (starts with 301) */
+    const flowFileNameToId = async (conn: Connection, filePath: string): Promise<string> => {
+      try {
+        const flow = await conn.singleRecordQuery<{ DurableId: string }>(
+          `SELECT DurableId FROM FlowVersionView WHERE FlowDefinitionView.ApiName = '${path.basename(
+            filePath,
+            '.flow-meta.xml'
+          )}' ORDER BY VersionNumber DESC LIMIT 1`
+        );
+        return flow.DurableId;
+      } catch (error) {
+        throw messages.createError('FlowIdNotFound', [filePath]);
+      }
+    };
+
+    let redirectUri = '';
+
+    switch (typeName) {
+      case 'Bot':
+        redirectUri = `/AiCopilot/copilotStudio.app#/copilot/builder?copilotId=${await botFileNameToId(
+          this.connection,
+          file
+        )}`;
+        break;
+      case 'ApexPage':
+        redirectUri = `/apex/${path.basename(file).replace('.page-meta.xml', '').replace('.page', '')}`;
+        break;
+      case 'Flow':
+        redirectUri = `/builder_platform_interaction/flowBuilder.app?flowId=${await flowFileNameToId(
+          this.connection,
+          file
+        )}`;
+        break;
+      case 'FlexiPage':
+        redirectUri = `/visualEditor/appBuilder.app?pageId=${await flexiPageFilenameToId(this.connection, file)}`;
+        break;
+      default:
+        redirectUri = '/lightning/setup/FlexiPageList/home';
+        break;
+    }
+
+    return this.getFrontDoorUrl(redirectUri);
+  }
+
+  /**
    * Get a Frontdoor URL
    *
    * This uses the UI Bridge API to generate a single-use Frontdoor URL:
    * https://help.salesforce.com/s/articleView?id=xcloud.frontdoor_singleaccess.htm&type=5
    */
-  public async getFrontDoorUrl(): Promise<string> {
+  public async getFrontDoorUrl(redirectUri?: string): Promise<string> {
     // the `singleaccess` endpoint returns 403 when using an expired token and jsforce only triggers a token refresh on 401 so we check if it's valid first
     await this.refreshAuth();
 
     type SingleAccessUrlRes = { frontdoor_uri: string | undefined };
 
-    const response = await this.connection.requestGet<SingleAccessUrlRes>('/services/oauth2/singleaccess');
+    const singleAccessUrl = new URL('/services/oauth2/singleaccess', this.connection.instanceUrl);
+    if (redirectUri) {
+      singleAccessUrl.searchParams.append('redirect_uri', redirectUri);
+    }
+
+    const response = await this.connection.requestGet<SingleAccessUrlRes>(singleAccessUrl.toString());
     if (response.frontdoor_uri) return response.frontdoor_uri;
     throw new SfError(messages.getMessage('FrontdoorURLError')).setData(response);
   }

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -247,7 +247,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
   }
 
   /**
-   * Generate a Salesforce "builder" valid URL path for supported metadata types.
+   * Generate a URL to a metadata UI builder/setup section in an org.
    *
    * Bot: open in Agentforce Builder
    * ApexPage: opens page
@@ -257,8 +257,21 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
    * ApexClass: open in Setup -> Apex Classes UI
    *
    * if you pass any other metadata type you'll get a path to Lightning App Builder
+   *
+   * @example
+   *   // use SDR resolver:
+   *   import { MetadataResolver } from '@salesforce/source-deploy-retrieve';
+   *
+   *   const metadataResolver = new MetadataResolver();
+   *   const components = metadataResolver.getComponentsFromPath(filePath);
+   *   const typeName = components[0]?.type?.name;
+   *
+   *   const metadataBuilderUrl = await org.getMetadataUIURL(typeName, filePath);
+   *
+   * @typeName Bot | ApexPage | Flow | FlexiPage | CustomObject | ApexClass
+   * @file Absolute file path to the metadata file
    */
-  public async getMetadataBuilderUrl(typeName: string, file: string): Promise<string> {
+  public async getMetadataUIURL(typeName: string, file: string): Promise<string> {
     const botFileNameToId = async (conn: Connection, filePath: string): Promise<string> =>
       (
         await conn.singleRecordQuery<{ Id: string }>(

--- a/yarn.lock
+++ b/yarn.lock
@@ -624,10 +624,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@jsforce/jsforce-node@^3.8.2":
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.8.2.tgz#68b903f6733ae479086ab02ea4a2de87a7f208eb"
-  integrity sha512-ewaRr9JnZRW6I28C/TzUnv5p70zMrWsKCq2ovRW6X557/ikdfvA24F9k4cQXZnTG2lZLEfVn+WwdBGEtY7pPnQ==
+"@jsforce/jsforce-node@^3.9.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.9.1.tgz#503bcee3b511b2768abb090b8c8af508c2412244"
+  integrity sha512-tHG9Wozb9tQMiOyKz4MgcSK0XEDdER+dUm42o7qUaokwqC+IPmjgptx0PNTO75U1nqgW6yX6M5Qq1thhj7KMCA==
   dependencies:
     "@sindresorhus/is" "^4"
     base64url "^3.0.1"


### PR DESCRIPTION
### What does this PR do?
Adds a `getFrontdoorUrl` method to the `Org` class to generate a frontdoor URL using the bridge API:
https://help.salesforce.com/s/articleView?id=xcloud.frontdoor_singleaccess.htm&type=5

Also adds an `Org.getMetadataBuilderUrl` method that gives you frontdoor URLs to specific metadata builder UIs or object manager for custom objects.

Will be used in: https://github.com/salesforcecli/mcp/pull/89

Others:
bumped jsforce

TODO:
- [x] deprecate the frontdoor method in `AuthInfo`

### What issues does this PR fix or reference?
@W-18944112@