### PR TITLE
fix: incorrect enum value, swapped log rotation descriptions, wrong JSDoc, and stray artifacts in error messages

### DIFF
--- a/messages/envVars.md
+++ b/messages/envVars.md
@@ -104,11 +104,11 @@ Level of messages that the CLI writes to the log file. Valid values are trace, d
 
 # sfdxLogRotationCount
 
-The default rotation period for logs. Example '1d' will rotate logs daily (at midnight).
+The number of backup rotated log files to keep. Example: '3' will have the base sf.log file, and the past 3 (period) log files.
 
 # sfdxLogRotationPeriod
 
-The number of backup rotated log files to keep. Example: '3' will have the base sf.log file, and the past 3 (period) log files.
+The default rotation period for logs. Example '1d' will rotate logs daily (at midnight).
 
 # sfdxMaxQueryLimit
 
@@ -244,11 +244,11 @@ Level of messages that the CLI writes to the log file. Valid values are trace, d
 
 # sfLogRotationCount
 
-The default rotation period for logs. Example '1d' will rotate logs daily (at midnight).
+The number of backup rotated log files to keep. Example: '3' will have the base sf.log file, and the past 3 (period) log files.
 
 # sfLogRotationPeriod
 
-The number of backup rotated log files to keep. Example: '3' will have the base sf.log file, and the past 3 (period) log files.
+The default rotation period for logs. Example '1d' will rotate logs daily (at midnight).
 
 # sfOrgMaxQueryLimit
 

--- a/messages/scratchOrgInfoGenerator.md
+++ b/messages/scratchOrgInfoGenerator.md
@@ -1,26 +1,26 @@
 # Package2AncestorsIdsKeyNotSupportedError
 
-The package2AncestorIds key is no longer supported in a scratch org definition. Ancestors defined in sfdx-project.json will be included in the scratch org.",
+The package2AncestorIds key is no longer supported in a scratch org definition. Ancestors defined in sfdx-project.json will be included in the scratch org.
 
 # InvalidAncestorVersionFormatError
 
-The ancestor versionNumber must be in the format major.minor.patch but the value found is %s",
+The ancestor versionNumber must be in the format major.minor.patch but the value found is %s
 
 # NoMatchingAncestorError
 
-The ancestor for ancestorVersion %s can't be found. Package ID %s.",
+The ancestor for ancestorVersion %s can't be found. Package ID %s.
 
 # NoMatchingAncestorIdError
 
-The ancestor for ancestorId [%s] can't be found. Package ID %s."
+The ancestor for ancestorId [%s] can't be found. Package ID %s.
 
 # AncestorNotReleasedError
 
-The ancestor package version [%s] specified in the sfdx-project.json file may exist hasn’t been promoted and released. Release the ancestor package version before specifying it as the ancestor in a new package or patch version.",
+The ancestor package version [%s] specified in the sfdx-project.json file may exist hasn’t been promoted and released. Release the ancestor package version before specifying it as the ancestor in a new package or patch version.
 
 # AncestorIdVersionMismatchError
 
-The ancestorVersion in sfdx-project.json is not the version expected for the ancestorId you supplied. ancestorVersion %s. ancestorID %s."
+The ancestorVersion in sfdx-project.json is not the version expected for the ancestorId you supplied. ancestorVersion %s. ancestorID %s.
 
 # unsupportedSnapshotOrgCreateOptions
 

--- a/src/config/configAggregator.ts
+++ b/src/config/configAggregator.ts
@@ -288,9 +288,9 @@ export class ConfigAggregator extends AsyncOptionalCreatable<ConfigAggregator.Op
    * Gets a resolved config property location.
    *
    * For example, `getLocation('logLevel')` will return:
-   * 1. `Location.GLOBAL` if resolved to an environment variable.
+   * 1. `Location.ENVIRONMENT` if resolved to an environment variable.
    * 1. `Location.LOCAL` if resolved to local project config.
