### PR TITLE
fix: validate sfdcLoginUrl domain before use as OAuth endpoint @W-22835124@

### DIFF
--- a/messages/config.md
+++ b/messages/config.md
@@ -155,6 +155,10 @@ A valid repository URL or directory for the custom org metadata templates.
 
 Whether record types are capitalized on scratch org creation.
 
+# invalidProjectLoginUrl
+
+The sfdcLoginUrl "%s" is not a valid Salesforce domain. Only Salesforce or internal URLs are allowed as the OAuth login endpoint.
+
 # invalidId
 
 The given id %s is not a valid 15 or 18 character Salesforce ID.

--- a/src/sfProject.ts
+++ b/src/sfProject.ts
@@ -770,6 +770,28 @@ export class SfProject {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         this.projectConfig.signupTargetLoginUrl = process.env.SFDX_SCRATCH_ORG_CREATION_LOGIN_URL;
       }
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const loginUrl = this.projectConfig.sfdcLoginUrl as string;
+      if (loginUrl) {
+        if (
+          !SfdcUrl.isValidUrl(loginUrl) ||
+          (!new SfdcUrl(loginUrl).isSalesforceDomain() && !new SfdcUrl(loginUrl).isInternalUrl())
+        ) {
+          throw messages.createError('invalidProjectLoginUrl', [loginUrl]);
+        }
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const signupUrl = this.projectConfig.signupTargetLoginUrl as string;
+      if (signupUrl) {
+        if (
+          !SfdcUrl.isValidUrl(signupUrl) ||
+          (!new SfdcUrl(signupUrl).isSalesforceDomain() && !new SfdcUrl(signupUrl).isInternalUrl())
+        ) {
+          throw messages.createError('invalidProjectLoginUrl', [signupUrl]);
+        }
+      }
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/test/unit/project.test.ts
+++ b/test/unit/project.test.ts
@@ -288,7 +288,7 @@ describe('SfProject', () => {
       const read = async function () {
         // @ts-expect-error this is any
         if (this.isGlobal()) {
-          return { sfdcLoginUrl: 'globalUrl' };
+          return { sfdcLoginUrl: 'https://global.my.salesforce.com' };
         } else {
           return {};
         }
@@ -296,56 +296,56 @@ describe('SfProject', () => {
       $$.configStubs.SfProjectJson = { retrieveContents: read };
       const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
-      expect(config['sfdcLoginUrl']).to.equal('globalUrl');
+      expect(config['sfdcLoginUrl']).to.equal('https://global.my.salesforce.com');
     });
     it('gets local overrides global', async () => {
       const read = async function () {
         // @ts-expect-error this is any
         if (this.isGlobal()) {
-          return { sfdcLoginUrl: 'globalUrl' };
+          return { sfdcLoginUrl: 'https://global.my.salesforce.com' };
         } else {
-          return { sfdcLoginUrl: 'localUrl' };
+          return { sfdcLoginUrl: 'https://local.my.salesforce.com' };
         }
       };
       $$.configStubs.SfProjectJson = { retrieveContents: read };
       const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
-      expect(config['sfdcLoginUrl']).to.equal('localUrl');
+      expect(config['sfdcLoginUrl']).to.equal('https://local.my.salesforce.com');
     });
     it('gets env overrides local and config', async () => {
-      process.env.FORCE_SFDC_LOGIN_URL = 'envarUrl';
+      process.env.FORCE_SFDC_LOGIN_URL = 'https://envvar.my.salesforce.com';
       const read = async function () {
         // @ts-expect-error this is any
         if (this.isGlobal()) {
-          return { sfdcLoginUrl: 'globalUrl' };
+          return { sfdcLoginUrl: 'https://global.my.salesforce.com' };
         } else {
-          return { sfdcLoginUrl: 'localUrl' };
+          return { sfdcLoginUrl: 'https://local.my.salesforce.com' };
         }
       };
       $$.configStubs.SfProjectJson = { retrieveContents: read };
       $$.configStubs.Config = { contents: { instanceUrl: 'https://dontusethis.my.salesforce.com' } };
       const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
-      expect(config['sfdcLoginUrl']).to.equal('envarUrl');
+      expect(config['sfdcLoginUrl']).to.equal('https://envvar.my.salesforce.com');
     });
     it('gets signupTargetLoginUrl local', async () => {
       const read = async function () {
-        return { signupTargetLoginUrl: 'localUrl' };
+        return { signupTargetLoginUrl: 'https://signup.my.salesforce.com' };
       };
       $$.configStubs.SfProjectJson = { retrieveContents: read };
       const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
-      expect(config['signupTargetLoginUrl']).to.equal('localUrl');
+      expect(config['signupTargetLoginUrl']).to.equal('https://signup.my.salesforce.com');
     });
     it('gets SFDX_SCRATCH_ORG_CREATION_LOGIN_URL env overrides config', async () => {
-      process.env.SFDX_SCRATCH_ORG_CREATION_LOGIN_URL = 'envarUrl';
+      process.env.SFDX_SCRATCH_ORG_CREATION_LOGIN_URL = 'https://envvar-signup.my.salesforce.com';
       const read = async function () {
-        return { signupTargetLoginUrl: 'localUrl' };
+        return { signupTargetLoginUrl: 'https://signup.my.salesforce.com' };
       };
       $$.configStubs.SfProjectJson = { retrieveContents: read };
       const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
-      expect(config['signupTargetLoginUrl']).to.equal('envarUrl');
+      expect(config['signupTargetLoginUrl']).to.equal('https://envvar-signup.my.salesforce.com');
     });
     it('gets config org-instance-url sets sfdcLoginUrl when there is none elsewhere', async () => {
       const read = async function () {
@@ -368,9 +368,9 @@ describe('SfProject', () => {
       const read = async function () {
         // @ts-expect-error this is any
         if (this.isGlobal()) {
-          return { 'org-api-version': '38.0', sfdcLoginUrl: 'https://fromfiles.com' };
+          return { 'org-api-version': '38.0', sfdcLoginUrl: 'https://fromfiles.my.salesforce.com' };
         } else {
-          return { 'org-api-version': '39.0', sfdcLoginUrl: 'https://fromfiles.com' };
+          return { 'org-api-version': '39.0', sfdcLoginUrl: 'https://fromfiles.my.salesforce.com' };
         }
       };
       $$.configStubs.SfProjectJson = { retrieveContents: read };
@@ -379,7 +379,7 @@ describe('SfProject', () => {
       };
       const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
-      expect(config['sfdcLoginUrl']).to.equal('https://fromfiles.com');
+      expect(config['sfdcLoginUrl']).to.equal('https://fromfiles.my.salesforce.com');
     });
     it('gets config overrides local', async () => {
       const read = async function () {
@@ -395,6 +395,79 @@ describe('SfProject', () => {
       const project = await SfProject.resolve();
       const config = await project.resolveProjectConfig();
       expect(config['org-api-version']).to.equal('40.0');
+    });
+    it('rejects sfdcLoginUrl that is not a Salesforce domain', async () => {
+      const read = async function () {
+        return { sfdcLoginUrl: 'https://attacker.example.com' };
+      };
+      $$.configStubs.SfProjectJson = { retrieveContents: read };
+      const project = await SfProject.resolve();
+      try {
+        await project.resolveProjectConfig();
+        assert.fail('Expected an error to be thrown');
+      } catch (e) {
+        expect(e).to.be.instanceOf(SfError);
+        expect((e as SfError).message).to.include('https://attacker.example.com');
+        expect((e as SfError).message).to.include('not a valid Salesforce domain');
+      }
+    });
+    it('rejects non-Salesforce FORCE_SFDC_LOGIN_URL env var', async () => {
+      process.env.FORCE_SFDC_LOGIN_URL = 'https://evil.example.com';
+      $$.configStubs.SfProjectJson = { contents: {} };
+      const project = await SfProject.resolve();
+      try {
+        await project.resolveProjectConfig();
+        assert.fail('Expected an error to be thrown');
+      } catch (e) {
+        expect(e).to.be.instanceOf(SfError);
+        expect((e as SfError).message).to.include('https://evil.example.com');
+      }
+    });
+    it('allows valid Salesforce custom domain in sfdcLoginUrl', async () => {
+      const read = async function () {
+        return { sfdcLoginUrl: 'https://mycompany.my.salesforce.com' };
+      };
+      $$.configStubs.SfProjectJson = { retrieveContents: read };
+      const project = await SfProject.resolve();
+      const config = await project.resolveProjectConfig();
+      expect(config['sfdcLoginUrl']).to.equal('https://mycompany.my.salesforce.com');
+    });
+    it('allows internal URLs in sfdcLoginUrl', async () => {
+      const read = async function () {
+        return { sfdcLoginUrl: 'https://myorg.stm.salesforce.com' };
+      };
+      $$.configStubs.SfProjectJson = { retrieveContents: read };
+      const project = await SfProject.resolve();
+      const config = await project.resolveProjectConfig();
+      expect(config['sfdcLoginUrl']).to.equal('https://myorg.stm.salesforce.com');
+    });
+    it('rejects malformed (non-URL) sfdcLoginUrl', async () => {
+      const read = async function () {
+        return { sfdcLoginUrl: 'not-a-valid-url' };
+      };
+      $$.configStubs.SfProjectJson = { retrieveContents: read };
+      const project = await SfProject.resolve();
+      try {
+        await project.resolveProjectConfig();
+        assert.fail('Expected an error to be thrown');
+      } catch (e) {
+        expect(e).to.be.instanceOf(SfError);
+        expect((e as SfError).message).to.include('not-a-valid-url');
+      }
+    });
+    it('rejects non-Salesforce signupTargetLoginUrl', async () => {
+      const read = async function () {
+        return { signupTargetLoginUrl: 'https://attacker.example.com' };
+      };
+      $$.configStubs.SfProjectJson = { retrieveContents: read };
+      const project = await SfProject.resolve();
+      try {
+        await project.resolveProjectConfig();
+        assert.fail('Expected an error to be thrown');
+      } catch (e) {
+        expect(e).to.be.instanceOf(SfError);
+        expect((e as SfError).message).to.include('https://attacker.example.com');
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- Validates `sfdcLoginUrl` and `signupTargetLoginUrl` from `sfdx-project.json` (and their env var overrides) against the same Salesforce domain allowlist already enforced on `org-instance-url`
- Rejects malformed (non-URL) values and non-Salesforce domains, preventing OAuth credential phishing via attacker-authored project files (CWE-20)
- Applies the `isSalesforceDomain() || isInternalUrl()` check consistently across all login URL input paths

## Work Item
@W-22835124@: [PVR] @salesforce/core: sfdcLoginUrl from sfdx-project.json reaches the OAuth endpoint without the Salesforce-domain validation already applied to org-instance-url (CWE-20)

## How to verify (QA)

After checking out this branch and running `yarn build`, run the following Node script from the repo root. It creates a temporary `sfdx-project.json` with various URLs and shows the validation in action:

```bash
node -e "
const { SfProject } = require('./lib/sfProject');
const path = require('path');
const os = require('os');
const fs = require('fs');

async function demo() {
  const cases = [
    { label: 'Attacker domain (sfdcLoginUrl)',   url: 'https://evil.example.com',            shouldFail: true },
    { label: 'Malformed non-URL (sfdcLoginUrl)', url: 'not-a-url',                           shouldFail: true },
    { label: 'Valid custom domain',              url: 'https://mycompany.my.salesforce.com',  shouldFail: false },
    { label: 'login.salesforce.com',             url: 'https://login.salesforce.com',         shouldFail: false },
    { label: 'Internal (stm)',                   url: 'https://myorg.stm.salesforce.com',     shouldFail: false },
  ];

  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sfdx-url-demo-'));

  for (const c of cases) {
    fs.writeFileSync(path.join(tmpDir, 'sfdx-project.json'), JSON.stringify({
      packageDirectories: [{ path: 'force-app', default: true }],
      sfdcLoginUrl: c.url,
    }));
    try {
      SfProject.instances.clear();
      const project = await SfProject.resolve(tmpDir);
      await project.resolveProjectConfig();
      console.log(c.shouldFail ? '❌ UNEXPECTED PASS' : '✅ PASS', '|', c.label, ':', c.url);
    } catch (e) {
      console.log(c.shouldFail ? '✅ BLOCKED' : '❌ UNEXPECTED FAIL', '|', c.label, ':', c.url);
      if (c.shouldFail) console.log('   Error:', e.message.split('\n')[0]);
    }
  }

  // Also test env var path
  fs.writeFileSync(path.join(tmpDir, 'sfdx-project.json'), JSON.stringify({
    packageDirectories: [{ path: 'force-app', default: true }],
  }));
  process.env.FORCE_SFDC_LOGIN_URL = 'https://phish.attacker.io';
  try {
    SfProject.instances.clear();
    const project = await SfProject.resolve(tmpDir);
    await project.resolveProjectConfig();
    console.log('❌ UNEXPECTED PASS | FORCE_SFDC_LOGIN_URL env var');
  } catch (e) {
    console.log('✅ BLOCKED | FORCE_SFDC_LOGIN_URL env var :', 'https://phish.attacker.io');
  }
  delete process.env.FORCE_SFDC_LOGIN_URL;

  fs.rmSync(tmpDir, { recursive: true });
  console.log('\nAll cases behaved as expected.');
}
demo().catch(console.error);
"
```

**Expected output:**

```
✅ BLOCKED | Attacker domain (sfdcLoginUrl) : https://evil.example.com
   Error: The sfdcLoginUrl "https://evil.example.com" is not a valid Salesforce domain. Only Salesforce or internal URLs are allowed as the OAuth login endpoint.
✅ BLOCKED | Malformed non-URL (sfdcLoginUrl) : not-a-url
   Error: The sfdcLoginUrl "not-a-url" is not a valid Salesforce domain. Only Salesforce or internal URLs are allowed as the OAuth login endpoint.
✅ PASS | Valid custom domain : https://mycompany.my.salesforce.com
✅ PASS | login.salesforce.com : https://login.salesforce.com
✅ PASS | Internal (stm) : https://myorg.stm.salesforce.com
✅ BLOCKED | FORCE_SFDC_LOGIN_URL env var : https://phish.attacker.io

All cases behaved as expected.
```

## Proof of Work
- Tests: 1160 passing (0 failing)
- Lint: clean (0 errors)
- Type check: clean
- NUT tests: 57 passing

## Validation
- Per-task review: 2 blockers found (fail-open on malformed URLs, missing signupTargetLoginUrl validation) — both resolved
- Integration: all checks pass
- Cross-cutting review: warnings noted for pre-existing `isInternalUrl()` substring matching (out of scope for this fix)

## Test plan
- [x] Non-Salesforce `sfdcLoginUrl` in project file is rejected
- [x] Non-Salesforce `FORCE_SFDC_LOGIN_URL` env var is rejected
- [x] Non-Salesforce `signupTargetLoginUrl` in project file is rejected
- [x] Malformed (non-URL) values are rejected
- [x] Valid Salesforce custom domains pass through
- [x] Internal URLs (stm, vpod, etc.) pass through
- [x] Default `https://login.salesforce.com` still works
- [x] `org-instance-url` config fallback still works