### PR TITLE
fix: validate cached instanceApiVersion before use @W-23157155@

### DIFF
--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -32,7 +32,7 @@ import { Config } from '../config/config';
 import { ConfigAggregator } from '../config/configAggregator';
 import { Logger } from '../logger/logger';
 import { SfError } from '../sfError';
-import { matchesOpaqueAccessToken, trimTo15 } from '../util/sfdc';
+import { matchesOpaqueAccessToken, trimTo15, validateApiVersion } from '../util/sfdc';
 import { StateAggregator } from '../stateAggregator/stateAggregator';
 import { filterSecrets } from '../logger/filters';
 import { Messages } from '../messages';
@@ -615,6 +615,12 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
    */
   public update(authData?: AuthFields): AuthInfo {
     if (authData && isPlainObject(authData)) {
+      if (authData.instanceApiVersion && !validateApiVersion(authData.instanceApiVersion)) {
+        this.logger.warn(
+          `Ignoring invalid instanceApiVersion "${authData.instanceApiVersion}" (expected format: "XX.0")`
+        );
+        delete authData.instanceApiVersion;
+      }
       this.username = authData.username ?? this.username;
       this.stateAggregator.orgs.update(this.username, authData);
       this.logger.info(`Updated auth info for username: ${this.username}`);

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -619,7 +619,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
         this.logger.warn(
           `Ignoring invalid instanceApiVersion "${authData.instanceApiVersion}" (expected format: "XX.0")`
         );
-        delete authData.instanceApiVersion;
+        authData.instanceApiVersion = undefined;
       }
       this.username = authData.username ?? this.username;
       this.stateAggregator.orgs.update(this.username, authData);

--- a/src/org/connection.ts
+++ b/src/org/connection.ts
@@ -252,8 +252,9 @@ export class Connection<S extends Schema = Schema> extends JSForceConnection<S> 
       if (error.name === DNS_ERROR_NAME) {
         throw error; // throws on DNS connection errors
       }
-      // Don't fail if we can't use the latest, just use the default
-      this.logger.warn('Failed to set the latest API version:', error);
+      this.logger.warn(
+        `Failed to set the latest API version (${error.name}: ${error.message}). Using default: v${this.version}`
+      );
     }
   }
 
