### PR TITLE
fix: drop Node 18/20 support, require >=22 @W-23388103@

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "lib/index.d.ts",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "exports": {
     ".": "./lib/index.js",


### PR DESCRIPTION
## Summary
- Bump `engines.node` from `>=18.0.0` to `>=22.0.0`
- Node 18 reached EOL September 2025, Node 20 reached EOL April 2026
- Fresh installs already crash on Node 18/20 due to `@jsforce/jsforce-node@3.10.17` pulling `undici@^8.5.0` (requires Node >=22)

Fixes https://github.com/forcedotcom/cli/issues/3596
Related https://github.com/forcedotcom/cli/issues/3603

## Work Item
@W-23388103@: [CLI] Use node v24, deprecate 18 and 20

## Test plan
- [ ] CI passes on Node 22 and 24 (already the case — CI hasn't tested 18/20 since they went EOL)
- [ ] `npm install` on Node <22 shows engines warning