### PR TITLE
W-22430240 Changes to serialize PostCopyConfig json array

### DIFF
--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -148,7 +148,16 @@ const sandboxInfoFields = [
   'SourceId',
   'ActivationUserGroupId',
   'Features',
+  'PostCopyConfig',
 ];
+
+export type PostCopyConfigEntry = {
+  ConfigurationName: string;
+  Label: string;
+  Fields: Record<string, string>;
+  IsActive: boolean;
+  ExecutionOrder: number;
+};
 
 export type SandboxRequest = {
   SandboxName: string;
@@ -159,6 +168,7 @@ export type SandboxRequest = {
   ApexClassId?: string;
   ActivationUserGroupId?: string;
   Features?: string[] | string;
+  PostCopyConfig?: PostCopyConfigEntry[] | string;
 };
 
 export type ResumeSandboxRequest = {
@@ -186,6 +196,7 @@ export type SandboxInfo = {
   ActivationUserGroupId?: string; // Support might be added back in API v61.0 (Summer '24)
   CopyArchivedActivities?: boolean; // only for full sandboxes; depends if a license was purchased
   Features?: string[];
+  PostCopyConfig?: PostCopyConfigEntry[] | string;
 };
 
 export type ScratchOrgRequest = Omit<ScratchOrgCreateOptions, 'hubOrg'>;
@@ -418,6 +429,9 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
     if (sandboxReq.Features && Array.isArray(sandboxReq.Features)) {
       sandboxReq.Features = JSON.stringify(sandboxReq.Features);
     }
+    if (sandboxReq.PostCopyConfig && Array.isArray(sandboxReq.PostCopyConfig)) {
+      sandboxReq.PostCopyConfig = JSON.stringify(sandboxReq.PostCopyConfig);
+    }
     const createResult = await this.connection.tooling.create('SandboxInfo', sandboxReq);
     this.logger.debug(createResult, 'Return from calling tooling.create');
 
@@ -463,6 +477,9 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
     }
   ): Promise<SandboxProcessObject> {
     this.logger.debug(sandboxInfo, 'RefreshSandbox called with SandboxInfo');
+    if (sandboxInfo.PostCopyConfig && Array.isArray(sandboxInfo.PostCopyConfig)) {
+      sandboxInfo.PostCopyConfig = JSON.stringify(sandboxInfo.PostCopyConfig);
+    }
     const refreshResult = await this.connection.tooling.update('SandboxInfo', sandboxInfo);
     this.logger.debug(refreshResult, 'Return from calling tooling.update');
 

--- a/test/unit/org/org.test.ts
+++ b/test/unit/org/org.test.ts
@@ -1186,6 +1186,45 @@ describe('Org Tests', () => {
         });
       });
 
+      it('will create the SandboxInfo sObject correctly with PostCopyConfig as an array', async () => {
+        const postCopyConfig = [
+          {
+            ConfigurationName: 'OutboundMessages',
+            Label: 'R12 Endpoint',
+            Fields: { EndpointUrl: 'Url' },
+            IsActive: true,
+            ExecutionOrder: 1,
+          },
+        ];
+        await prod.createSandbox(
+          { SandboxName: 'testSandbox', PostCopyConfig: postCopyConfig },
+          { wait: Duration.seconds(30) }
+        );
+        expect(createStub.calledOnce).to.be.true;
+        const createCallArgs = createStub.firstCall.args;
+        expect(createCallArgs[0]).to.equal('SandboxInfo');
+        expect(createCallArgs[1]).to.deep.include({
+          SandboxName: 'testSandbox',
+          PostCopyConfig: JSON.stringify(postCopyConfig),
+        });
+      });
+
+      it('will create the SandboxInfo sObject correctly with PostCopyConfig as a string', async () => {
+        const postCopyConfig =
+          '[{"ConfigurationName":"OutboundMessages","Label":"R12 Endpoint","Fields":{"EndpointUrl":"Url"},"IsActive":true,"ExecutionOrder":1}]';
+        await prod.createSandbox(
+          { SandboxName: 'testSandbox', PostCopyConfig: postCopyConfig },
+          { wait: Duration.seconds(30) }
+        );
+        expect(createStub.calledOnce).to.be.true;
+        const createCallArgs = createStub.firstCall.args;
+        expect(createCallArgs[0]).to.equal('SandboxInfo');
+        expect(createCallArgs[1]).to.deep.include({
+          SandboxName: 'testSandbox',
+          PostCopyConfig: postCopyConfig,
+        });
+      });
+
       it('will throw an error if it fails to create SandboxInfo', async () => {
         createStub.restore();
         createStub = stubMethod($$.SANDBOX, prod.getConnection().tooling, 'create').resolves({
@@ -1343,6 +1382,29 @@ describe('Org Tests', () => {
           expect((e as Error).message).to.include('duplicate value found');
           expect((e as SfError).exitCode).to.equal(1);
         }
+      });
+
+      it('will refresh the SandboxInfo sObject correctly with PostCopyConfig as an array', async () => {
+        querySandboxProcessStub.resolves({ records: [sbxProcess] });
+        const postCopyConfig = [
+          {
+            ConfigurationName: 'OutboundMessages',
+            Label: 'R12 Endpoint',
+            Fields: { EndpointUrl: 'Url' },
+            IsActive: true,
+            ExecutionOrder: 1,
+          },
+        ];
+        const sbxInfoWithPostCopy: SandboxInfo = { ...sbxInfo, PostCopyConfig: postCopyConfig };
+
+        await prod.refreshSandbox(sbxInfoWithPostCopy, { async: true });
+
+        expect(updateStub.calledOnce).to.be.true;
+        expect(updateStub.firstCall.args[0]).to.equal('SandboxInfo');
+        expect(updateStub.firstCall.args[1]).to.deep.include({
+          SandboxName: sbxInfo.SandboxName,
+          PostCopyConfig: JSON.stringify(postCopyConfig),
+        });
       });
     });
 

--- a/test/unit/org/org.test.ts
+++ b/test/unit/org/org.test.ts
@@ -1406,6 +1406,22 @@ describe('Org Tests', () => {
           PostCopyConfig: JSON.stringify(postCopyConfig),
         });
       });
