### PR TITLE
feat: env vars to override scratch org signup Connected App @W-23543471@

### DIFF
--- a/messages/scratchOrgErrorCodes.md
+++ b/messages/scratchOrgErrorCodes.md
@@ -113,3 +113,10 @@ The template specified in the Scratch Definition isn’t supported. Specify a ge
 # C-9999
 
 A fatal signup error occurred. Please try again. If you still see this error, contact Salesforce Support for assistance
+
+# action.C-1016
+
+If your Dev Hub is authenticated via an External Client App (ECA), the signup service cannot replicate it into the new scratch org. As a workaround, set these environment variables to use Salesforce's built-in Connected App for signup instead:
+
+SF_SCRATCH_SIGNUP_CONNECTED_APP=PlatformCLI
+SF_SCRATCH_SIGNUP_CALLBACK_URL=http://localhost:1717/OauthRedirect

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/core",
-  "version": "8.32.6-eca.1",
+  "version": "8.32.6-eca.2",
   "description": "Core libraries to interact with SFDX projects, orgs, and APIs.",
   "main": "lib/index",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/core",
-  "version": "8.32.6-eca.0",
+  "version": "8.32.6-eca.1",
   "description": "Core libraries to interact with SFDX projects, orgs, and APIs.",
   "main": "lib/index",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/core",
