### PR TITLE
chore: eliminate @ts-ignore pragmas in core @W-5414318@

### DIFF
--- a/src/crypto/keyChainImpl.ts
+++ b/src/crypto/keyChainImpl.ts
@@ -171,9 +171,7 @@ export class KeychainAccess implements PasswordStore {
       try {
         return await this.osImpl.onGetCommandClose(code, stdout, stderr, opts, fn);
       } catch (e) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        if (e.retry) {
+        if ((e as { retry?: boolean }).retry) {
           if (retryCount >= GET_PASSWORD_RETRY_COUNT) {
             throw messages.createError('passwordRetryError', [GET_PASSWORD_RETRY_COUNT]);
           }
@@ -306,9 +304,7 @@ const linuxImpl: OsImpl = {
       // This is a workaround for linux.
       // Calling secret-tool too fast can cause it to return an unexpected error. (below)
       if (stderr?.includes('invalid or unencryptable secret')) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore TODO: make an error subclass with this field
-        error.retry = true;
+        (error as SfError & { retry: boolean }).retry = true;
 
         // Throwing here allows us to perform a retry in KeychainAccess
         throw error;

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -1148,8 +1148,6 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
       throw messages.createError('refreshTokenAuthError', [cause.message], undefined, cause);
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     const { orgId } = parseIdUrl(authFieldsBuilder.id);
 
     let username = this.getUsername();
@@ -1208,8 +1206,6 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     // Only need to query for the username if it isn't known. For example, a new auth code exchange
     // rather than refreshing a token on an existing connection.
     if (!username) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       const userInfo = await this.retrieveUserInfo(authFields.instance_url, authFields.access_token);
       username = userInfo?.username;
     }

--- a/src/org/connection.ts
+++ b/src/org/connection.ts
@@ -5,8 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-
 import { URL } from 'node:url';
 import { AsyncResult, DeployOptions, DeployResultLocator } from '@jsforce/jsforce-node/lib/api/metadata';
 import { Duration, env, maxBy } from '@salesforce/kit';
@@ -518,6 +516,5 @@ const getOptionsVersion = async <S extends Schema>(options: Connection.Options<S
 // jsforce does some interesting proxy loading on lib classes.
 // Setting this in the Connection.tooling getter will not work, it
 // must be set on the prototype.
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-JSForceTooling.prototype.autoFetchQuery = Connection.prototype.autoFetchQuery; // eslint-disable-line @typescript-eslint/unbound-method
+(JSForceTooling.prototype as unknown as { autoFetchQuery: Connection['autoFetchQuery'] }).autoFetchQuery =
+  Connection.prototype.autoFetchQuery; // eslint-disable-line @typescript-eslint/unbound-method

--- a/src/org/org.ts
+++ b/src/org/org.ts
@@ -227,6 +227,7 @@ export type SandboxInfoQueryFields = XOR<{ name: string }, { id: string }>;
  * **See** https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_cli_usernames_orgs.htm
  */
 export class Org extends AsyncOptionalCreatable<Org.Options> {
+  // @ts-expect-error: read dynamically via getField(Org.Fields.STATUS)
   private status: Org.Status = Org.Status.UNKNOWN;
   private configAggregator!: ConfigAggregator;
 
@@ -1171,13 +1172,9 @@ export class Org extends AsyncOptionalCreatable<Org.Options> {
    * Returns an org field. Returns undefined if the field is not set or invalid.
    */
   public getField<T = AnyJson>(key: Org.Fields): T {
-    /* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
-    // @ts-ignore Legacy. We really shouldn't be doing this.
-    const ownProp = this[key];
-    if (ownProp && typeof ownProp !== 'function') return ownProp;
-    // @ts-ignore
-    return this.getConnection().getAuthInfoFields()[key];
-    /* eslint-enable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
+    const ownProp = (this as unknown as Record<string, unknown>)[key];
+    if (ownProp && typeof ownProp !== 'function') return ownProp as T;
+    return (this.getConnection().getAuthInfoFields() as unknown as Record<string, unknown>)[key] as T;
   }
 
   /**

--- a/src/status/streamingClient.ts
+++ b/src/status/streamingClient.ts
@@ -5,8 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-
 import { resolve as resolveUrl } from 'node:url';
 import { AsyncOptionalCreatable, Duration, Env, env, set } from '@salesforce/kit';
 import { AnyFunction, AnyJson, ensure, ensureString, JsonMap } from '@salesforce/ts-types';
@@ -343,18 +341,13 @@ export class StreamingClient extends AsyncOptionalCreatable<StreamingClient.Opti
     // and will prevent the timeout from disconnecting. Here for example we will detect there is no client id but
     // unauthenticated connections are being made to salesforce. Let's close the dispatcher if it exists and
     // has no clientId.
-    // @ts-ignore
+    const client = this.cometClient as unknown as { _dispatcher?: { clientId?: string; close(): void } };
     // eslint-disable-next-line no-underscore-dangle
-    if (this.cometClient._dispatcher) {
+    const dispatcher = client._dispatcher;
+    if (dispatcher) {
       this.log('Closing the faye dispatcher');
-      // @ts-ignore
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, no-underscore-dangle
-      const dispatcher = this.cometClient._dispatcher;
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
       this.log(`dispatcher.clientId: ${dispatcher.clientId}`);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (!dispatcher.clientId) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         dispatcher.close();
       } else {
         this.disconnectClient();
@@ -472,15 +465,12 @@ export namespace StreamingClient {
       this.subscribeTimeout = StreamingClient.DefaultOptions.DEFAULT_SUBSCRIBE_TIMEOUT;
       this.handshakeTimeout = StreamingClient.DefaultOptions.DEFAULT_HANDSHAKE_TIMEOUT;
       this.streamingImpl = {
-        getCometClient: (url: string): CometClient =>
-          // @ts-ignore
-          new Faye.Client(url),
+        getCometClient: (url: string): CometClient => new Faye.Client(url) as unknown as CometClient,
         setLogger: (logLine: (message: string) => void): void => {
-          // @ts-ignore
-          Faye.logger = {};
+          const faye = Faye as unknown as { logger: Record<string, (message: string) => void> };
+          faye.logger = {};
           ['info', 'error', 'fatal', 'warn', 'debug'].forEach((element) => {
-            // @ts-ignore
-            set(Faye.logger, element, logLine);
+            set(faye.logger, element, logLine);
           });
         },
       };

--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 /* eslint-disable no-param-reassign */ // mutate ALL the THINGS!
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable class-methods-use-this */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
@@ -668,7 +667,7 @@ export const restoreContext = (testContext: TestContext): void => {
   StateAggregator.clearInstance();
   SfProject.clearInstances();
   // Allow each test to have their own config aggregator
-  // @ts-ignore clear for testing.
+  // @ts-expect-error: synchronous access to protected map for test isolation
   ConfigAggregator.instances.clear();
 };
 


### PR DESCRIPTION
@W-5414318@

## Summary
- Remove all 13 `@ts-ignore` pragmas across 6 source files in `src/`
- Replace with proper type-safe alternatives (local casts, typed assertions)
- Use `@ts-expect-error` (self-validating) only where no proper type fix exists (2 instances)

## Work Item
@W-5414318@: [sfdx-core][task] Eliminate @ts-ignore pragmas in core

## Proof of Work
- Tests: all passing (npm run test ✅)
- Lint: clean (0 errors, 4 pre-existing warnings)
- Type check: clean (npx tsc --noEmit ✅)
- grep -rn "@ts-ignore" src/: 0 results

## Validation
- Per-task review: 0 blockers, 2 warnings (pre-existing design concerns), 5 nits
- Integration: all checks pass
- Cross-cutting review: 0 blockers, 2 warnings (pre-existing, not introduced), 5 nits

## Test plan
- [ ] CI passes (type check, lint, unit tests)
- [ ] No public API type changes (signature of getField, Connection, etc. unchanged)
- [ ] Consumers compile without changes