### PR TITLE
fix: typos in messages, JSDoc, and inline comments

### DIFF
--- a/messages/envVars.md
+++ b/messages/envVars.md
@@ -72,7 +72,7 @@ Number of source-tracked file updates to batch after a deploy or retrieve. The d
 
 # sfdxDisableTelemetry
 
-Set to true to disable Salesforce CLI from collecting usage information, user environment information, and crash reports. Default value is false. Overrides the disableTelemetry configration variable.
+Set to true to disable Salesforce CLI from collecting usage information, user environment information, and crash reports. Default value is false. Overrides the disableTelemetry configuration variable.
 
 # sfdxDnsTimeout
 
@@ -192,7 +192,7 @@ URL that overrides the aud (audience) field used for JWT authentication so that 
 
 # sfCodeCoverageRequirement
 
-Code coverage percentages that are displayed in green when you run the Apex test CLIcommands with the --code-coverage flag.
+Code coverage percentages that are displayed in green when you run the Apex test CLI commands with the --code-coverage flag.
 
 # sfContentType
 
@@ -212,7 +212,7 @@ Set to true to disable polling of your org’s SourceMember object when you run 
 
 # sfDisableTelemetry
 
-Set to true to disable Salesforce CLI from collecting usage information, user environment information, and crash reports. Default value is false. Overrides the disableTelemetry configration variable.
+Set to true to disable Salesforce CLI from collecting usage information, user environment information, and crash reports. Default value is false. Overrides the disableTelemetry configuration variable.
 
 # sfDnsTimeout
 

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -1052,7 +1052,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     const audienceUrl = await url.getJwtAudienceUrl(createdOrgInstance);
     let authFieldsBuilder: JsonMap | undefined;
     const authErrors = [];
-    // given that we can no longer depend on instance names or URls to determine audience, let's try them all
+    // given that we can no longer depend on instance names or URLs to determine audience, let's try them all
     const loginAndAudienceUrls = getLoginAudienceCombos(audienceUrl, loginUrl);
     for (const [login, audience] of loginAndAudienceUrls) {
       try {

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -675,7 +675,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
     await this.removeSandboxConfig();
     await this.removeUsers(throwWhenRemoveFails);
     await this.removeUsersConfig();
-    // An attempt to remove this org's auth file occurs in this.removeUsersConfig. That's because this org's usersname is also
+    // An attempt to remove this org's auth file occurs in this.removeUsersConfig. That's because this org's username is also
     // included in the OrgUser config file.
     //
     // So, just in case no users are added to this org we will try the remove again.
@@ -1305,7 +1305,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
   /**
    * Gets the sandboxProcessObject and then polls for it to complete.
    *
-   * @param sandboxProcessName sanbox process name
+   * @param sandboxProcessName sandbox process name
    * @param options { wait?: Duration; interval?: Duration }
    * @returns {SandboxProcessObject} The SandboxProcessObject for the sandbox
    */

--- a/src/org/scratchOrgInfoApi.ts
+++ b/src/org/scratchOrgInfoApi.ts
@@ -42,7 +42,7 @@ const errorCodes = Messages.loadMessages('@salesforce/core', 'scratchOrgErrorCod
  * Returns the url to be used to authorize into the new scratch org
  *
  * @param scratchOrgInfoComplete The completed ScratchOrgInfo
- * @param hubOrgLoginUrl the hun org login url
+ * @param hubOrgLoginUrl the hub org login url
  * @param signupTargetLoginUrl the login url
  * @returns {string}
  */

--- a/src/org/user.ts
+++ b/src/org/user.ts
@@ -244,7 +244,7 @@ export class User extends AsyncCreatable<User.Options> {
       }
     });
 
-    // Concatinating remaining length randomly with all lower characters
+    // Concatenating remaining length randomly with all lower characters
     password = password.concat(
       Array(Math.max(passwordCondition.length - password.length, 0))
         .fill('0')

--- a/src/sfError.ts
+++ b/src/sfError.ts
@@ -66,7 +66,7 @@ export class SfError<T extends ErrorDataProperties = ErrorDataProperties> extend
   public data?: T;
 
   /**
-   * Some errors support `error.code` instead of `error.name`. This keeps backwards compatability.
+   * Some errors support `error.code` instead of `error.name`. This keeps backwards compatibility.
    */
   #code?: string;
 
@@ -76,7 +76,7 @@ export class SfError<T extends ErrorDataProperties = ErrorDataProperties> extend
    * @param message The error message.
    * @param name The error name. Defaults to 'SfError'.
    * @param actions The action message(s).
-   * @param exitCodeOrCause The exit code which will be used by SfdxCommand or he underlying error that caused this error to be raised.
+   * @param exitCodeOrCause The exit code which will be used by SfdxCommand or the underlying error that caused this error to be raised.
    * @param cause The underlying error that caused this error to be raised.
    */
   public constructor(

--- a/src/status/myDomainResolver.ts
+++ b/src/status/myDomainResolver.ts
@@ -71,7 +71,7 @@ export class MyDomainResolver extends AsyncOptionalCreatable<MyDomainResolver.Op
    * given the optional interval. Returns the resolved ip address.
    *
    * If SFDX_DISABLE_DNS_CHECK environment variable is set to true, it will immediately return the host without
-   * executing the dns loookup.
+   * executing the dns lookup.
    */
   public async resolve(): Promise<string> {
     const env = new Env();

--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -869,7 +869,7 @@ export class StreamingMockCometClient extends CometClient {
   public setHeader(name: string, value: string): void {}
 
   /**
-   * Fake subscription that completed after the setTimout event phase.
+   * Fake subscription that completed after the setTimeout event phase.
    *
    * @param channel The streaming channel.
    * @param callback The function to invoke after the subscription completes.


### PR DESCRIPTION
## Summary

11 typos across `messages/envVars.md` and source files in `src/`:

### Messages (user-visible)
- `envVars.md`: "configration" → "configuration" — appears in `sfdxDisableTelemetry` and `sfDisableTelemetry` descriptions
- `envVars.md`: "CLIcommands" → "CLI commands" — missing space in `sfCodeCoverageRequirement` description

### JSDoc / comments
- `sfError.ts:69`: "compatability" → "compatibility"
- `sfError.ts:79`: "he underlying error" → "the underlying error" (missing "t")
- `scratchOrgInfoApi.ts:45`: "hun org" → "hub org" in `@param hubOrgLoginUrl` JSDoc
- `org.ts:678`: "usersname" → "username" in inline comment
- `org.ts:1308`: "sanbox" → "sandbox" in `@param` JSDoc
- `authInfo.ts:1055`: "URls" → "URLs" in inline comment
- `user.ts:247`: "Concatinating" → "Concatenating" in comment
- `myDomainResolver.ts:74`: "dns loookup" → "dns lookup" (triple-o) in JSDoc
- `testSetup.ts:872`: "setTimout" → "setTimeout" in JSDoc

## Test plan
- [ ] `yarn build` passes
- [ ] Existing tests pass
- [ ] All changes are in string literals and comments only — no logic changes