@@ -468,7 +469,12 @@ export class Connection<S extends Schema = Schema> extends JSForceConnection<S> 
       );
 
       if (!has24HoursPastSinceLastCheck && version) {
-        // return cached API version
+        if (!validateApiVersion(version)) {
+          this.logger.warn(
+            `Cached instanceApiVersion "${version}" is invalid (expected format: "XX.0"). Ignoring cache and re-fetching.`
+          );
+          return;
+        }
         this.logger.debug(`Using cached API version: ${version}`);
         return version;
       } else {

--- a/test/unit/org/authInfo.test.ts
+++ b/test/unit/org/authInfo.test.ts
@@ -1117,6 +1117,66 @@ describe('AuthInfo', () => {
       expect(decryptedActualFields).to.deep.equal(expectedFields);
     });
 
+    it('should strip invalid instanceApiVersion on update', async () => {
+      stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
+
+      const refreshTokenConfig = {
+        refreshToken: testOrg.refreshToken,
+        loginUrl: testOrg.loginUrl,
+      };
+      const authResponse = {
+        access_token: testOrg.accessToken,
+        instance_url: testOrg.instanceUrl,
+        id: '00DAuthInfoTest_orgId/005AuthInfoTest_userId',
+        expirationDate: testOrg.expirationDate,
+      };
+
+      postParamsStub.resolves(authResponse);
+
+      const authInfo = await AuthInfo.create({
+        username: testOrg.username,
+        oauth2Options: refreshTokenConfig,
+      });
+
+      authInfoStubs.update.resetHistory();
+
+      // Calling update with invalid instanceApiVersion should not persist it
+      authInfo.update({ instanceApiVersion: 'latest' });
+      const fields = authInfo.getFields();
+      expect(fields.instanceApiVersion).to.not.equal('latest');
+    });
+
+    it('should allow valid instanceApiVersion on update', async () => {
+      stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
+
+      const refreshTokenConfig = {
+        refreshToken: testOrg.refreshToken,
+        loginUrl: testOrg.loginUrl,
+      };
+      const authResponse = {
+        access_token: testOrg.accessToken,
+        instance_url: testOrg.instanceUrl,
+        id: '00DAuthInfoTest_orgId/005AuthInfoTest_userId',
+        expirationDate: testOrg.expirationDate,
+      };
+
+      postParamsStub.resolves(authResponse);
+
+      const authInfo = await AuthInfo.create({
+        username: testOrg.username,
+        oauth2Options: refreshTokenConfig,
+      });
+
+      authInfoStubs.update.resetHistory();
+
+      // Calling update with valid instanceApiVersion should persist it
+      authInfo.update({ instanceApiVersion: '61.0' });
+      const fields = authInfo.getFields();
+      expect(fields.instanceApiVersion).to.equal('61.0');
+    });
+
     it('should not save accesstoken files', async () => {
       // invalid access token
       const username =

--- a/test/unit/org/authInfo.test.ts
+++ b/test/unit/org/authInfo.test.ts
@@ -1144,7 +1144,7 @@ describe('AuthInfo', () => {
       // Calling update with invalid instanceApiVersion should not persist it
       authInfo.update({ instanceApiVersion: 'latest' });
       const fields = authInfo.getFields();
-      expect(fields.instanceApiVersion).to.not.equal('latest');
+      expect(fields.instanceApiVersion).to.be.undefined;
     });
 
     it('should allow valid instanceApiVersion on update', async () => {

--- a/test/unit/org/connection.test.ts
+++ b/test/unit/org/connection.test.ts
@@ -172,6 +172,37 @@ describe('Connection', () => {
     expect(conn.maxApiVersion).to.equal('51.0');
   });
 
+  it('getCachedApiVersion should ignore invalid cached version and re-fetch', async () => {
+    $$.SANDBOX.stub(Connection.prototype, 'isResolvable').resolves(true);
+
+    // Set up getFields to return an invalid cached version BEFORE create
+    testAuthInfo.getFields.returns({
+      instanceApiVersionLastRetrieved: new Date(Date.now() - Duration.hours(10).milliseconds).toLocaleString(),
+      instanceApiVersion: 'latest',
+    });
+
+    // The request mock (first call) returns the version list when cache is invalid
+    const conn = await Connection.create({ authInfo: fromStub(testAuthInfo) });
+    // 'latest' is invalid, so cache is ignored and server is hit → returns '50.0'
+    expect(conn.getApiVersion()).to.equal('50.0');
+    expect(requestMock.calledOnce).to.be.true;
+  });
+
+  it('getCachedApiVersion should accept valid cached version', async () => {
+    $$.SANDBOX.stub(Connection.prototype, 'isResolvable').resolves(true);
+
+    // Set up getFields to return a valid cached version BEFORE create
+    testAuthInfo.getFields.returns({
+      instanceApiVersionLastRetrieved: new Date(Date.now() - Duration.hours(10).milliseconds).toLocaleString(),
+      instanceApiVersion: '59.0',
+    });
+
+    const conn = await Connection.create({ authInfo: fromStub(testAuthInfo) });
+    // Valid cache is used directly, no server request needed
+    expect(conn.getApiVersion()).to.equal('59.0');
+    expect(requestMock.called).to.be.false;
+  });
+
   it('setApiVersion() should throw with invalid version', async () => {
     const conn = await Connection.create({ authInfo: fromStub(testAuthInfo) });
 


### PR DESCRIPTION
## Summary
- **Validate on read**: `getCachedApiVersion()` now validates the cached `instanceApiVersion` via `validateApiVersion()` before returning it. Invalid values (e.g. `"latest"`) are logged at warn level and ignored, forcing a fresh fetch from `services/data`.
- **Validate on write**: `AuthInfo.update()` strips invalid `instanceApiVersion` values before persisting, preventing the poisoned-cache scenario at the source.
- **Improved fallback logging**: `useLatestApiVersion()` now logs the actual version being fallen back to (e.g. `v50.0`) so the degradation is visible in debug output.

## Work Item
@W-23157155@: getCachedApiVersion() returns cached instanceApiVersion without re-validating, silently degrading to jsforce default (v50)

## Proof of Work
- Tests: 1158 passing (unit), 57 passing (NUT)
- Lint: clean (0 errors, pre-existing warnings only)
- Type check: clean
- Build: clean

## Test plan
- [x] Set `instanceApiVersion: "latest"` in `~/.sfdx/<username>.json` and verify `connection.getApiVersion()` returns the org's real max version (not `50.0`)
- [x] Verify that `AuthInfo.save({ instanceApiVersion: 'latest' })` strips the invalid value and logs a warning
- [x] Verify valid cached versions (e.g. `"61.0"`) are still used from cache without a network call
- [x] Verify expired cache (>24h) still triggers a re-fetch as before