### PR TITLE
feat: add org edition (OrganizationType) to auth info fields - W-22434738

### DIFF
--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -89,6 +89,7 @@ export type AuthFields = {
   [Org.Fields.IS_SANDBOX]?: boolean;
   [Org.Fields.IS_SCRATCH]?: boolean;
   [Org.Fields.TRIAL_EXPIRATION_DATE]?: Nullable<string>;
+  [Org.Fields.ORG_EDITION]?: string;
 };
 
 export type OrgAuthorization = {

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -52,6 +52,7 @@ export type OrganizationInformation = {
   IsSandbox: boolean;
   TrialExpirationDate: string | null;
   NamespacePrefix: string | null;
+  OrganizationType: string;
 };
 
 export enum OrgTypes {
@@ -940,7 +941,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
    */
   public async retrieveOrganizationInformation(): Promise<OrganizationInformation> {
     return this.getConnection().singleRecordQuery<OrganizationInformation>(
-      'SELECT Name, InstanceName, IsSandbox, TrialExpirationDate, NamespacePrefix FROM Organization'
+      'SELECT Name, InstanceName, IsSandbox, TrialExpirationDate, NamespacePrefix, OrganizationType FROM Organization'
     );
   }
 
@@ -982,6 +983,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
         | Org.Fields.IS_SANDBOX
         | Org.Fields.IS_SCRATCH
         | Org.Fields.TRIAL_EXPIRATION_DATE
+        | Org.Fields.ORG_EDITION
       >
     | undefined
   > {
@@ -998,6 +1000,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
         [Org.Fields.IS_SANDBOX]: organization.IsSandbox && !organization.TrialExpirationDate,
         [Org.Fields.IS_SCRATCH]: organization.IsSandbox && Boolean(organization.TrialExpirationDate),
         [Org.Fields.TRIAL_EXPIRATION_DATE]: organization.TrialExpirationDate,
+        [Org.Fields.ORG_EDITION]: organization.OrganizationType,
       };
       stateAggregator.orgs.update(username, updateFields);
       await stateAggregator.orgs.write(username);
@@ -1883,6 +1886,10 @@ export namespace Org {
     NAMESPACE_PREFIX = 'namespacePrefix',
     INSTANCE_NAME = 'instanceName',
     TRIAL_EXPIRATION_DATE = 'trailExpirationDate',
+    /**
+     * The org edition. e.g. `Developer Edition`, `Enterprise Edition`.
+     */
+    ORG_EDITION = 'orgEdition',
 
     /**
      * The Salesforce instance the org was created on. e.g. `cs42`.

--- a/test/unit/org/org.test.ts
+++ b/test/unit/org/org.test.ts
@@ -105,6 +105,24 @@ describe('Org Tests', () => {
     });
   });
 
+  describe('updateLocalInformation', () => {
+    it('should persist orgEdition from Organization.OrganizationType', async () => {
+      const org = await Org.create({ aliasOrUsername: testData.username });
+      stubMethod($$.SANDBOX, Connection.prototype, 'singleRecordQuery').resolves({
+        Name: 'My Org',
+        InstanceName: 'cs42',
+        IsSandbox: false,
+        TrialExpirationDate: null,
+        NamespacePrefix: null,
+        OrganizationType: 'Developer Edition',
+      });
+      const result = await org.updateLocalInformation();
+      expect(result).to.have.property('orgEdition', 'Developer Edition');
+      expect(result).to.have.property('name', 'My Org');
+      expect(result).to.have.property('instanceName', 'cs42');
+    });
+  });
+
   describe('org:create', () => {
     it('should create an org from a username', async () => {
       const org = await Org.create({ aliasOrUsername: testData.username });


### PR DESCRIPTION
## Summary
- Adds `Organization.OrganizationType` (e.g. "Developer Edition", "Enterprise Edition") as `orgEdition` to the locally cached auth info fields
- Follows the existing pipeline: SOQL query in `retrieveOrganizationInformation()` → mapping in `updateLocalInformation()` → persisted via `StateAggregator`
- Adds `Org.Fields.ORG_EDITION` enum value, `OrganizationType` to `OrganizationInformation` type, and `[Org.Fields.ORG_EDITION]` to `AuthFields`

## Test plan
- [x] New unit test verifies `updateLocalInformation()` persists `orgEdition` from `Organization.OrganizationType`
- [x] All existing org and authInfo unit tests pass (87 + 86)
- [x] Build passes cleanly

@W-22434738@

🤖 Generated with [Claude Code](https://claude.com/claude-code)