### PR TITLE
fix(W-22515355): add mocha types to testSetup.ts

### DIFF
--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 // mutate ALL the THINGS!
+/// <reference types="mocha" />
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable class-methods-use-this */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */


### PR DESCRIPTION
### What does this PR do?
Adds mocha types to testSetup.ts. Needed in preparation for TypeScript v6 upgrade.

### What issues does this PR fix or reference?
[@W-22515355@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002a82ohYAA/view)
