### PR TITLE
fix: remove double slash in determineIfDevHub request URL @W-23299190@

### DIFF
--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -1289,7 +1289,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     const apiVersion = 'v51.0'; // hardcoding to v51.0 just for this call is okay.
     const instance = ensure(instanceUrl);
     const baseUrl = new SfdcUrl(instance);
-    const scratchOrgInfoUrl = `${baseUrl.toString()}/services/data/${apiVersion}/query?q=SELECT%20Id%20FROM%20ScratchOrgInfo%20limit%201`;
+    const scratchOrgInfoUrl = `${baseUrl.toString()}services/data/${apiVersion}/query?q=SELECT%20Id%20FROM%20ScratchOrgInfo%20limit%201`;
     const headers = Object.assign({ Authorization: `Bearer ${accessToken}` }, SFDX_HTTP_HEADERS);
 
     try {

--- a/test/unit/org/authInfo.test.ts
+++ b/test/unit/org/authInfo.test.ts
@@ -2096,13 +2096,15 @@ describe('AuthInfo', () => {
 
   describe('determineIfDevHub', () => {
     it('should return true if request succeeds', async () => {
-      stubMethod($$.SANDBOX, Transport.prototype, 'httpRequest').resolves({
+      const httpRequestStub = stubMethod($$.SANDBOX, Transport.prototype, 'httpRequest').resolves({
         statusCode: 200,
         body: JSON.stringify([]),
       });
       const authInfo = await AuthInfo.create({ username: testOrg.username });
       // @ts-expect-error because private method
       expect(await authInfo.determineIfDevHub(testOrg.instanceUrl, testOrg.accessToken)).to.be.true;
+      const requestedUrl = httpRequestStub.firstCall.args[0].url as string;
+      expect(requestedUrl.startsWith(`${testOrg.instanceUrl}/services/data/`)).to.be.true;
     });
 
     it('should return false if request returns 400', async () => {


### PR DESCRIPTION
## Summary
@W-23299190@

- `determineIfDevHub` built its ScratchOrgInfo query URL as `` `${baseUrl.toString()}/services/data/...` ``. `SfdcUrl` extends the WHATWG `URL` class, and `toString()` on a bare origin always includes a trailing slash, so the extra leading slash produced a double slash (e.g. `https://instance.salesforce.com//services/data/...`).
- Removed the leading slash so the URL matches the pattern already used correctly by the sibling `retrieveUserInfo` method a few lines up in the same file.

## Test plan
- [x] Added a URL-shape assertion to the existing `determineIfDevHub` "should return true" unit test verifying the constructed request URL has a single slash between the instance URL and `services/data`
- [x] `yarn test:only`, `yarn lint`, `yarn compile`, `yarn bundle:check`, `yarn test:nuts` all pass