-   * 1. `Location.ENVIRONMENT` if resolved to the global config.
+   * 1. `Location.GLOBAL` if resolved to the global config.
    *
    * @param key The key of the property.
    */

--- a/src/config/envVars.ts
+++ b/src/config/envVars.ts
@@ -260,7 +260,7 @@ export const SUPPORTED_ENV_VARS: EnvType = {
     synonymOf: EnvironmentVariable.SF_USE_PROGRESS_BAR,
   },
   [EnvironmentVariable.SFDX_LAZY_LOAD_MODULES]: {
-    description: getMessage(EnvironmentVariable.SFDX_USE_PROGRESS_BAR),
+    description: getMessage(EnvironmentVariable.SFDX_LAZY_LOAD_MODULES),
     synonymOf: EnvironmentVariable.SF_LAZY_LOAD_MODULES,
   },
   [EnvironmentVariable.SFDX_S3_HOST]: {

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -1865,7 +1865,7 @@ export namespace Org {
     NAME = 'name',
     NAMESPACE_PREFIX = 'namespacePrefix',
     INSTANCE_NAME = 'instanceName',
-    TRIAL_EXPIRATION_DATE = 'trailExpirationDate',
+    TRIAL_EXPIRATION_DATE = 'trialExpirationDate',
 
     /**
      * The Salesforce instance the org was created on. e.g. `cs42`.


### PR DESCRIPTION
## Summary

Five bugs found across `org.ts`, `envVars.ts`, `envVars.md`, `configAggregator.ts`, and `scratchOrgInfoGenerator.md`:

### `src/org/org.ts:1868` — `TRIAL_EXPIRATION_DATE` enum has wrong string value

```ts
// before
TRIAL_EXPIRATION_DATE = 'trailExpirationDate',

// after
TRIAL_EXPIRATION_DATE = 'trialExpirationDate',
```

This enum value is used as a property key when reading auth fields from the org. The Salesforce API returns `trialExpirationDate`; the typo (`trail`) would cause trial expiration date lookups to silently return `undefined`.

### `src/config/envVars.ts:263` — `SFDX_LAZY_LOAD_MODULES` shows wrong description

```ts
// before
[EnvironmentVariable.SFDX_LAZY_LOAD_MODULES]: {
  description: getMessage(EnvironmentVariable.SFDX_USE_PROGRESS_BAR),  // copy-paste bug

// after
[EnvironmentVariable.SFDX_LAZY_LOAD_MODULES]: {
  description: getMessage(EnvironmentVariable.SFDX_LAZY_LOAD_MODULES),
```

`SFDX_LAZY_LOAD_MODULES` displayed the help text for `SFDX_USE_PROGRESS_BAR` instead of its own description. Every other entry in `SUPPORTED_ENV_VARS` correctly references its own key.

### `messages/envVars.md` — `sfdxLogRotationCount` / `sfdxLogRotationPeriod` descriptions are swapped (both SFDX_ and SF_ variants)

`sfdxLogRotationCount` had the rotation-period description ("Example '1d' will rotate logs daily"), and `sfdxLogRotationPeriod` had the count description ("3 backup files to keep"). Same swap in the `sfLogRotationCount` / `sfLogRotationPeriod` entries. Fixed by swapping both pairs back to their correct keys.

### `src/config/configAggregator.ts:291-293` — `getLocation()` JSDoc lists `GLOBAL` and `ENVIRONMENT` backwards

The JSDoc said `GLOBAL` for env vars and `ENVIRONMENT` for global config, which is the opposite of what the method actually returns. Corrected to match the implementation.

### `messages/scratchOrgInfoGenerator.md` — 5 error messages have trailing `",` artifacts

Remnants of a JSON-to-markdown migration. Each affected message would appear with a literal trailing `",` in user-facing error output (e.g., `"...scratch org definition.","`). Removed the artifacts from all 5 messages.

## Test plan
- [ ] `yarn build` passes
- [ ] Existing tests pass
- [ ] Manual: `sf env var list` should show correct descriptions for `SFDX_LAZY_LOAD_MODULES` and log rotation vars