### PR TITLE
W-23024170  fix: handling postcopyconfig sandboxinfo field for lower orgs too

### DIFF
--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -972,10 +972,30 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
     }
 
     const whereClause = by.id ? `Id='${by.id}'` : `SandboxName='${by.name ?? '<undefined>'}'`;
-    const soql = `SELECT ${sandboxInfoFields.join(
-      ','
-    )} FROM SandboxInfo WHERE ${whereClause} ORDER BY CreatedDate DESC`;
-    const result = (await this.connection.tooling.query<SandboxInfo>(soql)).records.filter((item) => !item.IsDeleted);
+    const buildSoql = (fields: string[]): string =>
+      `SELECT ${fields.join(',')} FROM SandboxInfo WHERE ${whereClause} ORDER BY CreatedDate DESC`;
+
+    let soql = buildSoql(sandboxInfoFields);
+    let records: SandboxInfo[];
+    try {
+      records = (await this.connection.tooling.query<SandboxInfo>(soql)).records;
+    } catch (err) {
+      // PostCopyConfig is only available on orgs running a release that exposes the field on
+      // the Tooling API. Older orgs reject the SOQL with INVALID_FIELD ("No such column ...").
+      // Retry once without PostCopyConfig so existing customers aren't broken.
+      const message = err instanceof Error ? err.message : String(err);
+      const isInvalidField =
+        (err instanceof Error && err.name === 'INVALID_FIELD') || message.includes('No such column');
+      if (isInvalidField && message.includes('PostCopyConfig')) {
+        this.logger.debug('PostCopyConfig not supported on this org; retrying SandboxInfo query without it');
+        soql = buildSoql(sandboxInfoFields.filter((f) => f !== 'PostCopyConfig'));
+        records = (await this.connection.tooling.query<SandboxInfo>(soql)).records;
+      } else {
+        throw err;
+      }
+    }
+
+    const result = records.filter((item) => !item.IsDeleted);
 
     if (result.length === 0) {
       throw new SfError(`No record found for ${soql}`, SingleRecordQueryErrors.NoRecords);

--- a/test/unit/org/org.test.ts
+++ b/test/unit/org/org.test.ts
@@ -1778,6 +1778,56 @@ describe('Org Tests', () => {
         }
       });
     });
+
+    describe('querySandboxInfo', () => {
+      const sandboxInfoRecord: SandboxInfo = {
+        Id: '0GQB0000000TVobOAG',
+        IsDeleted: false,
+        CreatedDate: '2023-06-16T18:35:47.000+0000',
+        CreatedById: '005B0000004TiUpIAK',
+        LastModifiedDate: '2023-09-27T20:50:26.000+0000',
+        LastModifiedById: '005B0000004TiUpIAK',
+        SandboxName: 'mySbx',
+        LicenseType: 'DEVELOPER',
+        HistoryDays: 0,
+        CopyChatter: false,
+        AutoActivate: true,
+      };
+
+      let queryStub: SinonStub;
+
+      beforeEach(() => {
+        queryStub = stubMethod($$.SANDBOX, prod.getConnection().tooling, 'query');
+      });
+
+      it('queries SandboxInfo including PostCopyConfig on orgs that support the field', async () => {
+        queryStub.resolves({ records: [sandboxInfoRecord] });
+
+        const result = await prod.querySandboxInfo({ name: 'mySbx' });
+
+        expect(queryStub.calledOnce).to.be.true;
+        expect(queryStub.firstCall.firstArg).to.include('PostCopyConfig');
+        expect(queryStub.firstCall.firstArg).to.include("SandboxName='mySbx'");
+        expect(result).to.deep.equal(sandboxInfoRecord);
+      });
+
+      it('retries without PostCopyConfig when the org rejects the field with INVALID_FIELD', async () => {
+        const invalidFieldErr = Object.assign(
+          new Error("No such column 'PostCopyConfig' on entity 'SandboxInfo'."),
+          { name: 'INVALID_FIELD' }
+        );
+        queryStub.onFirstCall().rejects(invalidFieldErr);
+        queryStub.onSecondCall().resolves({ records: [sandboxInfoRecord] });
+
+        const result = await prod.querySandboxInfo({ name: 'mySbx' });
+
+        expect(queryStub.calledTwice).to.be.true;
+        expect(queryStub.firstCall.firstArg).to.include('PostCopyConfig');
+        expect(queryStub.secondCall.firstArg).to.not.include('PostCopyConfig');
+        expect(queryStub.secondCall.firstArg).to.include("SandboxName='mySbx'");
+        expect(result).to.deep.equal(sandboxInfoRecord);
+      });
+    });
   });
 
   describe('org edition detection', () => {


### PR DESCRIPTION
@W-23024170@
### What does this PR do?
 - Fixing the PostCopyConfig field issue for SandboxInfo BPO. The changes for the BPO are in 264 and hence the customers updating the CLI started facing the issue while doing sandbox create. 
 - Added unit tests wherever required

### What issues does this PR fix or reference?
 - [Slack Thread](https://salesforce-internal.slack.com/archives/C01LKDT1P6J/p1781612204012569)
