### PR TITLE
W-18988586 feat: support paths for ConfigAggregator

### DIFF
--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -669,7 +669,7 @@ export const restoreContext = (testContext: TestContext): void => {
   SfProject.clearInstances();
   // Allow each test to have their own config aggregator
   // @ts-ignore clear for testing.
-  delete ConfigAggregator.instance;
+  ConfigAggregator.instances.clear();
 };
 
 /**


### PR DESCRIPTION
### What does this PR do?
ConfigAggregator is a singleton
instead of caching 1 ConfigAggregator instance, it has one per sfdx project
to help with multiple project and VSCode when the user changes projects and the singleton has to be destroyed and recreated.

### What issues does this PR fix or reference?
@W-18988586@