### PR TITLE
feat: persist orgEdition during Org.create for all org types - W-22583951

### DIFF
--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -9,7 +9,6 @@
 import { randomBytes } from 'node:crypto';
 import { resolve as pathResolve } from 'node:path';
 import * as os from 'node:os';
-import { Record as RecordType } from '@jsforce/jsforce-node';
 import { AsyncOptionalCreatable, env, isEmpty, parseJson, parseJsonMap } from '@salesforce/kit';
 import {
   AnyJson,
@@ -40,7 +39,7 @@ import { Messages } from '../messages';
 import { getLoginAudienceCombos, SfdcUrl } from '../util/sfdcUrl';
 import { findSuggestion } from '../util/findSuggestion';
 import { Connection, SFDX_HTTP_HEADERS } from './connection';
-import { Org, SandboxFields } from './org';
+import { Org, OrganizationInformation, SandboxFields } from './org';
 import { OrgConfigProperties } from './orgConfigProperties';
 
 Messages.importMessagesDirectory(__dirname);
@@ -406,6 +405,8 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     // authInfo before it is necessary.
     const logger = await Logger.child('Common', { tag: 'identifyPossibleScratchOrgs' });
 
+    await AuthInfo.determineOrg(orgAuthInfo);
+
     // return if we already know the hub org, we know it is a devhub or prod-like, or no orgId present
     if (Boolean(fields.isDevHub) || Boolean(fields.devHubUsername) || !fields.orgId) return;
 
@@ -460,6 +461,33 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
         await AuthInfo.identifyPossibleSandbox(pOrgAuthInfo, fields, orgAuthInfo, logger);
       }),
     ]);
