### PR TITLE
fix: resolve TS2694 pino.TransportSingleOptions type error in emitted .d.ts @W-23751214@

### DIFF
--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -16,7 +16,7 @@
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { type Logger as PinoLogger, pino } from 'pino';
+import { type Logger as PinoLogger, type TransportSingleOptions, pino, levels as pinoLevels } from 'pino';
 import { Env } from '@salesforce/kit';
 import { isKeyOf, isString } from '@salesforce/ts-types';
 import { Global, Mode } from '../global';
@@ -460,7 +460,7 @@ export class Logger {
 }
 
 /** return various streams that the logger could send data to, depending on the options and env  */
-export const getWriteStream = (level = 'warn'): pino.TransportSingleOptions => {
+export const getWriteStream = (level = 'warn'): TransportSingleOptions => {
   const env = new Env();
   // used when debug mode, writes to stdout (colorized)
   if (process.env.DEBUG) {
@@ -519,13 +519,13 @@ const levelFromOption = (value?: string | number): string => {
     case 'string':
       return value;
     default:
-      return pino.levels.labels[Logger.DEFAULT_LEVEL];
+      return pinoLevels.labels[Logger.DEFAULT_LEVEL];
   }
 };
 // /** match a number to a pino level, or if a match isn't found, the next highest level */
 const numberToLevel = (level: number): string =>
-  pino.levels.labels[level] ??
-  Object.entries(pino.levels.labels).find(([value]) => Number(value) > level)?.[1] ??
+  pinoLevels.labels[level] ??
+  Object.entries(pinoLevels.labels).find(([value]) => Number(value) > level)?.[1] ??
   'warn';
 
 const getDefaultLevel = (): LoggerLevel => {


### PR DESCRIPTION
## Summary
- Fix TS2694 error where emitted `logger.d.ts` referenced `pino.TransportSingleOptions` through the inner `pino.pino` namespace, which doesn't export that type
- Import `TransportSingleOptions` directly from pino's module-level exports so the emitted `.d.ts` references the correct type path
- Also import `levels` directly (`pinoLevels`) to avoid namespace access through the same problematic inner binding

Fixes https://github.com/forcedotcom/cli/issues/3618

## Work Item
@W-23751214@: @salesforce/core type declaration references pino.pino.TransportSingleOptions, breaks builds with skipLibCheck: false (TS2694)

## Root Cause
`import { pino } from 'pino'` resolves to the inner namespace binding. When TypeScript emits `.d.ts`, it writes `pino.TransportSingleOptions` which consumers resolve as `pino.pino.TransportSingleOptions` — but `TransportSingleOptions` only exists in the outer `declare namespace pino`.

## Proof of Work
- `tsc --noEmit`: clean
- Full test suite: 7 scripts, all passing (31.8s)
- Emitted `lib/logger/logger.d.ts` now correctly shows:
  - `import { type TransportSingleOptions } from 'pino';`
  - `export declare const getWriteStream: (level?: string) => TransportSingleOptions;`

## Validation
- Per-task adversarial review: no blockers, no warnings
- Integration: all checks pass
- Type check: clean
- Build: clean

## Test plan
- [ ] Verify `tsc --noEmit` passes with `skipLibCheck: false` in a downstream consumer using `@salesforce/core`
- [ ] Verify existing logger tests pass
- [ ] Verify emitted `.d.ts` no longer references `pino.TransportSingleOptions`