+
+      it('will refresh the SandboxInfo sObject correctly with PostCopyConfig as a string', async () => {
+        querySandboxProcessStub.resolves({ records: [sbxProcess] });
+        const postCopyConfig =
+          '[{"ConfigurationName":"OutboundMessages","Label":"R12 Endpoint","Fields":{"EndpointUrl":"Url"},"IsActive":true,"ExecutionOrder":1}]';
+        const sbxInfoWithPostCopy: SandboxInfo = { ...sbxInfo, PostCopyConfig: postCopyConfig };
+
+        await prod.refreshSandbox(sbxInfoWithPostCopy, { async: true });
+
+        expect(updateStub.calledOnce).to.be.true;
+        expect(updateStub.firstCall.args[0]).to.equal('SandboxInfo');
+        expect(updateStub.firstCall.args[1]).to.deep.include({
+          SandboxName: sbxInfo.SandboxName,
+          PostCopyConfig: postCopyConfig,
+        });
+      });
     });
 
     describe('cloneSandbox', () => {


### PR DESCRIPTION
@W-22430240@
## Summary
- Add `PostCopyConfig` field and `PostCopyConfigEntry` type to `SandboxRequest` and `SandboxInfo` so callers can pass post-copy configurations when creating or refreshing a sandbox.
- Serialize `PostCopyConfig` to JSON in `Org.createSandbox` and `Org.refreshSandbox` (mirroring the existing `Features` handling) before sending it to the Tooling API.
- Add unit tests in `test/unit/org/org.test.ts` covering the new serialization behavior.

## Test plan
- `yarn test` passes locally
- New `PostCopyConfig` tests in `test/unit/org/org.test.ts` exercise both `createSandbox` and `refreshSandbox` paths
- Tested end to end by linking my core to the changes done in this file and created sandbox via SF CLI by providing json array as the PostCopyConfig input and it worked fine. 

Request given to the SF CLI : 

> {
>   "SandboxName": "MyDevSbx1",
>   "LicenseType": "Developer",
>   "Description": "Example developer sandbox created from a definition file.",
>   "AutoActivate": false,
>   "CopyChatter": false,
>   "HistoryDays": 0,
>   "PostCopyConfig": [
>     {
>       "ConfigurationName": "OutboundMessages",
>       "Label": "R12 Endpoint",
>       "Fields": {
>         "EndpointUrl": "Url"
>       },
>       "IsActive": true,
>       "ExecutionOrder": 1
>     },
>     {
>       "ConfigurationName": "RemoteSiteSettings",
>       "Label": "R12 Remote Site",
>       "Fields": {
>         "RemoteSiteName": "Name",
>         "RemoteSiteUrl": "Url"
>       },
>       "IsActive": true,
>       "ExecutionOrder": 2
>     }
>   ]
> }

Output as sandbox creation in progress and verified the entry in SandboxInfo and SandboxProcess BPO.
<img width="948" height="554" alt="Screenshot 2026-05-13 at 2 29 14 PM" src="https://github.com/user-attachments/assets/306a7e39-a4c2-422d-b084-4253df20d3dd" />

Sandbox refresh in progress, updated the postcopyconfig file while doing the refresh and also verified that the field got updated in the respective BPO. 
<img width="1012" height="610" alt="Screenshot 2026-05-18 at 11 55 27 AM" src="https://github.com/user-attachments/assets/9ef40b41-77a9-4292-9f6d-93472df9ab37" />