+  }
+
+  /**
+   * Query the Organization object and persist org metadata fields if not already populated.
+   * Best-effort: silently returns if the org is unreachable or the query fails.
+   */
+  public static async determineOrg(orgAuthInfo: AuthInfo): Promise<void> {
+    if (orgAuthInfo.getFields().orgEdition) return;
+
+    try {
+      const conn = await Connection.create({ authInfo: orgAuthInfo });
+      const result = await conn.singleRecordQuery<OrganizationInformation>(
+        'SELECT Name, InstanceName, IsSandbox, TrialExpirationDate, NamespacePrefix, OrganizationType FROM Organization'
+      );
+      await orgAuthInfo.save({
+        [Org.Fields.NAME]: result.Name,
+        [Org.Fields.INSTANCE_NAME]: result.InstanceName,
+        [Org.Fields.NAMESPACE_PREFIX]: result.NamespacePrefix,
+        [Org.Fields.IS_SANDBOX]: result.IsSandbox && !result.TrialExpirationDate,
+        [Org.Fields.IS_SCRATCH]: result.IsSandbox && Boolean(result.TrialExpirationDate),
+        [Org.Fields.TRIAL_EXPIRATION_DATE]: result.TrialExpirationDate,
+        [Org.Fields.ORG_EDITION]: result.OrganizationType,
+      });
+    } catch (err) {
+      const logger = await Logger.child('AuthInfo', { tag: 'determineOrg' });
+      logger.debug('determineOrg failed', err);
+    }
   }
 
   /**
@@ -967,19 +995,13 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
         ensureString(authConfig.accessToken)
       );
 
-      const namespacePrefix = await this.getNamespacePrefix(
-        ensureString(authConfig.instanceUrl),
-        ensureString(authConfig.accessToken)
-      );
-
-      if (namespacePrefix) {
-        authConfig.namespacePrefix = namespacePrefix;
-      }
-
       if (authConfig.username) await this.stateAggregator.orgs.read(authConfig.username, false, false);
 
       // Update the auth fields WITH encryption
       this.update(authConfig);
+
+      // Populate Organization metadata (orgEdition, isScratch, isSandbox, etc.) in a single query.
+      await AuthInfo.determineOrg(this);
     }
 
     return this;
@@ -1281,32 +1303,6 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     throw new SfError(errorMsg);
   }
 
-  private async getNamespacePrefix(instanceUrl: string, accessToken: string): Promise<string | undefined> {
-    // Make a REST call for the Organization obj directly.  Normally this is done via a connection
-    // but we don't want to create circular dependencies or lots of snowflakes
-    // within this file to support it.
-    const apiVersion = 'v51.0'; // hardcoding to v51.0 just for this call is okay.
-    const instance = ensure(instanceUrl);
-    const baseUrl = new SfdcUrl(instance);
-    const namespacePrefixOrgUrl = `${baseUrl.toString()}/services/data/${apiVersion}/query?q=Select%20Namespaceprefix%20FROM%20Organization`;
-    const headers = Object.assign({ Authorization: `Bearer ${accessToken}` }, SFDX_HTTP_HEADERS);
-
-    try {
-      const res = await new Transport().httpRequest({ url: namespacePrefixOrgUrl, method: 'GET', headers });
-      if (res.statusCode >= 400) {
-        return;
-      }
-
-      const namespacePrefix = JSON.parse(res.body) as {
-        records: RecordType[];
-      };
-
-      return ensureString(namespacePrefix.records[0]?.NamespacePrefix);
-    } catch (err) {
-      /* Doesn't have a namespace */
-      return;
-    }
-  }
   /**
    * Returns `true` if the org is a Dev Hub.
    *

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -39,7 +39,8 @@ import { Messages } from '../messages';
 import { getLoginAudienceCombos, SfdcUrl } from '../util/sfdcUrl';
 import { findSuggestion } from '../util/findSuggestion';
 import { Connection, SFDX_HTTP_HEADERS } from './connection';
-import { Org, OrganizationInformation, SandboxFields } from './org';
+import { determineOrg } from './determineOrg';
+import { Org, SandboxFields } from './org';
 import { OrgConfigProperties } from './orgConfigProperties';
 
 Messages.importMessagesDirectory(__dirname);
@@ -405,7 +406,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     // authInfo before it is necessary.
     const logger = await Logger.child('Common', { tag: 'identifyPossibleScratchOrgs' });
 
-    await AuthInfo.determineOrg(orgAuthInfo);
+    await determineOrg(orgAuthInfo);
 
     // return if we already know the hub org, we know it is a devhub or prod-like, or no orgId present
     if (Boolean(fields.isDevHub) || Boolean(fields.devHubUsername) || !fields.orgId) return;
@@ -461,33 +462,6 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
         await AuthInfo.identifyPossibleSandbox(pOrgAuthInfo, fields, orgAuthInfo, logger);
       }),
     ]);
-  }
-
-  /**
-   * Query the Organization object and persist org metadata fields if not already populated.
-   * Best-effort: silently returns if the org is unreachable or the query fails.
-   */
-  public static async determineOrg(orgAuthInfo: AuthInfo): Promise<void> {
-    if (orgAuthInfo.getFields().orgEdition) return;
-
-    try {
-      const conn = await Connection.create({ authInfo: orgAuthInfo });
-      const result = await conn.singleRecordQuery<OrganizationInformation>(
-        'SELECT Name, InstanceName, IsSandbox, TrialExpirationDate, NamespacePrefix, OrganizationType FROM Organization'
-      );
-      await orgAuthInfo.save({
-        [Org.Fields.NAME]: result.Name,
-        [Org.Fields.INSTANCE_NAME]: result.InstanceName,
-        [Org.Fields.NAMESPACE_PREFIX]: result.NamespacePrefix,
-        [Org.Fields.IS_SANDBOX]: result.IsSandbox && !result.TrialExpirationDate,
-        [Org.Fields.IS_SCRATCH]: result.IsSandbox && Boolean(result.TrialExpirationDate),
-        [Org.Fields.TRIAL_EXPIRATION_DATE]: result.TrialExpirationDate,
-        [Org.Fields.ORG_EDITION]: result.OrganizationType,
-      });
-    } catch (err) {
-      const logger = await Logger.child('AuthInfo', { tag: 'determineOrg' });
-      logger.debug('determineOrg failed', err);
-    }
   }
 
   /**
@@ -1001,7 +975,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
       this.update(authConfig);
 
       // Populate Organization metadata (orgEdition, isScratch, isSandbox, etc.) in a single query.
-      await AuthInfo.determineOrg(this);
+      await determineOrg(this);
     }
 
     return this;

--- a/src/org/determineOrg.ts
+++ b/src/org/determineOrg.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Logger } from '../logger/logger';
+import { AuthInfo } from './authInfo';
+import { Connection } from './connection';
+import { Org, OrganizationInformation } from './org';
+
+export async function determineOrg(orgAuthInfo: AuthInfo): Promise<void> {
+  const fields = orgAuthInfo.getFields();
+
+  if (fields.orgEdition && fields.namespacePrefix !== undefined) return;
+
+  try {
+    const conn = await Connection.create({ authInfo: orgAuthInfo });
+    const result = await conn.singleRecordQuery<OrganizationInformation>(
+      'SELECT Name, InstanceName, IsSandbox, TrialExpirationDate, NamespacePrefix, OrganizationType FROM Organization'
+    );
+
+    if (fields.orgEdition) {
+      await orgAuthInfo.save({
+        [Org.Fields.NAMESPACE_PREFIX]: result.NamespacePrefix,
+      });
+    } else {
+      await orgAuthInfo.save({
+        [Org.Fields.NAME]: result.Name,
+        [Org.Fields.INSTANCE_NAME]: result.InstanceName,
+        [Org.Fields.NAMESPACE_PREFIX]: result.NamespacePrefix,
+        [Org.Fields.IS_SANDBOX]: result.IsSandbox && !result.TrialExpirationDate,
+        [Org.Fields.IS_SCRATCH]: result.IsSandbox && Boolean(result.TrialExpirationDate),
+        [Org.Fields.TRIAL_EXPIRATION_DATE]: result.TrialExpirationDate,
+        [Org.Fields.ORG_EDITION]: result.OrganizationType,
+      });
+    }
+  } catch (err) {
+    const logger = await Logger.child('AuthInfo', { tag: 'determineOrg' });
+    logger.debug('determineOrg failed', err);
+  }
+}

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -37,6 +37,7 @@ import { StateAggregator } from '../stateAggregator/stateAggregator';
 import { PollingClient } from '../status/pollingClient';
 import { StatusResult } from '../status/types';
 import { Connection, SingleRecordQueryErrors } from './connection';
+import { determineOrg } from './determineOrg';
 import { AuthFields, AuthInfo } from './authInfo';
 import { scratchOrgCreate, ScratchOrgCreateOptions, ScratchOrgCreateResult } from './scratchOrgCreate';
 import { OrgConfigProperties } from './orgConfigProperties';
@@ -1313,7 +1314,7 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
     this.orgId = this.getField(Org.Fields.ORG_ID);
 
     try {
-      await AuthInfo.determineOrg(this.getConnection().getAuthInfo());
+      await determineOrg(this.getConnection().getAuthInfo());
     } catch {
       // best effort — connection may not support getAuthInfo (e.g. passed-in mock)
     }

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -1312,13 +1312,10 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
     }
     this.orgId = this.getField(Org.Fields.ORG_ID);
 
-    // Lazily populate org metadata (including orgEdition) if not yet persisted.
-    if (this.getField(Org.Fields.ORG_EDITION) === undefined) {
-      try {
-        await this.updateLocalInformation();
-      } catch {
-        // best effort — org may not be reachable (e.g. expired scratch org)
-      }
+    try {
+      await AuthInfo.determineOrg(this.getConnection().getAuthInfo());
+    } catch {
+      // best effort — connection may not support getAuthInfo (e.g. passed-in mock)
     }
   }
 

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -1311,6 +1311,15 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
       this.connection = this.options.connection;
     }
     this.orgId = this.getField(Org.Fields.ORG_ID);
+
+    // Lazily populate org metadata (including orgEdition) if not yet persisted.
+    if (this.getField(Org.Fields.ORG_EDITION) === undefined) {
+      try {
+        await this.updateLocalInformation();
+      } catch {
+        // best effort — org may not be reachable (e.g. expired scratch org)
+      }
+    }
   }
 
   /**

--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -940,6 +940,7 @@ export class MockTestOrgData {
   public isExpired?: boolean | 'unknown';
   public password?: string;
   public namespacePrefix?: string;
+  public orgEdition?: string;
 
   public constructor(id: string = uniqid(), options?: { username: string }) {
     this.testId = id;
@@ -955,6 +956,7 @@ export class MockTestOrgData {
     this.refreshToken = `${this.testId}/refreshToken`;
     this.redirectUri = 'http://localhost:1717/OauthRedirect';
     this.namespacePrefix = `acme_${this.testId}`;
+    this.orgEdition = 'Developer Edition';
   }
 
   /**
@@ -1044,6 +1046,7 @@ export class MockTestOrgData {
     }
 
     config.isDevHub = this.isDevHub;
+    config.orgEdition = this.orgEdition;
 
     if (this.password) {
       config.password = crypto.encrypt(this.password);

--- a/test/unit/org/authInfo.test.ts
+++ b/test/unit/org/authInfo.test.ts
@@ -19,7 +19,7 @@ import { expect, config as chaiConfig } from 'chai';
 import { Transport } from '@jsforce/jsforce-node/lib/transport';
 
 import { OAuth2 } from '@jsforce/jsforce-node';
-import { SinonSpy, SinonStub, match } from 'sinon';
+import { SinonSpy, SinonStub } from 'sinon';
 import { Org } from '../../../src/org/org';
 import { AuthFields, AuthInfo } from '../../../src/org/authInfo';
 import { JwtOAuth2Config } from '../../../src/org/authInfo';
@@ -293,7 +293,7 @@ describe('AuthInfo', () => {
 
     it('should return an AuthInfo instance when passed a parent username', async () => {
       stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-      stubMethod($$.SANDBOX, AuthInfo.prototype, 'getNamespacePrefix').resolves();
+      stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
 
       await $$.stubConfig({ [OrgConfigProperties.ORG_INSTANCE_URL]: testOrg.instanceUrl });
       // Stub the http request (OAuth2.refreshToken())
@@ -513,7 +513,7 @@ describe('AuthInfo', () => {
 
       it('should return a JWT AuthInfo instance when passed a username and JWT auth options despite failed DNS lookup', async () => {
         stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-        stubMethod($$.SANDBOX, AuthInfo.prototype, 'getNamespacePrefix').resolves();
+        stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
 
         $$.setConfigStubContents('AuthInfoConfig', { contents: await testOrg.getConfig() });
 
@@ -585,7 +585,7 @@ describe('AuthInfo', () => {
     describe('Refresh Token', () => {
       it('should return a refresh token AuthInfo instance when passed a username and refresh token auth options', async () => {
         stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-        stubMethod($$.SANDBOX, AuthInfo.prototype, 'getNamespacePrefix').resolves();
+        stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
 
         const refreshTokenConfig = {
           refreshToken: testOrg.refreshToken,
@@ -642,7 +642,7 @@ describe('AuthInfo', () => {
 
       it('should return a refresh token AuthInfo instance with username in auth options', async () => {
         stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-        stubMethod($$.SANDBOX, AuthInfo.prototype, 'getNamespacePrefix').resolves();
+        stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
 
         const refreshTokenConfig = {
           refreshToken: testOrg.refreshToken,
@@ -765,7 +765,7 @@ describe('AuthInfo', () => {
 
       it('should return a refresh token AuthInfo instance with custom clientId and clientSecret', async () => {
         stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-        stubMethod($$.SANDBOX, AuthInfo.prototype, 'getNamespacePrefix').resolves();
+        stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
 
         const refreshTokenConfig = {
           clientId: 'authInfoTest_clientId',
@@ -1049,7 +1049,7 @@ describe('AuthInfo', () => {
   describe('save', () => {
     it('should update the AuthInfo fields, and write to file', async () => {
       stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-      stubMethod($$.SANDBOX, AuthInfo.prototype, 'getNamespacePrefix').resolves();
+      stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
 
       const refreshTokenConfig = {
         refreshToken: testOrg.refreshToken,
@@ -1197,7 +1197,7 @@ describe('AuthInfo', () => {
         accessToken: '',
       });
       stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-      stubMethod($$.SANDBOX, AuthInfo.prototype, 'getNamespacePrefix').resolves();
+      stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
 
       await AuthInfo.create({
         username: testOrg.username,
@@ -1325,7 +1325,7 @@ describe('AuthInfo', () => {
   describe('getSfdxAuthUrl', () => {
     it('should return the correct sfdx auth url', async () => {
       stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-      stubMethod($$.SANDBOX, AuthInfo.prototype, 'getNamespacePrefix').resolves();
+      stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
 
       const authResponse = {
         access_token: testOrg.accessToken,
@@ -1352,7 +1352,7 @@ describe('AuthInfo', () => {
 
     it('should handle instance url with a port on it', async () => {
       stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-      stubMethod($$.SANDBOX, AuthInfo.prototype, 'getNamespacePrefix').resolves();
+      stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
 
       const url = new URL(`${testOrg.instanceUrl}:6101`);
 
@@ -1382,7 +1382,7 @@ describe('AuthInfo', () => {
 
     it('should handle undefined client secret', async () => {
       stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-      stubMethod($$.SANDBOX, AuthInfo.prototype, 'getNamespacePrefix').resolves();
+      stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
 
       const authResponse = {
         access_token: testOrg.accessToken,
@@ -1411,7 +1411,7 @@ describe('AuthInfo', () => {
     describe('error conditions', () => {
       it('should handle undefined refresh token', async () => {
         stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-        stubMethod($$.SANDBOX, AuthInfo.prototype, 'getNamespacePrefix').resolves();
+        stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
 
         const authResponse = {
           access_token: testOrg.accessToken,
@@ -1438,7 +1438,7 @@ describe('AuthInfo', () => {
 
       it('should handle undefined instance url', async () => {
         stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-        stubMethod($$.SANDBOX, AuthInfo.prototype, 'getNamespacePrefix').resolves();
+        stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
 
         const authResponse = {
           access_token: testOrg.accessToken,
@@ -1554,62 +1554,6 @@ describe('AuthInfo', () => {
       expect(await AuthInfo.hasAuthentications()).to.be.true;
     });
   });
-  describe('getNamespacePrefix', () => {
-    it('should get the namespace associated to the org', async () => {
-      $$.setConfigStubContents('AuthInfoConfig', { contents: await testOrg.getConfig() });
-
-      stubMethod($$.SANDBOX, Transport.prototype, 'httpRequest')
-        .withArgs(
-          match({
-            url: `${testOrg.instanceUrl}//services/data/v51.0/query?q=Select%20Namespaceprefix%20FROM%20Organization`,
-          })
-        )
-        .resolves({
-          statusCode: 200,
-          body: JSON.stringify({
-            records: [
-              {
-                NamespacePrefix: `acme_${testOrg.testId}`,
-              },
-            ],
-          }),
-        });
-      const authInfo = await AuthInfo.create({ username: testOrg.username });
-      // @ts-expect-error because private method
-      expect(await authInfo.getNamespacePrefix(testOrg.instanceUrl, testOrg.accessToken)).to.equal(
-        `acme_${testOrg.testId}`
-      );
-
-      expect(authInfo.getFields().namespacePrefix).to.equal(`acme_${testOrg.testId}`);
-    });
-    it('should not set namespace prop if org doesn not have one', async () => {
-      const orgConfig = await testOrg.getConfig();
-      orgConfig.namespacePrefix = undefined;
-      $$.setConfigStubContents('AuthInfoConfig', { contents: orgConfig });
-
-      stubMethod($$.SANDBOX, Transport.prototype, 'httpRequest')
-        .withArgs(
-          match({
-            url: `${testOrg.instanceUrl}//services/data/v51.0/query?q=Select%20Namespaceprefix%20FROM%20Organization`,
-          })
-        )
-        .resolves({
-          statusCode: 200,
-          body: JSON.stringify({
-            records: [
-              {
-                NamespacePrefix: null,
-              },
-            ],
-          }),
-        });
-      const authInfo = await AuthInfo.create({ username: testOrg.username });
-      // @ts-expect-error because private method
-      expect(await authInfo.getNamespacePrefix(testOrg.instanceUrl, testOrg.accessToken)).to.be.undefined;
-      expect(authInfo.getFields().namespacePrefix).to.be.undefined;
-    });
-  });
-
   describe('listAllAuthorizations', () => {
     describe('with no AuthInfo.create errors', () => {
       beforeEach(async () => {

--- a/test/unit/org/authInfo.test.ts
+++ b/test/unit/org/authInfo.test.ts
@@ -21,6 +21,7 @@ import { Transport } from '@jsforce/jsforce-node/lib/transport';
 import { OAuth2 } from '@jsforce/jsforce-node';
 import { SinonSpy, SinonStub } from 'sinon';
 import { Org } from '../../../src/org/org';
+import * as determineOrgModule from '../../../src/org/determineOrg';
 import { AuthFields, AuthInfo } from '../../../src/org/authInfo';
 import { JwtOAuth2Config } from '../../../src/org/authInfo';
 import { MockTestOrgData, shouldThrow, shouldThrowSync, TestContext } from '../../../src/testSetup';
@@ -293,7 +294,7 @@ describe('AuthInfo', () => {
 
     it('should return an AuthInfo instance when passed a parent username', async () => {
       stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-      stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
 
       await $$.stubConfig({ [OrgConfigProperties.ORG_INSTANCE_URL]: testOrg.instanceUrl });
       // Stub the http request (OAuth2.refreshToken())
@@ -513,7 +514,7 @@ describe('AuthInfo', () => {
 
       it('should return a JWT AuthInfo instance when passed a username and JWT auth options despite failed DNS lookup', async () => {
         stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-        stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
+        stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
 
         $$.setConfigStubContents('AuthInfoConfig', { contents: await testOrg.getConfig() });
 
@@ -585,7 +586,7 @@ describe('AuthInfo', () => {
     describe('Refresh Token', () => {
       it('should return a refresh token AuthInfo instance when passed a username and refresh token auth options', async () => {
         stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-        stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
+        stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
 
         const refreshTokenConfig = {
           refreshToken: testOrg.refreshToken,
@@ -642,7 +643,7 @@ describe('AuthInfo', () => {
 
       it('should return a refresh token AuthInfo instance with username in auth options', async () => {
         stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-        stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
+        stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
 
         const refreshTokenConfig = {
           refreshToken: testOrg.refreshToken,
@@ -765,7 +766,7 @@ describe('AuthInfo', () => {
 
       it('should return a refresh token AuthInfo instance with custom clientId and clientSecret', async () => {
         stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-        stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
+        stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
 
         const refreshTokenConfig = {
           clientId: 'authInfoTest_clientId',
@@ -1049,7 +1050,7 @@ describe('AuthInfo', () => {
   describe('save', () => {
     it('should update the AuthInfo fields, and write to file', async () => {
       stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-      stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
 
       const refreshTokenConfig = {
         refreshToken: testOrg.refreshToken,
@@ -1197,7 +1198,7 @@ describe('AuthInfo', () => {
         accessToken: '',
       });
       stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-      stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
 
       await AuthInfo.create({
         username: testOrg.username,
@@ -1325,7 +1326,7 @@ describe('AuthInfo', () => {
   describe('getSfdxAuthUrl', () => {
     it('should return the correct sfdx auth url', async () => {
       stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-      stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
 
       const authResponse = {
         access_token: testOrg.accessToken,
@@ -1352,7 +1353,7 @@ describe('AuthInfo', () => {
 
     it('should handle instance url with a port on it', async () => {
       stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-      stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
 
       const url = new URL(`${testOrg.instanceUrl}:6101`);
 
@@ -1382,7 +1383,7 @@ describe('AuthInfo', () => {
 
     it('should handle undefined client secret', async () => {
       stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-      stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
 
       const authResponse = {
         access_token: testOrg.accessToken,
@@ -1411,7 +1412,7 @@ describe('AuthInfo', () => {
     describe('error conditions', () => {
       it('should handle undefined refresh token', async () => {
         stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-        stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
+        stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
 
         const authResponse = {
           access_token: testOrg.accessToken,
@@ -1438,7 +1439,7 @@ describe('AuthInfo', () => {
 
       it('should handle undefined instance url', async () => {
         stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-        stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
+        stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
 
         const authResponse = {
           access_token: testOrg.accessToken,
@@ -1961,6 +1962,7 @@ describe('AuthInfo', () => {
         username: user1.username,
       });
 
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
       const getDevHubAuthInfosStub = stubMethod($$.SANDBOX, AuthInfo, 'getDevHubAuthInfos').resolves([]);
       stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations').resolves([]);
       const queryScratchOrgStub = stubMethod($$.SANDBOX, AuthInfo, 'queryScratchOrg');
@@ -1984,6 +1986,7 @@ describe('AuthInfo', () => {
         username: user1.username,
       });
 
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
       const getDevHubAuthInfosStub = stubMethod($$.SANDBOX, AuthInfo, 'getDevHubAuthInfos').resolves([]);
       const queryScratchOrgStub = stubMethod($$.SANDBOX, AuthInfo, 'queryScratchOrg');
       const authInfoSaveStub = stubMethod($$.SANDBOX, AuthInfo.prototype, 'save');
@@ -2007,6 +2010,7 @@ describe('AuthInfo', () => {
         username: user1.username,
       });
 
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
       const getDevHubAuthInfosSpy = spyMethod($$.SANDBOX, AuthInfo, 'getDevHubAuthInfos');
       const queryScratchOrgStub = stubMethod($$.SANDBOX, AuthInfo, 'queryScratchOrg');
       const authInfoSaveStub = stubMethod($$.SANDBOX, AuthInfo.prototype, 'save');
@@ -2027,6 +2031,7 @@ describe('AuthInfo', () => {
         username: user1.username,
       });
 
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
       const devhubAuths = await AuthInfo.getDevHubAuthInfos();
       const getDevHubAuthInfosStub = stubMethod($$.SANDBOX, AuthInfo, 'getDevHubAuthInfos').resolves(devhubAuths);
       stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations').resolves([]);
@@ -2052,6 +2057,7 @@ describe('AuthInfo', () => {
         username: user1.username,
       });
 
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
       const stateAggregator = await StateAggregator.getInstance();
       const stateAggregatorStub = stubMethod($$.SANDBOX, StateAggregator, 'getInstance');
       const sandboxSetStub = stubMethod($$.SANDBOX, stateAggregator.sandboxes, 'set');

--- a/test/unit/org/org.test.ts
+++ b/test/unit/org/org.test.ts
@@ -1780,6 +1780,40 @@ describe('Org Tests', () => {
     });
   });
 
+  describe('org edition detection', () => {
+    it('calls updateLocalInformation during Org.create when orgEdition is missing', async () => {
+      $$.setConfigStubContents('AuthInfoConfig', { contents: { tracksSource: true } });
+      const querySpy = stubMethod($$.SANDBOX, Connection.prototype, 'singleRecordQuery').resolves({
+        Name: 'Test Org',
+        InstanceName: 'NA999',
+        IsSandbox: false,
+        TrialExpirationDate: null,
+        NamespacePrefix: null,
+        OrganizationType: 'Developer Edition',
+      });
+      const org = await Org.create({ aliasOrUsername: testData.username });
+      expect(querySpy.called).to.be.true;
+      expect(org.getField(Org.Fields.ORG_EDITION)).to.eq('Developer Edition');
+    });
+
+    it('does not call updateLocalInformation during Org.create when orgEdition is already present', async () => {
+      $$.setConfigStubContents('AuthInfoConfig', {
+        contents: { tracksSource: true, orgEdition: 'Enterprise Edition' },
+      });
+      const querySpy = stubMethod($$.SANDBOX, Connection.prototype, 'singleRecordQuery').resolves({});
+      const org = await Org.create({ aliasOrUsername: testData.username });
+      expect(querySpy.called).to.be.false;
+      expect(org.getField(Org.Fields.ORG_EDITION)).to.eq('Enterprise Edition');
+    });
+
+    it('Org.create succeeds even if updateLocalInformation throws', async () => {
+      $$.setConfigStubContents('AuthInfoConfig', { contents: { tracksSource: true } });
+      stubMethod($$.SANDBOX, Connection.prototype, 'singleRecordQuery').rejects(new Error('org unreachable'));
+      const org = await Org.create({ aliasOrUsername: testData.username });
+      expect(org.getField(Org.Fields.ORG_EDITION)).to.be.undefined;
+    });
+  });
+
   describe('source tracking detection', () => {
     it('orgs with property return the property', async () => {
       $$.setConfigStubContents('AuthInfoConfig', { contents: { tracksSource: false } });

--- a/test/unit/org/org.test.ts
+++ b/test/unit/org/org.test.ts
@@ -1798,7 +1798,7 @@ describe('Org Tests', () => {
 
     it('does not call updateLocalInformation during Org.create when orgEdition is already present', async () => {
       $$.setConfigStubContents('AuthInfoConfig', {
-        contents: { tracksSource: true, orgEdition: 'Enterprise Edition' },
+        contents: { tracksSource: true, orgEdition: 'Enterprise Edition', namespacePrefix: null },
       });
       const querySpy = stubMethod($$.SANDBOX, Connection.prototype, 'singleRecordQuery').resolves({});
       const org = await Org.create({ aliasOrUsername: testData.username });

--- a/test/unit/org/org.test.ts
+++ b/test/unit/org/org.test.ts
@@ -1806,6 +1806,52 @@ describe('Org Tests', () => {
       expect(org.getField(Org.Fields.ORG_EDITION)).to.eq('Enterprise Edition');
     });
 
+    it('fetches namespacePrefix when orgEdition is memoized but namespacePrefix is undefined', async () => {
+      $$.setConfigStubContents('AuthInfoConfig', {
+        contents: { tracksSource: true, orgEdition: 'Enterprise Edition' },
+      });
+      const querySpy = stubMethod($$.SANDBOX, Connection.prototype, 'singleRecordQuery').resolves({
+        Name: 'Test Org',
+        InstanceName: 'NA999',
+        IsSandbox: false,
+        TrialExpirationDate: null,
+        NamespacePrefix: 'myNs',
+        OrganizationType: 'Enterprise Edition',
+      });
+      const org = await Org.create({ aliasOrUsername: testData.username });
+      expect(querySpy.called).to.be.true;
+      expect(org.getField(Org.Fields.NAMESPACE_PREFIX)).to.eq('myNs');
+      expect(org.getField(Org.Fields.ORG_EDITION)).to.eq('Enterprise Edition');
+    });
+
+    it('persists a non-null namespacePrefix without overwriting orgEdition', async () => {
+      $$.setConfigStubContents('AuthInfoConfig', {
+        contents: { tracksSource: true, orgEdition: 'Developer Edition' },
+      });
+      const querySpy = stubMethod($$.SANDBOX, Connection.prototype, 'singleRecordQuery').resolves({
+        Name: 'Test Org',
+        InstanceName: 'NA999',
+        IsSandbox: false,
+        TrialExpirationDate: null,
+        NamespacePrefix: 'pkg1',
+        OrganizationType: 'Developer Edition',
+      });
+      const org = await Org.create({ aliasOrUsername: testData.username });
+      expect(querySpy.called).to.be.true;
+      expect(org.getField(Org.Fields.NAMESPACE_PREFIX)).to.eq('pkg1');
+      expect(org.getField(Org.Fields.ORG_EDITION)).to.eq('Developer Edition');
+    });
+
+    it('does not re-query once namespacePrefix is memoized with a non-null value', async () => {
+      $$.setConfigStubContents('AuthInfoConfig', {
+        contents: { tracksSource: true, orgEdition: 'Enterprise Edition', namespacePrefix: 'alreadySet' },
+      });
+      const querySpy = stubMethod($$.SANDBOX, Connection.prototype, 'singleRecordQuery').resolves({});
+      const org = await Org.create({ aliasOrUsername: testData.username });
+      expect(querySpy.called).to.be.false;
+      expect(org.getField(Org.Fields.NAMESPACE_PREFIX)).to.eq('alreadySet');
+    });
+
     it('Org.create succeeds even if updateLocalInformation throws', async () => {
       $$.setConfigStubContents('AuthInfoConfig', { contents: { tracksSource: true } });
       stubMethod($$.SANDBOX, Connection.prototype, 'singleRecordQuery').rejects(new Error('org unreachable'));

--- a/test/unit/org/user.test.ts
+++ b/test/unit/org/user.test.ts
@@ -317,7 +317,7 @@ describe('User Tests', () => {
           'auto-approve-user': '789101',
         },
       });
-      stubMethod($$.SANDBOX, AuthInfo.prototype, 'getNamespacePrefix').resolves();
+      stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
 
       const org = await Org.create({
         connection: await Connection.create({

--- a/test/unit/org/user.test.ts
+++ b/test/unit/org/user.test.ts
@@ -12,6 +12,7 @@ import { MockTestOrgData, shouldThrow, shouldThrowSync, TestContext } from '../.
 import { Org } from '../../../src/org/org';
 import { DefaultUserFields, User } from '../../../src/org/user';
 import { AuthInfo } from '../../../src/org/authInfo';
+import * as determineOrgModule from '../../../src/org/determineOrg';
 import { Connection } from '../../../src/org/connection';
 import { PermissionSetAssignment } from '../../../src/org/permissionSetAssignment';
 
@@ -317,7 +318,7 @@ describe('User Tests', () => {
           'auto-approve-user': '789101',
         },
       });
-      stubMethod($$.SANDBOX, AuthInfo, 'determineOrg').resolves();
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
 
       const org = await Org.create({
         connection: await Connection.create({


### PR DESCRIPTION
## Summary

- Add `AuthInfo.determineOrg()` — a single shared method that queries the Organization table once and persists all org metadata (`orgEdition`, `isScratch`, `isSandbox`, `name`, `instanceName`, `namespacePrefix`, `trialExpirationDate`) to the auth JSON file
- All login commands (web, jwt, sfdx-url, access-token) now capture org metadata at login time via `initAuthOptions` → `determineOrg`
- `Org.create()` also triggers `determineOrg` in `Org.init()`, ensuring metadata is populated for any code path that instantiates an Org
- Remove `getNamespacePrefix` — a raw jsforce Transport call to the Organization table that is now redundant. The consolidated query uses the core `Connection.singleRecordQuery` abstraction instead
- Uses `orgEdition` as a sentinel: if already set in the auth file, the Organization query is skipped entirely

### What issues does this PR fix or reference?

@W-22583951@

### Notes

**Problem:** The previous PR (`feat: add org edition (OrganizationType) to auth info fields`) added `orgEdition` to `AuthFields` and `updateLocalInformation()`, but `updateLocalInformation()` was never triggered during the login flow. Login commands work through `AuthInfo` and `WebOAuthServer` — they never instantiate an `Org`. Additionally, the existing code had multiple redundant Organization queries:

1. `getNamespacePrefix` — raw Transport call to `SELECT NamespacePrefix FROM Organization` during `initAuthOptions`
2. `Org.retrieveOrganizationInformation()` — full Organization query via `updateLocalInformation()` in `Org.init()`
3. `determineIfScratch()` / `determineIfSandbox()` — could each trigger `updateLocalInformation()` on cache miss

**Solution:** Consolidate into `AuthInfo.determineOrg()` which:
- Queries `SELECT Name, InstanceName, IsSandbox, TrialExpirationDate, NamespacePrefix, OrganizationType FROM Organization` — one round trip
- Persists all derived fields to the auth file
- Is called from three convergence points:
  - `initAuthOptions` (after `this.update(authConfig)`) — covers all login commands
  - `identifyPossibleScratchOrgs` — covers the login enrichment path
  - `Org.init()` — covers `Org.create()` consumers (plugin-org, plugin-deploy-retrieve, etc.)
- Subsequent calls are no-ops via the `orgEdition` sentinel check
- Since `isScratch`/`isSandbox` are now populated by `determineOrg`, calls to `determineIfScratch()`/`determineIfSandbox()` (e.g. from `tracksSource()`) will hit cache and avoid additional Organization queries

**Breaking change:** `getNamespacePrefix` was a private method, so no public API change. The `namespacePrefix` field is still populated — now via the consolidated Organization query rather than a separate raw Transport call.

## Test plan

### Automated tests
- [x] `determineOrg` queries Organization when `orgEdition` is missing from auth file
- [x] `determineOrg` skips query when `orgEdition` is already present (sentinel check)
- [x] `Org.create` succeeds even if `determineOrg` throws (best-effort)
- [x] `identifyPossibleScratchOrgs` updates auth file as a scratch org
- [x] `identifyPossibleScratchOrgs` updates auth file as a sandbox from possible prod orgs
- [x] `identifyPossibleScratchOrgs` does not update auth file when no dev hubs exist
- [x] `identifyPossibleScratchOrgs` does not update auth file when state already known
- [x] `identifyPossibleScratchOrgs` does not update auth file when no orgId present

### Manual tests
- [x] `sf org login web` — after completion, verified the orgEdition in the auth json was set to org edition of the target org
- [x] `sf org create scratch` — config requested Developer Edition. After completion, verified the orgEdition in the auth json was set to "Developer Edition"
- [x] `sf org create scratch` — config requested Enterprise Edition. After completion, verified the orgEdition in the auth json was set to "Enterprise Edition"
- [x] `sf org list` — this command verifies connectivity to each org and as a by-product of checking each, each org's existing json file was updated to include the new org edition