### PR TITLE
fix: detect Bun runtime so fs operations use node:fs

### DIFF
--- a/src/fs/fs.ts
+++ b/src/fs/fs.ts
@@ -13,7 +13,14 @@ import type { VirtualFs } from './types';
 
 export let fs: VirtualFs;
 
-const isWeb = (): boolean => process.env.FORCE_MEMFS === 'true' || 'window' in globalThis || 'self' in globalThis;
+const isWeb = (): boolean => {
+  if (process.env.FORCE_MEMFS === 'true') return true;
+  // Server runtimes (Node, Bun) expose web-style globals like `self` for Web
+  // API compatibility but are not web environments. Detect them explicitly so
+  // we don't fall through to the `'self' in globalThis` check below.
+  if (process.versions?.node || process.versions?.bun) return false;
+  return 'window' in globalThis || 'self' in globalThis;
+};
 
 export const getVirtualFs = (memfsVolume?: memfs.Volume): VirtualFs => {
   if (isWeb()) {

--- a/test/unit/fs/fs.test.ts
+++ b/test/unit/fs/fs.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as nodeFs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { expect } from 'chai';
+import { getVirtualFs } from '../../../src/fs/fs';
+
+describe('fs runtime detection', () => {
+  let originalSelf: PropertyDescriptor | undefined;
+  let originalForceMemfs: string | undefined;
+  let originalBunVersion: string | undefined;
+
+  beforeEach(() => {
+    originalSelf = Object.getOwnPropertyDescriptor(globalThis, 'self');
+    originalForceMemfs = process.env.FORCE_MEMFS;
+    originalBunVersion = process.versions.bun;
+    delete process.env.FORCE_MEMFS;
+  });
+
+  afterEach(() => {
+    if (originalSelf) {
+      Object.defineProperty(globalThis, 'self', originalSelf);
+    } else {
+      delete (globalThis as { self?: unknown }).self;
+    }
+    if (originalForceMemfs === undefined) {
+      delete process.env.FORCE_MEMFS;
+    } else {
+      process.env.FORCE_MEMFS = originalForceMemfs;
+    }
+    if (originalBunVersion === undefined) {
+      delete (process.versions as { bun?: string }).bun;
+    } else {
+      (process.versions as { bun?: string }).bun = originalBunVersion;
+    }
+  });
+
+  it('uses the real filesystem under Node', () => {
+    const tmpFile = path.join(os.tmpdir(), `sfdx-core-fs-runtime-${Date.now()}.txt`);
+    nodeFs.writeFileSync(tmpFile, 'real');
+    try {
+      expect(getVirtualFs().readFileSync(tmpFile, 'utf8')).to.equal('real');
+    } finally {
+      nodeFs.unlinkSync(tmpFile);
+    }
+  });
+
+  it('uses the real filesystem under Bun even when `self` is on globalThis', () => {
+    // Bun exposes `self` on globalThis as an alias for globalThis itself for
+    // Web API compatibility, and also sets `process.versions.bun`. Without the
+    // server-runtime check, the `'self' in globalThis` branch incorrectly
+    // routed Bun to memfs and broke filesystem-dependent functionality
+    // (issue #3535).
+    Object.defineProperty(globalThis, 'self', {
+      value: globalThis,
+      configurable: true,
+      writable: true,
+    });
+    (process.versions as { bun?: string }).bun = '1.3.9';
+
+    const tmpFile = path.join(os.tmpdir(), `sfdx-core-fs-runtime-bun-${Date.now()}.txt`);
+    nodeFs.writeFileSync(tmpFile, 'real');
+    try {
+      expect(getVirtualFs().readFileSync(tmpFile, 'utf8')).to.equal('real');
+    } finally {
+      nodeFs.unlinkSync(tmpFile);
+    }
+  });
+
+  it('uses memfs when FORCE_MEMFS=true', () => {
+    process.env.FORCE_MEMFS = 'true';
+    const fs = getVirtualFs();
+    const memOnlyPath = '/sfdx-core-fs-runtime-memfs-only.txt';
+    fs.writeFileSync(memOnlyPath, 'memfs');
+    expect(fs.readFileSync(memOnlyPath, 'utf8')).to.equal('memfs');
+    // Confirm the write only landed in memfs, not on the real filesystem.
+    expect(nodeFs.existsSync(memOnlyPath)).to.be.false;
+  });
+});


### PR DESCRIPTION
## What

Fixes [forcedotcom/cli#3535](https://github.com/forcedotcom/cli/issues/3535).

Bun exposes `self` on `globalThis` as an alias for `globalThis` itself for Web API compatibility. The previous `isWeb()` check in `src/fs/fs.ts` treated any environment with `self` on `globalThis` as a web environment, which caused all filesystem calls under Bun to be routed through `memfs` instead of `node:fs`. The first visible symptom is keychain access failing with `MissingCredentialProgramError: Unable to find required security software: /usr/bin/security` because `memfs` has no `/usr/bin/security`.

## How

`isWeb()` now short-circuits to `false` when either `process.versions.node` or `process.versions.bun` is set, so server runtimes are never mistaken for the browser. The `FORCE_MEMFS` escape hatch and the `'window' in globalThis || 'self' in globalThis` detection for real web/worker environments are preserved.

```ts
const isWeb = (): boolean => {
  if (process.env.FORCE_MEMFS === 'true') return true;
  if (process.versions?.node || process.versions?.bun) return false;
  return 'window' in globalThis || 'self' in globalThis;
};
```

## Tests

Added `test/unit/fs/fs.test.ts` with three behavioral tests that write/read through the real filesystem vs. `memfs`:

1. Real filesystem under Node (sanity check).
2. Real filesystem under Bun even when `self` is on `globalThis` and `process.versions.bun` is set (regression test for #3535).
3. `memfs` when `FORCE_MEMFS=true` (escape hatch preserved).

Verification on this branch:

- `yarn compile` — clean
- `yarn lint` — clean (5 pre-existing warnings in unrelated files)
- Unit tests — 1145 passing, 0 failing
- NUTs (`test/nut/**`) including the existing `virtualfs.nut.ts` — all passing

## Reproduction (before the fix)

```sh
bun -e "console.log('self' in globalThis)"  # true
node -e "console.log('self' in globalThis)" # false
```

Under Bun, the previous `isWeb()` returned `true`, so any call into `@salesforce/core` that touched the filesystem (auth, keychain, config) failed.