### PR TITLE
W-23735286- fix:  use native fetch in schema update scripts

### DIFF
--- a/schemas/project-scratch-def.schema.json
+++ b/schemas/project-scratch-def.schema.json
@@ -330,6 +330,11 @@
                 "pattern": "^PlatformEventsPerDay:[0-9]+$"
               },
               {
+                "title": "ServiceCloudVoicePartnerTelephony:<value>",
+                "type": "string",
+                "pattern": "^ServiceCloudVoicePartnerTelephony:[0-9]+$"
+              },
+              {
                 "title": "StreamingEventsPerDay:<value>",
                 "type": "string",
                 "pattern": "^StreamingEventsPerDay:[0-9]+$"
@@ -357,10 +362,13 @@
               "AdmissionsConnectUser",
               "AdvisorLinkFeature",
               "AdvisorLinkPathwaysFeature",
+              "AgentforceVibesIDEForDE",
+              "AgentforceVibesUnmeteredAccess",
               "AllUserIdServiceAccess",
               "AnalyticsAdminPerms",
               "AnalyticsAppEmbedded",
               "ApexGuruCodeAnalyzer",
+              "ApexIntegrationTests (Developer Preview)",
               "ApexUserModeWithPermSet",
               "ArcGraphCommunity",
               "Assessments",
@@ -395,6 +403,7 @@
               "ChatterEmailFooterLogo",
               "ChatterEmailFooterText",
               "ChatterEmailSenderName",
+              "CleanEnergyProgramManagement",
               "CloneApplication",
               "Communities",
               "CompareReportsOrgPerm",
@@ -437,6 +446,12 @@
               "DynamicClientCreationLimit",
               "EAOutputConnectors",
               "EASyncOut",
+              "EAndUAgentforce",
+              "EAndUCoreSales",
+              "EAndUCoreSelfServicePortal",
+              "EAndUCoreService",
+              "EAndUCoreTimeSheetService",
+              "EAndUDataKits",
               "EAndUDigitalSales",
               "EAndUSelfServicePortal",
               "ERMAnalytics",
@@ -457,6 +472,7 @@
               "EinsteinVisits",
               "EinsteinVisitsED",
               "EmbeddedLoginForIE",
+              "EmergencyManagement",
               "EnableManageIdConfUI",
               "EnablePRM",
               "EnableSetPasswordInApi",
@@ -511,6 +527,7 @@
               "IntelligentDocumentReader",
               "Interaction",
               "InvestigativeCaseManagement",
+              "InvocableActionExt",
               "InvoiceManagement",
               "IoT",
               "JigsawUser",
@@ -686,6 +703,14 @@
         },
         "addressSettings": {
           "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_addresssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "agentforceAccountManagementSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_agentforceaccountmanagementsettings.htm",
           "type": "object",
           "propertyNames": {
             "type": "string"

--- a/scripts/schemas/update-features.ts
+++ b/scripts/schemas/update-features.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { writeFileSync } from 'node:fs';
-import { get } from 'node:https';
 import { simpleFeaturesList } from '../../src/schema/project-scratch-def/simpleFeaturesList';
 import { patternFeaturesList } from '../../src/schema/project-scratch-def/patternFeaturesList';
 
@@ -52,20 +51,18 @@ const parseFeature = (text: string): { name: string; isPattern: boolean } => {
 const generateFileContent = (varName: string, features: readonly string[]): string =>
   `${COPYRIGHT_HEADER}export const ${varName} = [\n${features.map((f) => `  '${f}',`).join('\n')}\n];\n`;
 
-// Fetch JSON from URL using node:https
-// TODO: use node's `fetch` after dropping node v20
-const fetchJson = (url: string): Promise<DocsResponse> =>
-  new Promise((resolve, reject) => {
-    get(url, (res) => {
-      let data = '';
-      res.on('data', (chunk: string) => {
-        data += chunk;
-      });
-      res.on('end', () => {
-        resolve(JSON.parse(data) as DocsResponse);
-      });
-    }).on('error', reject);
-  });
+const fetchJson = async (url: string): Promise<DocsResponse> => {
+  // @ts-expect-error fetch is globally available in Node 18+ but tsconfig targets ES2022
+  const res: Response = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} from ${url}`);
+  }
+  const text = await res.text();
+  if (!text.startsWith('{') && !text.startsWith('[')) {
+    throw new Error(`Expected JSON but got: ${text.slice(0, 200)}`);
+  }
+  return JSON.parse(text) as DocsResponse;
+};
 
 const main = async (): Promise<void> => {
   console.log('Fetching features from Salesforce documentation...');
@@ -123,6 +120,6 @@ const main = async (): Promise<void> => {
 };
 
 main().catch((err: unknown) => {
-  console.error('Error:', err);
-  process.exit(1);
+  console.warn('Warning: could not update features list:', err instanceof Error ? err.message : err);
+  console.warn('This is expected when the Salesforce docs site is unreachable from CI runners.');
 });

--- a/scripts/schemas/update-features.ts
+++ b/scripts/schemas/update-features.ts
@@ -53,7 +53,9 @@ const generateFileContent = (varName: string, features: readonly string[]): stri
 
 const fetchJson = async (url: string): Promise<DocsResponse> => {
   // @ts-expect-error fetch is globally available in Node 18+ but tsconfig targets ES2022
-  const res: Response = await fetch(url);
+  const res: Response = await fetch(url, {
+    headers: { 'User-Agent': 'sfdx-core/schema-update' },
+  });
   if (!res.ok) {
     throw new Error(`HTTP ${res.status} from ${url}`);
   }

--- a/scripts/schemas/update-features.ts
+++ b/scripts/schemas/update-features.ts
@@ -122,6 +122,6 @@ const main = async (): Promise<void> => {
 };
 
 main().catch((err: unknown) => {
-  console.warn('Warning: could not update features list:', err instanceof Error ? err.message : err);
-  console.warn('This is expected when the Salesforce docs site is unreachable from CI runners.');
+  console.error('Error:', err instanceof Error ? err.message : err);
+  process.exit(1);
 });

--- a/scripts/schemas/update-settings.ts
+++ b/scripts/schemas/update-settings.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { readFileSync, writeFileSync } from 'node:fs';
-import { get } from 'node:https';
 
 const DOCS_URL = 'https://developer.salesforce.com/docs/get_document/atlas.en-us.api_meta.meta';
 const DOCS_BASE_URL = 'https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta';
@@ -83,19 +82,20 @@ export type Settings = z.infer<typeof SettingsSchema>;
 `;
 };
 
-// Fetch JSON from URL using node:https
-const fetchJson = (url: string): Promise<DocsResponse> =>
-  new Promise((resolve, reject) => {
-    get(url, (res) => {
-      let data = '';
-      res.on('data', (chunk: string) => {
-        data += chunk;
-      });
-      res.on('end', () => {
-        resolve(JSON.parse(data) as DocsResponse);
-      });
-    }).on('error', reject);
+const fetchJson = async (url: string): Promise<DocsResponse> => {
+  // @ts-expect-error fetch is globally available in Node 18+ but tsconfig targets ES2022
+  const res: Response = await fetch(url, {
+    headers: { 'User-Agent': 'sfdx-core/schema-update' },
   });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} from ${url}`);
+  }
+  const text = await res.text();
+  if (!text.startsWith('{') && !text.startsWith('[')) {
+    throw new Error(`Expected JSON but got: ${text.slice(0, 200)}`);
+  }
+  return JSON.parse(text) as DocsResponse;
+};
 
 const main = async (): Promise<void> => {
   console.log('Fetching settings from Salesforce Metadata API documentation...');
@@ -155,6 +155,6 @@ const main = async (): Promise<void> => {
 };
 
 main().catch((err: unknown) => {
-  console.error('Error:', err);
-  process.exit(1);
+  console.warn('Warning: could not update settings list:', err instanceof Error ? err.message : err);
+  console.warn('This is expected when the Salesforce docs site is unreachable from CI runners.');
 });

--- a/scripts/schemas/update-settings.ts
+++ b/scripts/schemas/update-settings.ts
@@ -155,6 +155,6 @@ const main = async (): Promise<void> => {
 };
 
 main().catch((err: unknown) => {
-  console.warn('Warning: could not update settings list:', err instanceof Error ? err.message : err);
-  console.warn('This is expected when the Salesforce docs site is unreachable from CI runners.');
+  console.error('Error:', err instanceof Error ? err.message : err);
+  process.exit(1);
 });

--- a/src/schema/project-scratch-def/patternFeaturesList.ts
+++ b/src/schema/project-scratch-def/patternFeaturesList.ts
@@ -1,8 +1,17 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 export const patternFeaturesList = [
   'AddCustomApps',

--- a/src/schema/project-scratch-def/patternFeaturesList.ts
+++ b/src/schema/project-scratch-def/patternFeaturesList.ts
@@ -1,17 +1,8 @@
 /*
- * Copyright 2026, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 export const patternFeaturesList = [
   'AddCustomApps',
@@ -68,6 +59,7 @@ export const patternFeaturesList = [
   'NumPlatformEvents',
   'PlatformConnect',
   'PlatformEventsPerDay',
+  'ServiceCloudVoicePartnerTelephony',
   'StreamingEventsPerDay',
   'SubPerStreamingChannel',
   'SubPerStreamingTopic',

--- a/src/schema/project-scratch-def/settings.ts
+++ b/src/schema/project-scratch-def/settings.ts
@@ -1,8 +1,17 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 import { z } from 'zod';
 

--- a/src/schema/project-scratch-def/settings.ts
+++ b/src/schema/project-scratch-def/settings.ts
@@ -1,17 +1,8 @@
 /*
- * Copyright 2026, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { z } from 'zod';
 
@@ -68,6 +59,12 @@ export const SettingsSchema = z
       .optional()
       .describe(
         'For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_addresssettings.htm'
+      ),
+    agentforceAccountManagementSettings: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe(
+        'For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_agentforceaccountmanagementsettings.htm'
       ),
     agentforceForDevelopersSettings: z
       .record(z.string(), z.unknown())

--- a/src/schema/project-scratch-def/simpleFeaturesList.ts
+++ b/src/schema/project-scratch-def/simpleFeaturesList.ts
@@ -1,8 +1,17 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 export const simpleFeaturesList = [
   'AIAttribution',

--- a/src/schema/project-scratch-def/simpleFeaturesList.ts
+++ b/src/schema/project-scratch-def/simpleFeaturesList.ts
@@ -1,17 +1,8 @@
 /*
- * Copyright 2026, Salesforce, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 export const simpleFeaturesList = [
   'AIAttribution',
@@ -23,10 +14,13 @@ export const simpleFeaturesList = [
   'AdmissionsConnectUser',
   'AdvisorLinkFeature',
   'AdvisorLinkPathwaysFeature',
+  'AgentforceVibesIDEForDE',
+  'AgentforceVibesUnmeteredAccess',
   'AllUserIdServiceAccess',
   'AnalyticsAdminPerms',
   'AnalyticsAppEmbedded',
   'ApexGuruCodeAnalyzer',
+  'ApexIntegrationTests (Developer Preview)',
   'ApexUserModeWithPermSet',
   'ArcGraphCommunity',
   'Assessments',
@@ -61,6 +55,7 @@ export const simpleFeaturesList = [
   'ChatterEmailFooterLogo',
   'ChatterEmailFooterText',
   'ChatterEmailSenderName',
+  'CleanEnergyProgramManagement',
   'CloneApplication',
   'Communities',
   'CompareReportsOrgPerm',
@@ -103,6 +98,12 @@ export const simpleFeaturesList = [
   'DynamicClientCreationLimit',
   'EAOutputConnectors',
   'EASyncOut',
+  'EAndUAgentforce',
+  'EAndUCoreSales',
+  'EAndUCoreSelfServicePortal',
+  'EAndUCoreService',
+  'EAndUCoreTimeSheetService',
+  'EAndUDataKits',
   'EAndUDigitalSales',
   'EAndUSelfServicePortal',
   'ERMAnalytics',
@@ -123,6 +124,7 @@ export const simpleFeaturesList = [
   'EinsteinVisits',
   'EinsteinVisitsED',
   'EmbeddedLoginForIE',
+  'EmergencyManagement',
   'EnableManageIdConfUI',
   'EnablePRM',
   'EnableSetPasswordInApi',
@@ -177,6 +179,7 @@ export const simpleFeaturesList = [
   'IntelligentDocumentReader',
   'Interaction',
   'InvestigativeCaseManagement',
+  'InvocableActionExt',
   'InvoiceManagement',
   'IoT',
   'JigsawUser',


### PR DESCRIPTION
### What does this PR do?
## Summary
  - Replace `node:https.get()` with native `fetch()` + explicit `User-Agent` header in `update-features.ts` and `update-settings.ts`
  - Add response validation (status check + JSON body check) and clear error
  - Include features/settings that have accumulated since the script broke in April
  - script broke since April: [https://github.com/forcedotcom/sfdx-core/actions/runs/23975886079](url)
  ## Test plan
  - [x] Both scripts pass locally
  - [x] CI workflow passes: [https://github.com/forcedotcom/sfdx-core/actions/runs/32074013293/job/95523138399](url)
### What issues does this PR fix or reference?
CLI related Issue: https://github.com/forcedotcom/cli/issues/3617
@W-23735286@