### PR TITLE
feat: add projectPath and skipCache options to AuthRemover @W-23271398@

### DIFF
--- a/src/org/authRemover.ts
+++ b/src/org/authRemover.ts
@@ -39,11 +39,27 @@ const messages = Messages.loadMessages('@salesforce/core', 'auth');
  * );
  * await remover.removeAuth(auth.username);
  * ```
+ *
+ * Pass a `projectPath` to resolve local config from a specific project instead of `process.cwd()`,
+ * and `skipCache` to re-read config from disk when the process-cached aggregator can't be trusted:
+ *
+ * ```
+ * const remover = await AuthRemover.create({ projectPath: '/path/to/project', skipCache: true });
+ * await remover.removeAuth('example@mycompany.com');
+ * ```
  */
-export class AuthRemover extends AsyncOptionalCreatable {
+export class AuthRemover extends AsyncOptionalCreatable<AuthRemoverOptions> {
   private config!: ConfigAggregator;
   private stateAggregator!: StateAggregator;
   private logger!: Logger;
+  private readonly projectPath?: string;
+  private readonly skipCache?: boolean;
+
+  public constructor(options?: AuthRemoverOptions) {
+    super(options);
+    this.projectPath = options?.projectPath;
+    this.skipCache = options?.skipCache;
+  }
 
   /**
    * Removes the authentication and any configs or aliases associated with it
@@ -101,7 +117,13 @@ export class AuthRemover extends AsyncOptionalCreatable {
 
   protected async init(): Promise<void> {
     this.logger = await Logger.child(this.constructor.name);
-    this.config = await ConfigAggregator.create();
+    this.config = await ConfigAggregator.create(this.projectPath ? { projectPath: this.projectPath } : undefined);
+    // ConfigAggregator.create returns a process-cached instance keyed by projectPath, so its
+    // in-memory config may be stale (set out of process, or before this call). When the caller
+    // can't trust the cache, skipCache re-reads from disk so unsetConfigValues sees current values.
+    if (this.skipCache) {
+      await this.config.reload();
+    }
     this.stateAggregator = await StateAggregator.getInstance();
     await this.stateAggregator.orgs.readAll();
   }
@@ -190,3 +212,13 @@ export class AuthRemover extends AsyncOptionalCreatable {
     }
   }
 }
+
+export type AuthRemoverOptions = {
+  /** an absolute path to the project root, used to resolve local config; defaults to `process.cwd()` */
+  projectPath?: string;
+  /**
+   * re-read config from disk instead of trusting the process-cached ConfigAggregator. Set `true`
+   * when the config may have changed out of process or before this call. Defaults to `false`.
+   */
+  skipCache?: boolean;
+};

--- a/test/unit/org/authRemover.test.ts
+++ b/test/unit/org/authRemover.test.ts
@@ -9,6 +9,7 @@ import { spyMethod } from '@salesforce/ts-sinon';
 import { expect } from 'chai';
 import { AuthRemover } from '../../../src/org/authRemover';
 import { Config } from '../../../src/config/config';
+import { ConfigAggregator } from '../../../src/config/configAggregator';
 import { AliasAccessor } from '../../../src/stateAggregator/accessors/aliasAccessor';
 import { MockTestOrgData, shouldThrow, TestContext } from '../../../src/testSetup';
 import { OrgConfigProperties } from '../../../src/org/orgConfigProperties';
@@ -154,6 +155,41 @@ describe('AuthRemover', () => {
       // expect 2 calls: one for each alias
       expect(aliasesSpy.callCount).to.equal(2);
       expect(aliasesSpy.args).to.deep.equal([[alias1], [alias2]]);
+    });
+  });
+
+  describe('projectPath', () => {
+    it('should forward projectPath to ConfigAggregator.create', async () => {
+      const createSpy = spyMethod($$.SANDBOX, ConfigAggregator, 'create');
+      const projectPath = '/some/project/path';
+
+      await AuthRemover.create({ projectPath });
+
+      expect(createSpy.calledWith({ projectPath })).to.equal(true);
+    });
+
+    it('should call ConfigAggregator.create with no options when projectPath is omitted', async () => {
+      const createSpy = spyMethod($$.SANDBOX, ConfigAggregator, 'create');
+
+      await AuthRemover.create();
+
+      expect(createSpy.calledWith(undefined)).to.equal(true);
+    });
+
+    it('should reload the ConfigAggregator when skipCache is true', async () => {
+      const reloadSpy = spyMethod($$.SANDBOX, ConfigAggregator.prototype, 'reload');
+
+      await AuthRemover.create({ skipCache: true });
+
+      expect(reloadSpy.calledOnce).to.equal(true);
+    });
+
+    it('should not reload the ConfigAggregator by default', async () => {
+      const reloadSpy = spyMethod($$.SANDBOX, ConfigAggregator.prototype, 'reload');
+
+      await AuthRemover.create();
+
+      expect(reloadSpy.called).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

`AuthRemover.init` calls `ConfigAggregator.create()` with no arguments — which (a) resolves the **local** project config relative to `process.cwd()`, and (b) trusts the **process-cached** aggregator instance. That breaks two consumer scenarios:

- **cwd can't be trusted** (e.g. `salesforcedx-vscode`, whose extension host can run with `cwd` = `/`) → `removeAuth` can't find/unset local config keys like `target-org`.
- **long-lived cached aggregator** — a consumer that already created a `ConfigAggregator` for the project gets that same cached instance back (it's memoized by resolved projectPath). Its in-memory config may be stale (changed out of process, or set after the aggregator was built), so `unsetConfigValues` reads stale values via `getKeysByValue`, matches nothing, and silently no-ops.

This adds two optional, **backward-compatible** options to `AuthRemover`:

```ts
const remover = await AuthRemover.create({ projectPath: '/path/to/project', skipCache: true });
await remover.removeAuth('example@mycompany.com');
```

- **`projectPath`** — forwarded to `ConfigAggregator.create({ projectPath })` (matching the option name/shape `ConfigAggregator` already accepts) so local config resolves from the given project instead of `process.cwd()`.
- **`skipCache`** — when `true`, `reload()` the aggregator so config is re-read from disk before `unsetConfigValues` runs. Defaults to `false`.

**Existing behavior is unchanged**: omit both and `init` calls `ConfigAggregator.create()` with no options and does not reload — exactly as before. No existing caller is affected.

Tests: spy `ConfigAggregator.create` to assert `projectPath` is forwarded (and the no-arg case); spy `ConfigAggregator.prototype.reload` to assert it runs only when `skipCache` is `true` and not by default.

### What issues does this PR fix or reference?

@W-23271398@ — enables `salesforcedx-vscode` to unset the local `target-org` on logout dir-explicitly (no `process.chdir`) and without being fooled by a stale cached aggregator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)