### PR TITLE
fix: better error msg for `Org.getFrontDoorUrl`

### DIFF
--- a/messages/org.md
+++ b/messages/org.md
@@ -74,6 +74,14 @@ The sandbox %s cannot resume with status of %s.
 
 Failed to generate a frontdoor URL.
 
+# FrontdoorURLBadOauthToken
+
+Failed to generate a frontdoor URL.
+
+# FrontdoorURLBadOauthToken.actions
+
+- Check that the user "%s" does not have the "API Only User" permission assigned, it prevents browser access.
+
 # FlowIdNotFound
 
 ID not found for Flow %s.

--- a/schemas/project-scratch-def.schema.json
+++ b/schemas/project-scratch-def.schema.json
@@ -452,6 +452,7 @@
               "EinsteinGPTForDevelopers",
               "EinsteinRecommendationBuilder",
               "EinsteinRecommendationBuilderMetadata",
+              "EinsteinSalesRepFdbk",
               "EinsteinSearch",
               "EinsteinVisits",
               "EinsteinVisitsED",

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -392,9 +392,17 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
       singleAccessUrl.searchParams.append('redirect_uri', redirectUri);
     }
 
-    const response = await this.connection.requestGet<SingleAccessUrlRes>(singleAccessUrl.toString());
-    if (response.frontdoor_uri) return response.frontdoor_uri;
-    throw new SfError(messages.getMessage('FrontdoorURLError')).setData(response);
+    try {
+      const response = await this.connection.requestGet<SingleAccessUrlRes>(singleAccessUrl.toString());
+      if (response.frontdoor_uri) return response.frontdoor_uri;
+      throw new SfError(messages.getMessage('FrontdoorURLError')).setData(response);
+    } catch (err) {
+      // See: https://help.salesforce.com/s/articleView?id=xcloud.frontdoor_singleaccess.htm&type=5
+      if (err instanceof Error && err.message.includes('Bad_OAuth_Token')) {
+        throw messages.createError('FrontdoorURLBadOauthToken', undefined, [this.getUsername()]);
+      }
+      throw err;
+    }
   }
 
   /**


### PR DESCRIPTION
### What does this PR do?
See this thread:
https://salesforce-internal.slack.com/archives/C01LKDT1P6J/p1774541830251329?thread_ts=1774447246.712929&cid=C01LKDT1P6J

The UI Bridge API can return 403/bad_oauth_token if the token isn't valid or if the user has the `API Only User` perm assigned, see:
https://help.salesforce.com/s/articleView?id=xcloud.frontdoor_singleaccess.htm&type=5

<img width="2253" height="999" alt="Screenshot 2026-03-26 at 21 56 09" src="https://github.com/user-attachments/assets/fe3c9eae-1998-48c0-922c-744d4ebf5b2d" />

<img width="2218" height="901" alt="Screenshot 2026-03-26 at 21 56 59" src="https://github.com/user-attachments/assets/45757738-9d18-4eed-b410-92df94a677fd" />

### Repro
0. checkout this branch, build and link into plugin-org
1. checkout ebikes, follow the readme to create scratch, deploy and assign the ebikes permset
2. `sf org open --path lightning/setup/PermSets/home`  and open the `ebikes` permset
3. click on `system permissions` -> `edit` and toggle the `API Only User` to QA this

### What issues does this PR fix or reference?
[skip-validate-pr]