-  "version": "8.32.5",
+  "version": "8.32.6-eca.0",
   "description": "Core libraries to interact with SFDX projects, orgs, and APIs.",
   "main": "lib/index",
   "types": "lib/index.d.ts",

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -936,24 +936,27 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
         this.update({ username: userInfo?.username, orgId: userInfo?.organizationId });
       } else {
         if (this.options.parentUsername) {
-          const parentFields = await this.loadDecryptedAuthFromConfig(this.options.parentUsername);
-
           if (process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP) {
-            // When the signup app is overridden, use it as the clientId for the auth code exchange
-            // and skip copying the parent's privateKey so we don't fall into the JWT flow.
+            // When the signup app is overridden, use it as the clientId for the auth code exchange.
+            // Skip loading parent fields entirely — we don't need the parent's privateKey/clientSecret
+            // and the parent org may not be in the StateAggregator cache.
             options.clientId = process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP;
+            if (process.env.SFDX_CLIENT_SECRET) {
+              options.clientSecret = process.env.SFDX_CLIENT_SECRET;
+            }
           } else {
+            const parentFields = await this.loadDecryptedAuthFromConfig(this.options.parentUsername);
             options.clientId = parentFields.clientId;
-          }
 
-          if (process.env.SFDX_CLIENT_SECRET) {
-            options.clientSecret = process.env.SFDX_CLIENT_SECRET;
-          } else if (!process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP) {
-            // Grab whatever flow is defined
-            Object.assign(options, {
-              clientSecret: parentFields.clientSecret,
-              privateKey: parentFields.privateKey ? pathResolve(parentFields.privateKey) : parentFields.privateKey,
-            });
+            if (process.env.SFDX_CLIENT_SECRET) {
+              options.clientSecret = process.env.SFDX_CLIENT_SECRET;
+            } else {
+              // Grab whatever flow is defined
+              Object.assign(options, {
+                clientSecret: parentFields.clientSecret,
+                privateKey: parentFields.privateKey ? pathResolve(parentFields.privateKey) : parentFields.privateKey,
+              });
+            }
           }
         }
 

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -938,11 +938,17 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
         if (this.options.parentUsername) {
           const parentFields = await this.loadDecryptedAuthFromConfig(this.options.parentUsername);
 
-          options.clientId = parentFields.clientId;
+          if (process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP) {
+            // When the signup app is overridden, use it as the clientId for the auth code exchange
+            // and skip copying the parent's privateKey so we don't fall into the JWT flow.
+            options.clientId = process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP;
+          } else {
+            options.clientId = parentFields.clientId;
+          }
 
           if (process.env.SFDX_CLIENT_SECRET) {
             options.clientSecret = process.env.SFDX_CLIENT_SECRET;
-          } else {
+          } else if (!process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP) {
             // Grab whatever flow is defined
             Object.assign(options, {
               clientSecret: parentFields.clientSecret,

--- a/src/org/scratchOrgErrorCodes.ts
+++ b/src/org/scratchOrgErrorCodes.ts
@@ -133,10 +133,12 @@ export const checkScratchOrgInfoForErrors = async (
   if (orgInfo.Status === 'Error' && orgInfo.ErrorCode) {
     await ScratchOrgCache.unset(orgInfo.Id);
     const message = optionalErrorCodeMessage(orgInfo.ErrorCode, [WORKSPACE_CONFIG_FILENAME]);
+    const actions = [namedMessages.getMessage('SignupFailedActionError', [orgInfo.ErrorCode])];
+    if (orgInfo.ErrorCode === 'C-1016') {
+      actions.push(namedMessages.getMessage('action.C-1016'));
+    }
     if (message) {
-      throw new SfError(message, 'RemoteOrgSignupFailed', [
-        namedMessages.getMessage('SignupFailedActionError', [orgInfo.ErrorCode]),
-      ]);
+      throw new SfError(message, 'RemoteOrgSignupFailed', actions);
     }
     throw new SfError(namedMessages.getMessage('SignupFailedError', [orgInfo.ErrorCode]));
   }

--- a/src/org/scratchOrgInfoApi.ts
+++ b/src/org/scratchOrgInfoApi.ts
@@ -87,7 +87,8 @@ const buildOAuth2Options = async (options: {
   delay?: number;
 }> => {
   const logger = await Logger.child('buildOAuth2Options');
-  const isJwtFlow = !!options.hubOrg.getConnection().getAuthInfoFields().privateKey;
+  const signupAppOverridden = !!process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP;
+  const isJwtFlow = !signupAppOverridden && !!options.hubOrg.getConnection().getAuthInfoFields().privateKey;
   const oauth2Options: JwtOAuth2Config = {
     loginUrl: getOrgInstanceAuthority(
       options.scratchOrgInfoComplete,
@@ -97,6 +98,7 @@ const buildOAuth2Options = async (options: {
   };
 
   logger.debug(`isJwtFlow: ${isJwtFlow}`);
+  logger.debug(`signupAppOverridden: ${signupAppOverridden}`);
   logger.debug(`using resolved loginUrl: ${oauth2Options.loginUrl ?? '<undefined>'}`);
 
   if (isJwtFlow && !process.env.SFDX_CLIENT_SECRET) {

--- a/src/org/scratchOrgInfoGenerator.ts
+++ b/src/org/scratchOrgInfoGenerator.ts
@@ -226,12 +226,13 @@ export const generateScratchOrgInfo = async ({
   return {
     ...payload,
     orgName: scratchOrgInfoPayload.orgName ?? 'Company',
-    // we already have the info, and want to get rid of configApi, so this doesn't use that
-    connectedAppCallbackUrl: `http://localhost:${await WebOAuthServer.determineOauthPort()}/OauthRedirect`,
+    connectedAppCallbackUrl:
+      process.env.SF_SCRATCH_SIGNUP_CALLBACK_URL ??
+      `http://localhost:${await WebOAuthServer.determineOauthPort()}/OauthRedirect`,
     ...(!nonamespace && namespace ? { namespace } : {}),
-    // Use the Hub org's client ID value, if one wasn't provided to us, or the default
     connectedAppConsumerKey:
       scratchOrgInfoPayload.connectedAppConsumerKey ??
+      process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP ??
       hubOrg.getConnection().getAuthInfoFields().clientId ??
       DEFAULT_CONNECTED_APP_INFO.clientId,
     package2AncestorIds:

--- a/test/unit/org/authInfo.test.ts
+++ b/test/unit/org/authInfo.test.ts
@@ -2197,6 +2197,36 @@ describe('AuthInfo', () => {
       }
     });
   });
+
+  describe('SF_SCRATCH_SIGNUP_CONNECTED_APP bypasses parent auth loading', () => {
+    it('should not throw NamedOrgNotFoundError when parent is not in cache', async () => {
+      stubMethod($$.SANDBOX, AuthInfo.prototype, 'determineIfDevHub').resolves(false);
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
+
+      process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP = 'PlatformCLI';
+
+      postParamsStub.callsFake(() => ({
+        access_token: testOrg.accessToken,
+        instance_url: testOrg.instanceUrl,
+        refresh_token: testOrg.refreshToken,
+        id: '00DAuthInfoTest_orgId/005AuthInfoTest_userId',
+      }));
+
+      try {
+        const authInfo = await AuthInfo.create({
+          username: testOrg.username,
+          parentUsername: 'nonexistent-parent@hub.org',
+          oauth2Options: {
+            loginUrl: testOrg.instanceUrl,
+            authCode: testOrg.authcode,
+          },
+        });
+        expect(authInfo.isRefreshTokenFlow()).to.be.true;
+      } finally {
+        delete process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP;
+      }
+    });
+  });
 });
 
 describe('AuthInfo No fs mock', () => {

--- a/test/unit/org/scratchOrgErrorCodes.test.ts
+++ b/test/unit/org/scratchOrgErrorCodes.test.ts
@@ -256,4 +256,20 @@ describe('getHumanErrorMessage', () => {
     const successOrgInfo: ScratchOrgInfo = { ...baseOrgInfo, Status: 'Active' };
     expect(await checkScratchOrgInfoForErrors(successOrgInfo, testUsername)).to.deep.equal(successOrgInfo);
   });
+
+  it('C-1016 includes env var workaround in actions', async () => {
+    const ErrorCode = 'C-1016';
+    try {
+      await shouldThrow(checkScratchOrgInfoForErrors({ ...baseOrgInfo, ErrorCode }, testUsername));
+    } catch (err) {
+      if (!(err instanceof SfError)) {
+        expect.fail('should have thrown SfError');
+      }
+      expect(err.name).to.equal('RemoteOrgSignupFailed');
+      expect(err.message).to.include('Connected App');
+      expect(err.actions).to.have.lengthOf(2);
+      expect(err.actions![0]).to.include('information on error code');
+      expect(err.actions![1]).to.include('SF_SCRATCH_SIGNUP_CONNECTED_APP');
+    }
+  });
 });

--- a/test/unit/org/scratchOrgInfoApi.test.ts
+++ b/test/unit/org/scratchOrgInfoApi.test.ts
@@ -463,7 +463,29 @@ describe('authorizeScratchOrg', () => {
 
   afterEach(() => {
     env.unset('SFDX_CLIENT_SECRET');
+    delete process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP;
     sandbox.restore();
+  });
+
+  it('authorizeScratchOrg uses auth code exchange when SF_SCRATCH_SIGNUP_CONNECTED_APP is set', async () => {
+    hubOrgStub.isDevHubOrg.returns(true);
+    process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP = 'PlatformCLI';
+
+    const result = await authorizeScratchOrg({
+      scratchOrgInfoComplete: TEMPLATE_SCRATCH_ORG_INFO,
+      hubOrg: hubOrgStub,
+    });
+
+    expect(result).to.be.equal(authInfo);
+    expect(authInfoStub.firstCall.args[0]).to.deep.equal({
+      username: TEMPLATE_SCRATCH_ORG_INFO.SignupUsername,
+      parentUsername: username,
+      oauth2Options: {
+        loginUrl: `https://${TEMPLATE_SCRATCH_ORG_INFO.SignupInstance}.salesforce.com`,
+        redirectUri: undefined,
+        authCode: TEMPLATE_SCRATCH_ORG_INFO.AuthCode,
+      },
+    });
   });
 
   it('authorizeScratchOrg basic', async () => {

--- a/test/unit/org/scratchOrgInfoGenerator.test.ts
+++ b/test/unit/org/scratchOrgInfoGenerator.test.ts
@@ -734,6 +734,99 @@ describe('scratchOrgInfoGenerator', () => {
     });
   });
 
+  describe('SF_SCRATCH_SIGNUP_CONNECTED_APP env var', () => {
+    const sandbox = sinon.createSandbox();
+    beforeEach(() => {
+      stubMethod(sandbox, Org, 'create').resolves(Org.prototype);
+      stubMethod(sandbox, Org.prototype, 'getConnection').returns(Connection.prototype);
+      stubMethod(sandbox, Connection.prototype, 'getAuthInfoFields').returns({
+        clientId: 'eca-client-id',
+      });
+      stubMethod(sandbox, SfProjectJson, 'create').rejects();
+    });
+
+    afterEach(() => {
+      delete process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP;
+      delete process.env.SF_SCRATCH_SIGNUP_CALLBACK_URL;
+      sandbox.restore();
+    });
+
+    after(() => {
+      sandbox.restore();
+    });
+
+    it('uses SF_SCRATCH_SIGNUP_CONNECTED_APP over hub clientId', async () => {
+      process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP = 'PlatformCLI';
+      expect(
+        await generateScratchOrgInfo({
+          hubOrg: await Org.create({}),
+          scratchOrgInfoPayload: {} as ScratchOrgInfoPayload,
+          nonamespace: false,
+          ignoreAncestorIds: false,
+        })
+      ).to.deep.equal({
+        orgName: 'Company',
+        package2AncestorIds: '',
+        connectedAppConsumerKey: 'PlatformCLI',
+        connectedAppCallbackUrl: 'http://localhost:1717/OauthRedirect',
+      });
+    });
+
+    it('uses SF_SCRATCH_SIGNUP_CALLBACK_URL over default callback', async () => {
+      process.env.SF_SCRATCH_SIGNUP_CALLBACK_URL = 'http://localhost:9999/OauthRedirect';
+      expect(
+        await generateScratchOrgInfo({
+          hubOrg: await Org.create({}),
+          scratchOrgInfoPayload: {} as ScratchOrgInfoPayload,
+          nonamespace: false,
+          ignoreAncestorIds: false,
+        })
+      ).to.deep.equal({
+        orgName: 'Company',
+        package2AncestorIds: '',
+        connectedAppConsumerKey: 'eca-client-id',
+        connectedAppCallbackUrl: 'http://localhost:9999/OauthRedirect',
+      });
+    });
+
+    it('explicit --client-id flag takes priority over env var', async () => {
+      process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP = 'PlatformCLI';
+      expect(
+        await generateScratchOrgInfo({
+          hubOrg: await Org.create({}),
+          scratchOrgInfoPayload: {
+            connectedAppConsumerKey: 'explicit-flag-value',
+          } as ScratchOrgInfoPayload,
+          nonamespace: false,
+          ignoreAncestorIds: false,
+        })
+      ).to.deep.equal({
+        orgName: 'Company',
+        package2AncestorIds: '',
+        connectedAppConsumerKey: 'explicit-flag-value',
+        connectedAppCallbackUrl: 'http://localhost:1717/OauthRedirect',
+      });
+    });
+
+    it('uses both env vars together for ECA workaround', async () => {
+      process.env.SF_SCRATCH_SIGNUP_CONNECTED_APP = 'PlatformCLI';
+      process.env.SF_SCRATCH_SIGNUP_CALLBACK_URL = 'http://localhost:1717/OauthRedirect';
+      expect(
+        await generateScratchOrgInfo({
+          hubOrg: await Org.create({}),
+          scratchOrgInfoPayload: {} as ScratchOrgInfoPayload,
+          nonamespace: false,
+          ignoreAncestorIds: false,
+        })
+      ).to.deep.equal({
+        orgName: 'Company',
+        package2AncestorIds: '',
+        connectedAppConsumerKey: 'PlatformCLI',
+        connectedAppCallbackUrl: 'http://localhost:1717/OauthRedirect',
+      });
+    });
+  });
+
   describe('generateScratchOrgInfo with nonamespace', () => {
     const sandbox = sinon.createSandbox();
     beforeEach(() => {


### PR DESCRIPTION
## Summary

- Adds `SF_SCRATCH_SIGNUP_CONNECTED_APP` and `SF_SCRATCH_SIGNUP_CALLBACK_URL` environment variables that override the Connected App used during scratch org signup
- Unblocks CI workflows using External Client Apps (ECA) + JWT for Dev Hub auth, which otherwise fail with C-1016 because Proxy Signup cannot replicate ECAs
- Env vars slot into the existing fallback chain without changing default behavior

## Context

- GitHub issue: https://github.com/forcedotcom/cli/issues/3515
- @W-23543471@

When a Dev Hub is authenticated via an ECA + JWT bearer flow, `sf org create scratch` fails with C-1016. The CLI derives the signup Connected App from the hub session's `clientId`, but ECAs cannot be replicated by Proxy Signup into the new scratch org.

**Usage:**
```bash
export SF_SCRATCH_SIGNUP_CONNECTED_APP=PlatformCLI
sf org create scratch ...
```

**Fallback priority:**
1. Explicit `--client-id` flag (existing behavior)
2. `SF_SCRATCH_SIGNUP_CONNECTED_APP` env var (new)
3. Hub org's clientId (existing behavior)
4. `PlatformCLI` default (existing behavior)

These env vars are intended as a temporary workaround until Proxy Signup supports ECA replication natively, at which point they become no-ops and can be deprecated.

## Test plan

- [x] Unit tests for env var override of consumer key
- [x] Unit tests for env var override of callback URL
- [x] Unit test verifying explicit flag still takes priority over env var
- [x] Unit test for both env vars together (full ECA workaround)
- [x] Existing tests unchanged (no regression)
- [ ] Integration test against ECA + JWT Dev Hub (community volunteer available)