### PR TITLE
@W-22620566: Change Lead business process picklist value to match Developer edition templates

### DIFF
--- a/src/org/scratchOrgSettingsGenerator.ts
+++ b/src/org/scratchOrgSettingsGenerator.ts
@@ -104,7 +104,7 @@ const calculateBusinessProcess = (
         businessProcessPicklistVal = 'New';
         break;
       case 'Lead':
-        businessProcessPicklistVal = 'New - Not Contacted';
+        businessProcessPicklistVal = 'Open - Not Contacted';
         break;
       case 'Opportunity':
         businessProcessPicklistVal = 'Prospecting';

--- a/test/unit/org/scratchOrgSettingsGenerator.test.ts
+++ b/test/unit/org/scratchOrgSettingsGenerator.test.ts
@@ -823,6 +823,37 @@ describe('scratchOrgSettingsGenerator', () => {
       expect(allRecordTypes).to.deep.equal(['Case.default']);
       expect(allbusinessProcesses).to.deep.equal(['Case.defaultProcess']);
     });
+
+    it('createRecordTypeAndBusinessProcessFileContent with lead values', () => {
+      const allRecordTypes: string[] = [];
+      const allbusinessProcesses: string[] = [];
+      const recordTypeAndBusinessProcessFileContent = createRecordTypeAndBusinessProcessFileContent(
+        'lead',
+        { defaultRecordType: 'default' },
+        allRecordTypes,
+        allbusinessProcesses,
+        true
+      );
+      expect(recordTypeAndBusinessProcessFileContent).to.deep.equal({
+        '@': { xmlns: 'http://soap.sforce.com/2006/04/metadata' },
+        recordTypes: {
+          fullName: 'Default',
+          label: 'Default',
+          active: true,
+          businessProcess: 'DefaultProcess',
+        },
+        businessProcesses: {
+          fullName: 'DefaultProcess',
+          isActive: true,
+          values: {
+            fullName: 'Open - Not Contacted',
+            default: true,
+          },
+        },
+      });
+      expect(allRecordTypes).to.deep.equal(['Lead.Default']);
+      expect(allbusinessProcesses).to.deep.equal(['Lead.DefaultProcess']);
+    });
   });
 
   describe('createObjectFileContent', () => {


### PR DESCRIPTION
@W-22620566@
Summary

  - Change hardcoded Lead business process picklist value from "New - Not Contacted" to "Open - Not Contacted" to match Developer edition scratch org templates
  - Fixes settings deploy failures when objectSettings.lead.defaultRecordType is specified in definition files
  - Affects scratch org creation, package version create, and package convert

  Test plan

  - [x] Unit test added asserting Lead picklist value is "Open - Not Contacted"
  - [x] All 27 existing tests pass
  - [x] Manual E2E: sf org create scratch with Developer edition + Lead record type → succeeds
  - [x] Manual E2E: sf package convert with Developer edition definition file → generates correct Lead.object
