### PR TITLE
feat: add Apex Symbols Connection API (W-23973889)

### DIFF
--- a/.cursor/plans/connection-symbols-endpoint.plan.md
+++ b/.cursor/plans/connection-symbols-endpoint.plan.md
@@ -6,7 +6,8 @@ Expose the Salesforce Tooling Apex Symbols endpoint through `@salesforce/core` a
 capability. Consumers must be able to retrieve symbol data for standard Apex classes, org-defined Apex classes, and
 installed-package Apex classes, and dynamic Apex classes without constructing authenticated URLs themselves. Support
 exact, namespace-qualified class lookups as well as broad Apex type discovery across every shipping category, with
-optional filters and explicit result formats. Provide a bounded materialized API for exact and ordinary requests and
+optional filters. Treat the endpoint's sole current `TYPE_STUB` response shape as the fixed contract rather than
+exposing its ineffective `format` query parameter. Provide a bounded materialized API for exact and ordinary requests and
 a genuinely streaming API for broad responses.
 
 The implementation must not introduce a new class. It should adapt the existing `Connection` and use plain TypeScript
@@ -36,12 +37,12 @@ types, functions, async iterators, and the existing `SfError` where local errors
 - Broad Apex type discovery through requests that omit `namespace` and/or `name`.
 - Dynamic Apex class lookup and discovery through the same request, response, materialization, and streaming APIs as
   the other categories.
-- Explicit `format` pass-through, with strong typing for the documented `TYPE_STUB` format.
+- A single strongly typed `TYPE_STUB` response contract; `format` is not part of the public request.
 - Internal selection of the server's maximum REST API version without exposing a caller override or mutating the
   shared `Connection`.
 - Bounded buffering, timeout, cancellation, backpressure, and true response streaming.
 - Incremental consumption of `TYPE_STUB` responses.
-- Raw streaming for undocumented or future result formats.
+- Raw streaming of the `TYPE_STUB` response for low-memory incremental consumption.
 - Endpoint-owned enforcement of the cross-session single-in-flight-request limit.
 - Exactly one HTTP attempt for each transport-eligible symbols API invocation, with no client-side retry, queueing,
   coalescing, or preflight concurrency check.
@@ -81,10 +82,9 @@ Live probes were run on 2026-08-25.
 - A valid miss is HTTP 200 with `{ "typeStubs": [] }`.
 - A returned stub can contain `compileError`. This means the type was identified but a usable symbol projection was
   not produced. It is not equivalent to a miss.
-- `format=TYPE_STUB` and an omitted `format` produced identical responses. An invalid format was silently ignored by
-  the v264 endpoint. Core must therefore pass formats through rather than claim the server validates them.
-- `TYPE_STUB` is the only result format described by the available documentation. Other formats must remain raw and
-  `unknown` until their contracts are supplied.
+- `format=TYPE_STUB`, an omitted `format`, and an invalid format produced the same response on the v264 endpoint.
+  `TYPE_STUB` is the only shape returned by the current endpoint, so Core omits the parameter and exposes that shape
+  directly. A future server capability with a different response shape requires an intentional API revision.
 - The live `ApexTypeStub` includes top-level `typeParameters`; this field is absent from `symbols.md` and must be
   represented in the raw contract.
 - Endpoint availability is a core-train capability, not a REST-version capability. A non-v264 org advertising v67.0
@@ -208,14 +208,11 @@ Add `src/org/apexSymbols.ts` containing no classes:
 export const apexSymbolCategories = ['BUILTIN', 'DATABASE', 'DYNAMIC'] as const;
 export type ApexSymbolCategory = (typeof apexSymbolCategories)[number];
 
-export type ApexSymbolsRequest<F extends string = string> = {
+export type ApexSymbolsRequest = {
   readonly category: ApexSymbolCategory;
-  readonly format?: F;
   readonly namespace?: string;
   readonly name?: string;
 };
-
-export type ApexTypeStubSymbolsRequest = ApexSymbolsRequest<'TYPE_STUB'>;
 ```
 
 `undefined` omits an optional query parameter. Do not trim, split, case-fold, or reinterpret `namespace` or `name` in
@@ -225,27 +222,27 @@ The API is intentionally Apex-specific. Representative request shapes are:
 
 ```ts
 // Standard Apex class.
-{ category: 'BUILTIN', namespace: 'System', name: 'String', format: 'TYPE_STUB' }
+{ category: 'BUILTIN', namespace: 'System', name: 'String' }
 
 // An org-defined Apex class in the org's default namespace.
-{ category: 'DATABASE', name: 'MyClass', format: 'TYPE_STUB' }
+{ category: 'DATABASE', name: 'MyClass' }
 
 // An installed-package Apex class.
-{ category: 'DATABASE', namespace: 'MyPackage', name: 'MyClass', format: 'TYPE_STUB' }
+{ category: 'DATABASE', namespace: 'MyPackage', name: 'MyClass' }
 
 // An exact dynamic Apex class lookup.
-{ category: 'DYNAMIC', name: 'MyDynamicClass', format: 'TYPE_STUB' }
+{ category: 'DYNAMIC', name: 'MyDynamicClass' }
 
 // Broad discovery of org-defined and installed-package Apex types.
-{ category: 'DATABASE', format: 'TYPE_STUB' }
+{ category: 'DATABASE' }
 
 // Broad discovery of dynamic Apex types.
-{ category: 'DYNAMIC', format: 'TYPE_STUB' }
+{ category: 'DYNAMIC' }
 ```
 
 The response describes Apex symbols, signatures, type relationships, and available documentation. It does not imply
-that Apex source is available. `DYNAMIC` uses the same typed `TYPE_STUB` envelope and raw-format escape hatch; it does
-not require a separate method or response model.
+that Apex source is available. `DYNAMIC` uses the same typed `TYPE_STUB` envelope and streaming representation; it
+does not require a separate method or response model.
 
 ### Request controls
 
@@ -311,14 +308,9 @@ Add overloads to the existing `Connection`:
 
 ```ts
 public retrieveApexSymbols(
-  request: ApexTypeStubSymbolsRequest,
-  controls?: ApexSymbolsMaterializedControls
-): Promise<ApexTypeStubResponse>;
-
-public retrieveApexSymbols(
   request: ApexSymbolsRequest,
   controls?: ApexSymbolsMaterializedControls
-): Promise<unknown>;
+): Promise<ApexTypeStubResponse>;
 
 public retrieveApexSymbols(
   request: ApexSymbolsRequest,
@@ -328,16 +320,15 @@ public retrieveApexSymbols(
 public retrieveApexSymbols(
   request: ApexSymbolsRequest,
   controls: ApexSymbolsRequestControls
-): Promise<unknown>;
+): Promise<ApexTypeStubResponse | ApexSymbolsStreamResponse>;
 ```
 
-- An omitted format and the literal `TYPE_STUB` select the known typed response.
-- An undocumented format is allowed but returns `unknown`.
+- `TYPE_STUB` is implicit and is the sole response contract. The request does not expose `format`.
 - `mode: 'materialized'` and omitted controls return the bounded materialized response; `mode: 'stream'` returns the
   raw streaming response. The overloads must preserve that return-type distinction.
 - The union overload supports callers whose control value is itself typed as `ApexSymbolsRequestControls`. Callers
   passing a literal or narrowed union member resolve through the earlier precise overload; an unnarrowed union
-  returns `unknown` because the materialized unknown-format result is itself `unknown`.
+  returns `ApexTypeStubResponse | ApexSymbolsStreamResponse`.
 - Materialization must be built on the bounded streaming path, not `Connection.request()`.
 - Abort and throw an existing `SfError` with a stable name when the decompressed-byte limit is crossed.
 - Do not silently truncate or return partial JSON.
@@ -359,7 +350,8 @@ export type ApexSymbolsStreamResponse = {
 
 - `ApexSymbolsStreamResponse` is returned by `retrieveApexSymbols(..., { mode: 'stream' })`; do not add a separate
   `streamApexSymbols()` method.
-- This is the full-format escape hatch. Core does not need a schema to stream a future format.
+- The stream contains the JSON encoding of the same `TYPE_STUB` contract. It exists to support incremental,
+  low-memory consumption rather than to expose alternate response formats.
 - Apply byte limits, total timeout, idle timeout, caller abort, and backpressure while streaming.
 - Stopping iteration early must abort the HTTP request and release sockets/listeners.
 - Do not log response bodies or authorization headers.
@@ -460,8 +452,8 @@ Use the existing `SfError` rather than defining error classes. Assign stable nam
 - Represent top-level generic type parameters observed on `System.List`.
 - Export the public types and constants from `src/index.ts`.
 - Add unit tests for all categories; standard `System.String`; an unnamespaced org-defined class; a
-  namespace-qualified installed-package class; exact and broad dynamic Apex class requests; omitted filters; format
-  pass-through; URL encoding; and internal server-maximum version selection.
+  namespace-qualified installed-package class; exact and broad dynamic Apex class requests; omitted filters; URL
+  encoding; and internal server-maximum version selection.
 
 ### 2. Non-buffering transport spike and decision
 
@@ -483,7 +475,7 @@ Use the existing `SfError` rather than defining error classes. Assign stable nam
 - Abort transport work promptly on every terminal path so an abandoned stream does not unnecessarily retain the
   endpoint-owned in-flight request.
 - Bound error bodies separately so a failed HTTP response cannot become another unbounded allocation.
-- Add diagnostic summary logging: category, whether filters are present, selected format, API version, status, time to
+- Add diagnostic summary logging: category, whether filters are present, API version, status, time to
   first byte, total time, decompressed bytes, and request ID. Never log names, response bodies, or credentials by
   default.
 
@@ -500,8 +492,7 @@ Use the existing `SfError` rather than defining error classes. Assign stable nam
 
 - Implement the omitted-controls and `mode: 'materialized'` branches of `Connection.retrieveApexSymbols()` by
   consuming the bounded internal stream.
-- Return `ApexTypeStubResponse` for omitted/`TYPE_STUB` format.
-- Return `unknown` for other formats.
+- Return `ApexTypeStubResponse`; no materialized path returns `unknown`.
 - Choose and document finite defaults based on benchmarks.
 - Verify the method never changes `connection.version`.
 - Map route-level 404 to the stable v264 minimum-release availability error without misclassifying other failures.
@@ -522,7 +513,7 @@ Use the existing `SfError` rather than defining error classes. Assign stable nam
 
 ### Unit tests
 
-- Every category and `TYPE_STUB`/omitted/unknown format.
+- Every category under the implicit `TYPE_STUB` contract, and absence of a `format` query parameter.
 - Discriminated-control typing and runtime behavior: omitted controls and `mode: 'materialized'` return materialized
   values; `mode: 'stream'` returns `ApexSymbolsStreamResponse`; fields belonging to the other branch are rejected.
 - Exact standard-class lookup for `System.String`, an unnamespaced org-defined Apex class lookup, and a
@@ -586,12 +577,13 @@ recommended broad-query path.
   API version identifies the org core release.
 - Consumers can retrieve symbols for standard Apex classes, org-defined Apex classes, namespace-qualified
   installed-package Apex classes, and dynamic Apex classes through one Apex-specific API.
-- Consumers can request every Apex category, omit or provide namespace/name filters, and pass any result format.
+- Consumers can request every Apex category and omit or provide namespace/name filters without selecting a format.
 - Exact and broad `DYNAMIC` requests use the same public API and typed `TYPE_STUB` response as the other Apex
   categories, without implicit fallback, fan-out, or merging.
 - The API clearly represents returned data as Apex type stubs/symbols and never as Apex source code.
 - `TYPE_STUB` requests have complete public TypeScript wire types, including top-level generic parameters.
-- Unknown formats are exposed as raw `unknown`/byte streams rather than falsely typed.
+- Materialized requests always return `ApexTypeStubResponse`; explicit streaming returns the raw bytes for that same
+  response contract.
 - Exact requests have a convenient bounded materialized API.
 - Broad responses can be consumed incrementally with backpressure and without whole-response buffering.
 - `ApexSymbolsRequestControls` is a discriminated union with only `mode: 'materialized'` and `mode: 'stream'`; the
@@ -612,7 +604,7 @@ recommended broad-query path.
 
 ## Open contract items
 
-- Authoritative names and response schemas for result formats other than `TYPE_STUB`.
+- Whether a future endpoint version will introduce another response shape that warrants a separate API revision.
 - Whether the endpoint will add server-side pagination, cursoring, limits, or record framing.
 - Whether an empty `namespace` has distinct semantics from an omitted namespace.
 - Whether the server can expose a more specific reason than the current generic `compileError` string.

--- a/.cursor/plans/connection-symbols-endpoint.plan.md
+++ b/.cursor/plans/connection-symbols-endpoint.plan.md
@@ -1,0 +1,618 @@
+# Connection Apex Symbols Endpoint
+
+## Objective
+
+Expose the Salesforce Tooling Apex Symbols endpoint through `@salesforce/core` as an Apex-specific `Connection`
+capability. Consumers must be able to retrieve symbol data for standard Apex classes, org-defined Apex classes, and
+installed-package Apex classes, and dynamic Apex classes without constructing authenticated URLs themselves. Support
+exact, namespace-qualified class lookups as well as broad Apex type discovery across every shipping category, with
+optional filters and explicit result formats. Provide a bounded materialized API for exact and ordinary requests and
+a genuinely streaming API for broad responses.
+
+The implementation must not introduce a new class. It should adapt the existing `Connection` and use plain TypeScript
+types, functions, async iterators, and the existing `SfError` where local errors are required.
+
+## Implementation status
+
+- Complete: public Apex request and wire contracts, URL construction, and `Connection.retrieveApexSymbols()`
+  overloads.
+- Complete: direct `undici.fetch` transport with true cancellation, proxy support, total/idle timeouts, decompressed
+  byte limits, bounded error bodies, no retries, and no local concurrency behavior.
+- Complete: bounded materialization, stable endpoint/error mapping, and diagnostic summaries that omit requested names.
+- Complete: incremental `TYPE_STUB` iteration using `@streamparser/json` with bounded input chunks, response/item/count
+  limits, backpressure, envelope validation, and upstream cancellation.
+- Complete: child-process memory regression proving a 128 MiB synthetic response can be consumed under a 96 MiB V8
+  heap limit; measured peak RSS was approximately 181 MiB. The bounded materialized path failed deterministically
+  with `ApexSymbolsResponseTooLargeError`.
+- Remaining: public usage documentation, final API review, and benchmark-based confirmation of default limits.
+
+## Scope
+
+### In scope
+
+- `GET /services/data/{apiVersion}/tooling/symbols`.
+- Apex categories `BUILTIN`, `DATABASE`, and `DYNAMIC`.
+- Exact unqualified and namespace-qualified Apex class lookups through optional `namespace` and `name` filters.
+- Broad Apex type discovery through requests that omit `namespace` and/or `name`.
+- Dynamic Apex class lookup and discovery through the same request, response, materialization, and streaming APIs as
+  the other categories.
+- Explicit `format` pass-through, with strong typing for the documented `TYPE_STUB` format.
+- Internal selection of the server's maximum REST API version without exposing a caller override or mutating the
+  shared `Connection`.
+- Bounded buffering, timeout, cancellation, backpressure, and true response streaming.
+- Incremental consumption of `TYPE_STUB` responses.
+- Raw streaming for undocumented or future result formats.
+- Endpoint-owned enforcement of the cross-session single-in-flight-request limit.
+- Exactly one HTTP attempt for each transport-eligible symbols API invocation, with no client-side retry, queueing,
+  coalescing, or preflight concurrency check.
+- Public exports, documentation, unit tests, and memory tests.
+- Explicit endpoint-availability behavior for the minimum org core release, 264.
+
+### Out of scope
+
+- Effect services, Effect schemas, catalog persistence, or provider routing. Those remain in
+  `salesforcedx-vscode-services`.
+- Converting type stubs into source files or canonical language-server symbols.
+- Retrieving Apex source code or Metadata API components. This endpoint supplies Apex symbol/type-stub data, not
+  source text.
+- Inferring support from REST API version alone.
+- Reconstructing members hidden by managed-package IP filtering.
+
+## Confirmed endpoint behavior
+
+Live probes were run on 2026-08-25.
+
+- The shipping route is `/services/data/{apiVersion}/tooling/symbols`. The route in `symbols.md`,
+  `/tooling/apex/symbols`, is stale.
+- `category` is required and accepts `BUILTIN`, `DATABASE`, or `DYNAMIC`. It selects three distinct Apex class/type
+  populations:
+
+  | Category   | Apex symbols requested                                                                                           |
+  | ---------- | ---------------------------------------------------------------------------------------------------------------- |
+  | `BUILTIN`  | Standard Apex classes and related types with documentation, such as `System.String`.                             |
+  | `DATABASE` | Org-defined and installed-package Apex classes and related types.                                                |
+  | `DYNAMIC`  | Dynamic Apex classes and related types supplied by the endpoint; this category excludes installed-package types. |
+
+- On `org-farm-264-2`, an unqualified `DATABASE` request returned 889 stubs: 76 unnamespaced and 813 in namespace
+  `FSLQA`.
+- `DYNAMIC` is a first-class request category, not a fallback for `DATABASE`. Core must pass it through unchanged and
+  must not infer, merge, or fan out across categories.
+- `namespace` and `name` are optional exact filters and have behaved case-insensitively.
+- A valid miss is HTTP 200 with `{ "typeStubs": [] }`.
+- A returned stub can contain `compileError`. This means the type was identified but a usable symbol projection was
+  not produced. It is not equivalent to a miss.
+- `format=TYPE_STUB` and an omitted `format` produced identical responses. An invalid format was silently ignored by
+  the v264 endpoint. Core must therefore pass formats through rather than claim the server validates them.
+- `TYPE_STUB` is the only result format described by the available documentation. Other formats must remain raw and
+  `unknown` until their contracts are supplied.
+- The live `ApexTypeStub` includes top-level `typeParameters`; this field is absent from `symbols.md` and must be
+  represented in the raw contract.
+- Endpoint availability is a core-train capability, not a REST-version capability. A non-v264 org advertising v67.0
+  returned 404, while a v264 org served the endpoint at v67.0 and v68.0.
+- The server permits only one symbol-table request in flight at a time per org. A request submitted while another is
+  active can fail with:
+
+  ```json
+  [
+    {
+      "message": "Symbol table request already in progress for this org. Please retry later.",
+      "errorCode": "UNKNOWN_EXCEPTION"
+    }
+  ]
+  ```
+
+  The endpoint owns this cross-session constraint. Core must send the invocation once, then surface this response
+  without retrying, queueing, or coalescing it with another request.
+
+### Response transport observations
+
+An exact request returned these relevant headers:
+
+```text
+content-type: application/json;charset=UTF-8
+transfer-encoding: chunked
+content-encoding: gzip
+connection: close
+```
+
+There was no `content-length`. Chunked HTTP transfer makes incremental byte consumption possible, but it does not
+prove that the server emits individual stubs promptly. The JSON response is one envelope containing one array; there
+is no documented cursor, `nextRecordsUrl`, limit, or record framing.
+
+## Availability and minimum org release
+
+The endpoint is available only on org core release 264 or later. This is a requirement on the org's core train, not
+an equivalence with a REST API number.
+
+`Connection` currently exposes `retrieveMaxApiVersion()` but no authoritative org core-release number. Therefore:
+
+- Do not map v67.0, v68.0, or any other REST version to org release 264.
+- Do not add a numeric REST-version precheck or a public capability Boolean inferred from REST version.
+- Always resolve the endpoint request against the server's maximum REST API version so a project-pinned older
+  `connection.version` does not create a false negative. This choice is internal; do not expose an API-version request
+  control.
+- Use the first real symbols request as the feature check; do not issue a separate probe that can duplicate work or
+  acquire the org-level symbol-generation lock.
+- Convert a route-level 404 into a stable `ApexSymbolsEndpointUnavailableError` whose structured data includes
+  `minimumOrgRelease: 264`, the internally selected REST API version, and the original cause. The message must explain
+  that the org may be older than release 264 or that the endpoint is unavailable at the server's maximum REST
+  version.
+- Scope an unavailable observation to the internally selected REST API version. Do not cache one 404 as proof that
+  every REST version on the org is unsupported.
+- A schema-valid HTTP 200, including `{ "typeStubs": [] }`, proves endpoint availability for that internally selected
+  version.
+- Authentication, authorization, timeout, malformed response, and server-busy failures are not evidence that the
+  endpoint is unsupported.
+
+## Endpoint-owned concurrency
+
+The one-in-flight limit is enforced across sessions by the Salesforce endpoint. Core must not attempt to reproduce
+that coordination in a process-local registry or lock:
+
+- Every valid invocation that is not already aborted dispatches exactly one HTTP request, including overlapping
+  invocations for the same org from the same process or `Connection` instance.
+- Do not add a mutex, semaphore, in-flight registry, promise chain, or org-ID admission check.
+- Do not provide a wait option, queue, priority, timeout-to-acquire, coalescing mode, or retry control.
+- When requests overlap, the endpoint decides which request proceeds. Core surfaces the result of each invocation.
+- Detect the documented `UNKNOWN_EXCEPTION` error code and message together and map that response to a stable
+  `ApexSymbolsRequestInProgressError`, while preserving the original server error as the cause and structured data.
+- Do not retry the in-progress response. A later explicit caller invocation is a new request, not continuation of a
+  queued request.
+
+For raw streaming, an invocation remains active at the endpoint until its response body completes or transport work
+is aborted. `cancel()`, early iterator return, timeouts, size failures, and parse failures must abort and clean up the
+HTTP request promptly, but Core does not track or allocate an org-level slot.
+
+## Critical Jsforce constraint
+
+Do not implement the streaming API by returning `Connection.request(...).stream()`.
+
+In the current `@jsforce/jsforce-node` dependency, `Transport.httpRequest()` always installs a `complete` listener.
+`createHttpRequestHandlerStreams()` reacts to that listener by calling `readAll()` into a `MemoryWriteStream`.
+Consequently, the promise side buffers the entire response even when a consumer reads the exposed stream. Merely
+surfacing `StreamPromise.stream()` would retain the OOM risk.
+
+The transport spike established that Jsforce's low-level request function emits chunks without buffering when no
+`complete` listener is attached. It is still insufficient: destroying the exposed duplex does not propagate to the
+underlying Undici fetch controller, and a controlled test showed that the server request remained active. That would
+leave the endpoint's cross-session in-flight request occupied after consumer cancellation.
+
+The selected implementation is a narrowly scoped functional transport in Core using `undici.fetch` directly:
+
+- Add `undici` as a direct dependency rather than relying on Jsforce's transitive installation.
+- Use the patched Undici 8.x line. Core's declared Node runtime floor is intentionally raised from Node 22.0 to Node
+  22.19 to satisfy Undici's engine requirement. The initial audited resolution is Undici 8.10.0. Jsforce's separate
+  transitive Undici remains outside this call path and outside the scope of this change.
+- Define no transport class. Isolate fetch, proxy-agent creation, abort handling, decompressed-byte counting, and
+  cleanup in `src/org/apexSymbolsTransport.ts`.
+- Supply the current Connection access token, Sforce call options, SFDX headers, explicit `httpProxy`, and standard
+  proxy environment behavior.
+- Use an owned `AbortController` so caller abort, `cancel()`, early iterator return, total timeout, idle timeout, and
+  size failures terminate the underlying request and release the socket.
+- Use plain `fetch`, which has no automatic HTTP retry. Do not use Undici retry interceptors or agents.
+- Do not implement auth refresh-and-replay. Surface HTTP 401 from the single request.
+- Keep response status, headers, and raw body available to the endpoint adapter, with bounded error-body handling.
+
+Controlled local tests must continue proving early chunk delivery, server-observed cancellation, one request for HTTP
+420, incremental decompressed-byte limits, idle timeout, and pre-abort before dispatch.
+
+## Proposed public API
+
+Names are proposed and should receive API review before implementation.
+
+### Data-only request types
+
+Add `src/org/apexSymbols.ts` containing no classes:
+
+```ts
+export const apexSymbolCategories = ['BUILTIN', 'DATABASE', 'DYNAMIC'] as const;
+export type ApexSymbolCategory = (typeof apexSymbolCategories)[number];
+
+export type ApexSymbolsRequest<F extends string = string> = {
+  readonly category: ApexSymbolCategory;
+  readonly format?: F;
+  readonly namespace?: string;
+  readonly name?: string;
+};
+
+export type ApexTypeStubSymbolsRequest = ApexSymbolsRequest<'TYPE_STUB'>;
+```
+
+`undefined` omits an optional query parameter. Do not trim, split, case-fold, or reinterpret `namespace` or `name` in
+Core. URL construction must use `URL`/`URLSearchParams` so reserved characters are encoded correctly.
+
+The API is intentionally Apex-specific. Representative request shapes are:
+
+```ts
+// Standard Apex class.
+{ category: 'BUILTIN', namespace: 'System', name: 'String', format: 'TYPE_STUB' }
+
+// An org-defined Apex class in the org's default namespace.
+{ category: 'DATABASE', name: 'MyClass', format: 'TYPE_STUB' }
+
+// An installed-package Apex class.
+{ category: 'DATABASE', namespace: 'MyPackage', name: 'MyClass', format: 'TYPE_STUB' }
+
+// An exact dynamic Apex class lookup.
+{ category: 'DYNAMIC', name: 'MyDynamicClass', format: 'TYPE_STUB' }
+
+// Broad discovery of org-defined and installed-package Apex types.
+{ category: 'DATABASE', format: 'TYPE_STUB' }
+
+// Broad discovery of dynamic Apex types.
+{ category: 'DYNAMIC', format: 'TYPE_STUB' }
+```
+
+The response describes Apex symbols, signatures, type relationships, and available documentation. It does not imply
+that Apex source is available. `DYNAMIC` uses the same typed `TYPE_STUB` envelope and raw-format escape hatch; it does
+not require a separate method or response model.
+
+### Request controls
+
+```ts
+export type ApexSymbolsTransportControls = {
+  /** Total time allowed, including time to first byte. */
+  readonly timeoutMs?: number;
+  /** Maximum idle time between response chunks. */
+  readonly idleTimeoutMs?: number;
+  /** Maximum decompressed response bytes. */
+  readonly maxResponseBytes?: number;
+  readonly signal?: AbortSignal;
+};
+
+export type ApexSymbolsMaterializedControls = ApexSymbolsTransportControls & {
+  readonly mode: 'materialized';
+  /** Maximum number of type stubs materialized for TYPE_STUB responses. */
+  readonly maxTypeStubs?: number;
+  /** Maximum serialized size of one decompressed type stub. */
+  readonly maxStubBytes?: number;
+};
+
+export type ApexSymbolsStreamControls = ApexSymbolsTransportControls & {
+  readonly mode: 'stream';
+};
+
+export type ApexSymbolsRequestControls = ApexSymbolsMaterializedControls | ApexSymbolsStreamControls;
+
+export type ApexTypeStubIterationOptions = {
+  /** Maximum decompressed bytes accepted from a generic input iterator. */
+  readonly maxResponseBytes?: number;
+  /** Maximum number of stubs emitted or materialized. */
+  readonly maxTypeStubs?: number;
+  /** Maximum serialized size of one decompressed stub. */
+  readonly maxStubBytes?: number;
+  readonly signal?: AbortSignal;
+};
+```
+
+- `mode` is the required discriminator whenever controls are supplied.
+- Omitting controls is shorthand for bounded materialization with documented defaults; it does not create a third
+  union member with an optional discriminator.
+- `maxTypeStubs` and `maxStubBytes` are valid only for `mode: 'materialized'`. Raw streaming applies transport byte
+  limits; callers parsing a raw stream pass item limits separately to `iterateApexTypeStubs()`.
+- Do not accept objects that mix fields from both union members or silently infer a mode from the fields present.
+
+- Resolve the internal route version with `await connection.retrieveMaxApiVersion()`.
+- Do not accept an API version in `ApexSymbolsRequest`, `ApexSymbolsRequestControls`, method overloads, or another
+  public request option.
+- Build the URL with the internally resolved version without calling `setApiVersion()` or `useLatestApiVersion()`.
+- Initial defaults are a 30-minute total timeout, 60-second idle timeout, 512 MiB raw-stream response limit, and 64
+  MiB materialized response limit. Confirm or revise them with the benchmark task before API review.
+- Initial materialization defaults are 10,000 type stubs and 8 MiB per type stub. Confirm or revise them with the
+  benchmark task before API review.
+- Do not add retry, wait, queue, coalescing, or local admission controls.
+- Count decompressed bytes because those determine parser and heap pressure. Reject early from `content-length` only
+  for an unencoded response; compressed length does not describe decompressed heap pressure. Always enforce the
+  incremental decompressed limit because length may be absent, misleading, or compressed.
+
+### Bounded materialization
+
+Add overloads to the existing `Connection`:
+
+```ts
+public retrieveApexSymbols(
+  request: ApexTypeStubSymbolsRequest,
+  controls?: ApexSymbolsMaterializedControls
+): Promise<ApexTypeStubResponse>;
+
+public retrieveApexSymbols(
+  request: ApexSymbolsRequest,
+  controls?: ApexSymbolsMaterializedControls
+): Promise<unknown>;
+
+public retrieveApexSymbols(
+  request: ApexSymbolsRequest,
+  controls: ApexSymbolsStreamControls
+): Promise<ApexSymbolsStreamResponse>;
+
+public retrieveApexSymbols(
+  request: ApexSymbolsRequest,
+  controls: ApexSymbolsRequestControls
+): Promise<unknown>;
+```
+
+- An omitted format and the literal `TYPE_STUB` select the known typed response.
+- An undocumented format is allowed but returns `unknown`.
+- `mode: 'materialized'` and omitted controls return the bounded materialized response; `mode: 'stream'` returns the
+  raw streaming response. The overloads must preserve that return-type distinction.
+- The union overload supports callers whose control value is itself typed as `ApexSymbolsRequestControls`. Callers
+  passing a literal or narrowed union member resolve through the earlier precise overload; an unnarrowed union
+  returns `unknown` because the materialized unknown-format result is itself `unknown`.
+- Materialization must be built on the bounded streaming path, not `Connection.request()`.
+- Abort and throw an existing `SfError` with a stable name when the decompressed-byte limit is crossed.
+- Do not silently truncate or return partial JSON.
+- Preserve all server fields, including unknown additive fields. Runtime schema normalization belongs to consumers.
+
+### Raw streaming
+
+Expose a plain-object response rather than a new response class:
+
+```ts
+export type ApexSymbolsStreamResponse = {
+  readonly apiVersion: string;
+  readonly statusCode: number;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: AsyncIterable<Uint8Array>;
+  readonly cancel: (reason?: unknown) => void;
+};
+```
+
+- `ApexSymbolsStreamResponse` is returned by `retrieveApexSymbols(..., { mode: 'stream' })`; do not add a separate
+  `streamApexSymbols()` method.
+- This is the full-format escape hatch. Core does not need a schema to stream a future format.
+- Apply byte limits, total timeout, idle timeout, caller abort, and backpressure while streaming.
+- Stopping iteration early must abort the HTTP request and release sockets/listeners.
+- Do not log response bodies or authorization headers.
+- Expose request ID and Salesforce limit headers through `headers` for diagnostics.
+
+### Incremental `TYPE_STUB` consumption
+
+Export a functional async generator for consumers that need broad typed results without accumulating the envelope:
+
+```ts
+export const iterateApexTypeStubs = (
+  body: AsyncIterable<Uint8Array>,
+  options?: ApexTypeStubIterationOptions
+): AsyncIterable<ApexTypeStub> => ...;
+```
+
+- Parse and emit elements of the top-level `typeStubs` array one at a time.
+- Use a maintained streaming JSON parser after dependency and bundle review. Do not implement JSON tokenization with
+  regular expressions or an ad hoc parser.
+- Respect backpressure: do not parse the next stub until the consumer requests it.
+- Bound total decompressed bytes and the maximum serialized size of one stub.
+- Reject malformed envelopes, unexpected top-level shapes, truncated JSON, and trailing non-whitespace content.
+- Preserve `compileError` stubs as values. Parsing must not filter them.
+- Keep runtime canonicalization and Effect validation outside Core.
+
+The selected parser is `@streamparser/json`. It is dependency-free, dual CommonJS/ESM, includes TypeScript
+declarations, supports Node and browser runtimes, and is MIT licensed. The iterator uses its `$.typeStubs.*` path
+filter with `keepStack: false`, so completed siblings are not retained. Core feeds bounded subchunks into the
+synchronous parser and drains emitted values before reading more input, preserving source-level backpressure without
+introducing a parser or response class.
+
+`retrieveApexSymbols()` for `TYPE_STUB` may collect this iterator after enforcing the materialization limit. Broad
+consumers should use `retrieveApexSymbols(..., { mode: 'stream' })` plus `iterateApexTypeStubs()` or a convenience
+iterator added after API review.
+
+## Raw `TYPE_STUB` contracts
+
+Define readonly TypeScript types for:
+
+- `ApexTypeStubResponse`
+- `ApexTypeStub`, including recursive `innerTypes` and top-level `typeParameters`
+- `ApexMethodStub`
+- `ApexFieldStub`
+- `ApexPropertyStub`
+- `ApexAccessorStub`
+- `ApexParameterStub`
+- `ApexAnnotationStub`
+- `ApexAnnotationParameterStub`
+- recursive `ApexTypeReference`
+- `ApexTypeKind`
+
+Model observed nullable and omitted fields honestly. Do not normalize missing arrays to empty arrays in Core. The
+wire contract should be permissive of additive server fields at runtime even though the exported TypeScript types
+describe known fields.
+
+## Errors and retry behavior
+
+### Preserve server outcomes
+
+- HTTP 200 plus an empty array is a miss.
+- HTTP 200 plus a stub with `compileError` is a found but incomplete stub.
+- HTTP 404 becomes `ApexSymbolsEndpointUnavailableError` for the internally selected server-maximum REST version,
+  with the documented minimum org release of 264. Do not infer availability solely from REST API version.
+- HTTP 403 `INVALID_INPUT` is a request-contract failure.
+- Authentication, authorization, network, and malformed-response failures remain operational failures.
+
+### Local bounded-stream errors
+
+Use the existing `SfError` rather than defining error classes. Assign stable names and structured data for at least:
+
+- `ApexSymbolsResponseTooLargeError`
+- `ApexSymbolsRequestTimeoutError`
+- `ApexSymbolsRequestAbortedError`
+- `ApexSymbolsIdleTimeoutError`
+- `ApexSymbolsMalformedResponseError`
+- `ApexSymbolsEndpointUnavailableError`
+- `ApexSymbolsRequestInProgressError`
+- `ApexSymbolsRequestError`
+- `ApexSymbolsInvalidControlError`
+
+### One-attempt failure behavior
+
+- Each valid, non-pre-aborted invocation makes exactly one HTTP attempt. Core does not suppress a call because another
+  request appears to be active locally; the endpoint owns that decision across sessions.
+- Disable transport retries for this call path, including retries for network errors, timeouts, HTTP 401, 420/429,
+  5xx responses, and the documented org-level in-progress response.
+- Do not refresh authentication and replay a failed symbols request. A 401 is surfaced as the outcome of that attempt.
+- A later explicit invocation by the caller is a new request. Core never schedules one as a continuation of a failed
+  invocation.
+- Preserve the original server error as the cause of any stable Core error mapping.
+
+## Implementation sequence
+
+### 1. Contract and query construction
+
+- Add the Apex category, request, response, and stub types in `src/org/apexSymbols.ts`.
+- Add a pure URL builder that accepts instance URL, numeric API version, and request fields.
+- Represent top-level generic type parameters observed on `System.List`.
+- Export the public types and constants from `src/index.ts`.
+- Add unit tests for all categories; standard `System.String`; an unnamespaced org-defined class; a
+  namespace-qualified installed-package class; exact and broad dynamic Apex class requests; omitted filters; format
+  pass-through; URL encoding; and internal server-maximum version selection.
+
+### 2. Non-buffering transport spike and decision
+
+- Record the Jsforce `complete` listener and `MemoryWriteStream` buffering path as the reason not to use
+  `Connection.request().stream()`.
+- Record the controlled finding that Jsforce's raw stream emits early bytes but does not propagate destruction to the
+  underlying request.
+- Use the selected Core-owned functional `undici.fetch` transport and direct dependency.
+- Verify proxy behavior, gzip decoding, chunked transfer, server-observed abort, bounded error handling, and that no
+  transport retry or auth-refresh replay exists on this call path.
+- Do not proceed to API review until the memory regression proves heap usage does not scale with streamed response
+  size.
+
+### 3. Bounded raw stream
+
+- Implement the `mode: 'stream'` branch of `Connection.retrieveApexSymbols()` on the chosen transport, without a
+  local concurrency registry or lock.
+- Add total and idle timers, `AbortSignal` composition, decompressed-byte counting, and deterministic cleanup.
+- Abort transport work promptly on every terminal path so an abandoned stream does not unnecessarily retain the
+  endpoint-owned in-flight request.
+- Bound error bodies separately so a failed HTTP response cannot become another unbounded allocation.
+- Add diagnostic summary logging: category, whether filters are present, selected format, API version, status, time to
+  first byte, total time, decompressed bytes, and request ID. Never log names, response bodies, or credentials by
+  default.
+
+### 4. Incremental `TYPE_STUB` parser
+
+- Evaluate a maintained streaming JSON parser for Node 22, TypeScript declarations, browser/bundle impact, license,
+  security posture, and backpressure behavior. The normal minimum-module-age rule is explicitly waived for this
+  effort, but maintenance and security review still apply.
+- Implement `iterateApexTypeStubs()` as an async generator.
+- Add per-item and total limits and malformed/truncated input handling.
+- Verify that consumer cancellation aborts parsing and the upstream HTTP request.
+
+### 5. Bounded materialized convenience API
+
+- Implement the omitted-controls and `mode: 'materialized'` branches of `Connection.retrieveApexSymbols()` by
+  consuming the bounded internal stream.
+- Return `ApexTypeStubResponse` for omitted/`TYPE_STUB` format.
+- Return `unknown` for other formats.
+- Choose and document finite defaults based on benchmarks.
+- Verify the method never changes `connection.version`.
+- Map route-level 404 to the stable v264 minimum-release availability error without misclassifying other failures.
+
+### 6. Documentation and consumer handoff
+
+- Add public API examples for exact `BUILTIN`, exact unnamespaced `DATABASE`, exact namespace-qualified `DATABASE`,
+  exact `DYNAMIC`, broad `DATABASE`, broad `DYNAMIC`, cancellation, and size-limit failures.
+- Show both discriminated control modes and document that omitted controls mean bounded materialization.
+- Document `DYNAMIC` as the category for dynamic Apex classes, distinct from `DATABASE`, and make clear that Core
+  does not perform cross-category fallback or merge results.
+- Document that broad `DATABASE` requests can be expensive and can serialize with other symbol generation in the org.
+- Document the difference between miss and `compileError`.
+- Update the Apex stub fetcher to use Core only in a separate consumer change after the Core API is released.
+- Update Services SVC-11/SVC-12 to consume Core rather than construct the endpoint URL directly.
+
+## Test plan
+
+### Unit tests
+
+- Every category and `TYPE_STUB`/omitted/unknown format.
+- Discriminated-control typing and runtime behavior: omitted controls and `mode: 'materialized'` return materialized
+  values; `mode: 'stream'` returns `ApexSymbolsStreamResponse`; fields belonging to the other branch are rejected.
+- Exact standard-class lookup for `System.String`, an unnamespaced org-defined Apex class lookup, and a
+  namespace-qualified installed-package Apex class lookup. Assert that Core preserves the requested namespace and
+  class name and maps the returned type stubs without treating them as source.
+- Exact dynamic Apex class hit and miss, plus a broad `DYNAMIC` response containing multiple type stubs. Assert that
+  Core sends `category=DYNAMIC`, preserves optional namespace/name filters, uses the same response contract, and does
+  not issue an implicit `DATABASE` or `BUILTIN` request.
+- Internal server-maximum API-version resolution; the shared connection version remains unchanged and there is no
+  caller version override.
+- A pre-v264 org advertising the same maximum REST version as a v264 org: route 404 is unavailable and route 200 is
+  available. This test must prove there is no REST-version-only gate.
+- A connection configured below the endpoint's route version that succeeds through the internally selected server
+  maximum.
+- Exact miss, one stub, multiple stubs, recursive inner types, recursive generics, triggers, and compile errors.
+- One-byte and irregular chunk boundaries across every JSON token type.
+- Gzip-decoded input where the decompressed limit is larger than the compressed input.
+- No `content-length`, misleading `content-length`, and early length rejection when available.
+- Total timeout before headers, idle timeout mid-body, caller abort, and consumer early return.
+- Backpressure with a deliberately slow consumer.
+- Oversized total response and oversized single stub.
+- Malformed envelope, truncated array, invalid JSON, and bounded HTTP error bodies.
+- Concurrent and identical calls through the same `Connection`, and through separate connections for the same org,
+  each dispatch once; Core does not serialize, reject locally, or coalesce them.
+- The documented server `UNKNOWN_EXCEPTION` body maps to `ApexSymbolsRequestInProgressError` and preserves the cause.
+- Streaming completion, early return, cancellation, timeout, size failure, and transport failure all clean up the
+  underlying request promptly.
+- Network failure, timeout, HTTP 401, 420/429, 5xx, and server-busy cases each invoke the transport exactly once.
+- Listener/socket cleanup on success, failure, timeout, size limit, and cancellation.
+
+### Memory regression test
+
+- Generate a synthetic chunked `TYPE_STUB` response substantially larger than the test process heap budget.
+- Run the iterator in a child process with a deliberately small `--max-old-space-size`.
+- Consume one stub at a time without retaining them and assert completion plus bounded peak RSS.
+- Run the bounded materialized API against the same stream and assert a deterministic
+  `ApexSymbolsResponseTooLargeError`, not process OOM.
+- Include a single oversized stub to prove the per-item limit works.
+
+## Benchmark and defaults decision
+
+These are development-time measurements, not committed live-org tests. Use manually captured measurements and
+representative mocked or synthetic responses when selecting public defaults. Measure at least:
+
+- Exact small `DATABASE` hit and miss.
+- Exact small `DYNAMIC` hit and miss.
+- Exact large `BUILTIN` such as `System.String`.
+- Broad `DATABASE` with hundreds of types.
+- Broad `DYNAMIC` with representative mocked or captured payloads.
+- Broad `BUILTIN` where permitted.
+- Slow time-to-first-byte and slow-body simulations.
+
+Choose finite defaults that allow normal exact requests and provide clear guidance for broad streaming. Record the
+measurements and rationale in the PR. Raising a materialization limit must be explicit; streaming must remain the
+recommended broad-query path.
+
+## Acceptance criteria
+
+- No new classes are introduced.
+- The endpoint is documented and enforced as requiring org core release 264 or later without pretending that a REST
+  API version identifies the org core release.
+- Consumers can retrieve symbols for standard Apex classes, org-defined Apex classes, namespace-qualified
+  installed-package Apex classes, and dynamic Apex classes through one Apex-specific API.
+- Consumers can request every Apex category, omit or provide namespace/name filters, and pass any result format.
+- Exact and broad `DYNAMIC` requests use the same public API and typed `TYPE_STUB` response as the other Apex
+  categories, without implicit fallback, fan-out, or merging.
+- The API clearly represents returned data as Apex type stubs/symbols and never as Apex source code.
+- `TYPE_STUB` requests have complete public TypeScript wire types, including top-level generic parameters.
+- Unknown formats are exposed as raw `unknown`/byte streams rather than falsely typed.
+- Exact requests have a convenient bounded materialized API.
+- Broad responses can be consumed incrementally with backpressure and without whole-response buffering.
+- `ApexSymbolsRequestControls` is a discriminated union with only `mode: 'materialized'` and `mode: 'stream'`; the
+  selected mode determines the return type and valid limits through the single `retrieveApexSymbols()` entry point.
+- Finite byte, item, total-time, idle-time, and per-item protections fail deterministically before OOM.
+- Cancellation aborts network work and releases resources.
+- Concurrent invocations each dispatch exactly once; Core performs no local admission, serialization, queueing, or
+  coalescing.
+- Every valid, non-pre-aborted invocation makes one HTTP attempt; Core performs no retry or auth-refresh replay for
+  any failure.
+- The documented server-side in-progress error is surfaced as a stable error without retry.
+- Proxy behavior, Salesforce headers, and diagnostics are preserved.
+- The implementation never mutates the configured API version on the shared `Connection`.
+- The public request and controls types contain no API-version selector; Core resolves the server maximum internally.
+- Availability is established from the actual request result, not REST API version alone.
+- Tests prove that heap usage does not grow with total streamed response size.
+- Existing `Connection.request()` behavior and existing consumers remain unchanged.
+
+## Open contract items
+
+- Authoritative names and response schemas for result formats other than `TYPE_STUB`.
+- Whether the endpoint will add server-side pagination, cursoring, limits, or record framing.
+- Whether an empty `namespace` has distinct semantics from an omitted namespace.
+- Whether the server can expose a more specific reason than the current generic `compileError` string.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.19.0"
   },
   "exports": {
     ".": "./lib/index.js",
@@ -65,6 +65,7 @@
     "@jsforce/jsforce-node": "^3.10.22",
     "@salesforce/kit": "^4.0.0",
     "@salesforce/ts-types": "^3.0.0",
+    "@streamparser/json": "^0.0.26",
     "ajv": "^8.18.0",
     "change-case": "^4.1.2",
     "fast-levenshtein": "^3.0.0",
@@ -80,6 +81,7 @@
     "proper-lockfile": "^4.1.2",
     "semver": "^7.8.0",
     "ts-retry-promise": "^0.8.1",
+    "undici": "^8.9.0",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,6 @@ export {
   ApexTypeStub,
   ApexTypeStubIterationOptions,
   ApexTypeStubResponse,
-  ApexTypeStubSymbolsRequest,
 } from './org/apexSymbols';
 
 export { iterateApexTypeStubs } from './org/apexTypeStubIterator';

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,35 @@ export { AuthFields, AuthInfo, AuthSideEffects, OrgAuthorization } from './org/a
 
 export { AuthRemover } from './org/authRemover';
 
+export {
+  apexSymbolCategories,
+  apexTypeKinds,
+  ApexAccessorStub,
+  ApexAnnotationParameterStub,
+  ApexAnnotationStub,
+  ApexCompileErrorTypeStub,
+  ApexFieldStub,
+  ApexMethodStub,
+  ApexParameterStub,
+  ApexPropertyStub,
+  ApexResolvedTypeStub,
+  ApexSymbolCategory,
+  ApexSymbolsMaterializedControls,
+  ApexSymbolsRequest,
+  ApexSymbolsRequestControls,
+  ApexSymbolsStreamControls,
+  ApexSymbolsStreamResponse,
+  ApexSymbolsTransportControls,
+  ApexTypeKind,
+  ApexTypeReference,
+  ApexTypeStub,
+  ApexTypeStubIterationOptions,
+  ApexTypeStubResponse,
+  ApexTypeStubSymbolsRequest,
+} from './org/apexSymbols';
+
+export { iterateApexTypeStubs } from './org/apexTypeStubIterator';
+
 export { Connection, SFDX_HTTP_HEADERS } from './org/connection';
 
 export { Mode, Global } from './global';

--- a/src/org/apexSymbols.ts
+++ b/src/org/apexSymbols.ts
@@ -20,14 +20,11 @@ export type ApexSymbolCategory = (typeof apexSymbolCategories)[number];
 export const apexTypeKinds = ['CLASS', 'INTERFACE', 'ENUM', 'TRIGGER'] as const;
 export type ApexTypeKind = (typeof apexTypeKinds)[number];
 
-export type ApexSymbolsRequest<F extends string = string> = {
+export type ApexSymbolsRequest = {
   readonly category: ApexSymbolCategory;
-  readonly format?: F;
   readonly namespace?: string;
   readonly name?: string;
 };
-
-export type ApexTypeStubSymbolsRequest = ApexSymbolsRequest<'TYPE_STUB'>;
 
 export type ApexSymbolsTransportControls = {
   readonly timeoutMs?: number;
@@ -171,9 +168,6 @@ export const buildApexSymbolsUrl = (instanceUrl: string, apiVersion: string, req
   const url = new URL(`/services/data/v${apiVersion}/tooling/symbols`, instanceUrl);
   url.searchParams.set('category', request.category);
 
-  if (request.format !== undefined) {
-    url.searchParams.set('format', request.format);
-  }
   if (request.namespace !== undefined) {
     url.searchParams.set('namespace', request.namespace);
   }

--- a/src/org/apexSymbols.ts
+++ b/src/org/apexSymbols.ts
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const apexSymbolCategories = ['BUILTIN', 'DATABASE', 'DYNAMIC'] as const;
+export type ApexSymbolCategory = (typeof apexSymbolCategories)[number];
+
+export const apexTypeKinds = ['CLASS', 'INTERFACE', 'ENUM', 'TRIGGER'] as const;
+export type ApexTypeKind = (typeof apexTypeKinds)[number];
+
+export type ApexSymbolsRequest<F extends string = string> = {
+  readonly category: ApexSymbolCategory;
+  readonly format?: F;
+  readonly namespace?: string;
+  readonly name?: string;
+};
+
+export type ApexTypeStubSymbolsRequest = ApexSymbolsRequest<'TYPE_STUB'>;
+
+export type ApexSymbolsTransportControls = {
+  readonly timeoutMs?: number;
+  readonly idleTimeoutMs?: number;
+  readonly maxResponseBytes?: number;
+  readonly signal?: AbortSignal;
+};
+
+export type ApexSymbolsMaterializedControls = ApexSymbolsTransportControls & {
+  readonly mode: 'materialized';
+  readonly maxTypeStubs?: number;
+  readonly maxStubBytes?: number;
+};
+
+export type ApexSymbolsStreamControls = ApexSymbolsTransportControls & {
+  readonly mode: 'stream';
+};
+
+export type ApexSymbolsRequestControls = ApexSymbolsMaterializedControls | ApexSymbolsStreamControls;
+
+export type ApexTypeStubIterationOptions = {
+  readonly maxResponseBytes?: number;
+  readonly maxTypeStubs?: number;
+  readonly maxStubBytes?: number;
+  readonly signal?: AbortSignal;
+};
+
+export type ApexTypeReference = {
+  readonly namespacePrefix?: string | null;
+  readonly name: string;
+  readonly typeParameters?: readonly ApexTypeReference[] | null;
+};
+
+export type ApexAnnotationParameterStub = {
+  readonly name: string;
+  readonly type: ApexTypeReference;
+  readonly value: string;
+};
+
+export type ApexAnnotationStub = {
+  readonly name: string;
+  readonly parameters: readonly ApexAnnotationParameterStub[];
+  readonly documentation?: string | null;
+};
+
+export type ApexParameterStub = {
+  readonly name?: string | null;
+  readonly type?: ApexTypeReference | null;
+  readonly annotations: readonly ApexAnnotationStub[];
+  readonly documentation?: string | null;
+};
+
+export type ApexAccessorStub = {
+  readonly modifiers: readonly string[];
+  readonly documentation?: string | null;
+};
+
+export type ApexFieldStub = {
+  readonly name: string;
+  readonly type?: ApexTypeReference | null;
+  readonly modifiers: readonly string[];
+  readonly annotations: readonly ApexAnnotationStub[];
+  readonly documentation?: string | null;
+  readonly definingType?: ApexTypeReference | null;
+};
+
+export type ApexPropertyStub = {
+  readonly name: string;
+  readonly type?: ApexTypeReference | null;
+  readonly modifiers: readonly string[];
+  readonly annotations: readonly ApexAnnotationStub[];
+  readonly getter?: ApexAccessorStub | null;
+  readonly setter?: ApexAccessorStub | null;
+  readonly documentation?: string | null;
+  readonly definingType?: ApexTypeReference | null;
+};
+
+export type ApexMethodStub = {
+  readonly name: string;
+  readonly isConstructor?: boolean | null;
+  readonly returnType?: ApexTypeReference | null;
+  readonly modifiers: readonly string[];
+  readonly annotations: readonly ApexAnnotationStub[];
+  readonly parameters: readonly ApexParameterStub[];
+  readonly documentation?: string | null;
+  readonly definingType?: ApexTypeReference | null;
+};
+
+type ApexTypeStubIdentity = {
+  readonly name: string;
+  readonly namespacePrefix: string | null;
+  readonly typeParameters?: readonly ApexTypeReference[] | null;
+  readonly documentation?: string | null;
+};
+
+export type ApexResolvedTypeStub = ApexTypeStubIdentity & {
+  readonly compileError?: null;
+  readonly kind: ApexTypeKind;
+  readonly modifiers: readonly string[];
+  readonly annotations: readonly ApexAnnotationStub[];
+  readonly superClass?: ApexTypeReference | null;
+  readonly interfaces: readonly ApexTypeReference[];
+  readonly fields: readonly ApexFieldStub[];
+  readonly properties: readonly ApexPropertyStub[];
+  readonly methods: readonly ApexMethodStub[];
+  readonly innerTypes: readonly ApexTypeStub[];
+  readonly triggerOperations?: readonly string[] | null;
+  readonly triggerObjectType?: ApexTypeReference | null;
+};
+
+export type ApexCompileErrorTypeStub = ApexTypeStubIdentity & {
+  readonly compileError: string;
+  readonly kind?: ApexTypeKind | null;
+  readonly modifiers?: readonly string[] | null;
+  readonly annotations?: readonly ApexAnnotationStub[] | null;
+  readonly superClass?: ApexTypeReference | null;
+  readonly interfaces?: readonly ApexTypeReference[] | null;
+  readonly fields?: readonly ApexFieldStub[] | null;
+  readonly properties?: readonly ApexPropertyStub[] | null;
+  readonly methods?: readonly ApexMethodStub[] | null;
+  readonly innerTypes?: readonly ApexTypeStub[] | null;
+  readonly triggerOperations?: readonly string[] | null;
+  readonly triggerObjectType?: ApexTypeReference | null;
+};
+
+export type ApexTypeStub = ApexResolvedTypeStub | ApexCompileErrorTypeStub;
+
+export type ApexTypeStubResponse = {
+  readonly typeStubs: readonly ApexTypeStub[];
+};
+
+export type ApexSymbolsStreamResponse = {
+  readonly apiVersion: string;
+  readonly statusCode: number;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: AsyncIterable<Uint8Array>;
+  readonly cancel: (reason?: unknown) => void;
+};
+
+export const buildApexSymbolsUrl = (instanceUrl: string, apiVersion: string, request: ApexSymbolsRequest): string => {
+  const url = new URL(`/services/data/v${apiVersion}/tooling/symbols`, instanceUrl);
+  url.searchParams.set('category', request.category);
+
+  if (request.format !== undefined) {
+    url.searchParams.set('format', request.format);
+  }
+  if (request.namespace !== undefined) {
+    url.searchParams.set('namespace', request.namespace);
+  }
+  if (request.name !== undefined) {
+    url.searchParams.set('name', request.name);
+  }
+
+  return url.toString();
+};

--- a/src/org/apexSymbolsErrors.ts
+++ b/src/org/apexSymbolsErrors.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SfError } from '../sfError';
+import { ApexSymbolsStreamResponse } from './apexSymbols';
+import { APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR } from './apexSymbolsTransport';
+
+export const APEX_SYMBOLS_ENDPOINT_UNAVAILABLE_ERROR = 'ApexSymbolsEndpointUnavailableError';
+export const APEX_SYMBOLS_REQUEST_IN_PROGRESS_ERROR = 'ApexSymbolsRequestInProgressError';
+export const APEX_SYMBOLS_REQUEST_ERROR = 'ApexSymbolsRequestError';
+export const APEX_SYMBOLS_MALFORMED_RESPONSE_ERROR = 'ApexSymbolsMalformedResponseError';
+
+const MINIMUM_ORG_RELEASE = 264;
+const MAX_ERROR_RESPONSE_BYTES = 1024 * 1024;
+const REQUEST_IN_PROGRESS_CODE = 'UNKNOWN_EXCEPTION';
+const REQUEST_IN_PROGRESS_MESSAGE = 'Symbol table request already in progress for this org. Please retry later.';
+
+type SalesforceError = {
+  readonly message: string;
+  readonly errorCode: string;
+};
+
+const isSalesforceError = (value: unknown): value is SalesforceError =>
+  typeof value === 'object' &&
+  value !== null &&
+  'message' in value &&
+  typeof value.message === 'string' &&
+  'errorCode' in value &&
+  typeof value.errorCode === 'string';
+
+const parseSalesforceErrors = (body: string): SalesforceError[] => {
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (Array.isArray(parsed)) {
+      return parsed.filter(isSalesforceError);
+    }
+    return isSalesforceError(parsed) ? [parsed] : [];
+  } catch {
+    return [];
+  }
+};
+
+const readErrorBody = async (response: ApexSymbolsStreamResponse): Promise<string> => {
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+
+  for await (const chunk of response.body) {
+    bytes += chunk.byteLength;
+    if (bytes > MAX_ERROR_RESPONSE_BYTES) {
+      response.cancel();
+      throw new SfError(
+        `The Apex Symbols error response exceeded the ${MAX_ERROR_RESPONSE_BYTES}-byte limit.`,
+        APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR
+      );
+    }
+    chunks.push(chunk);
+  }
+
+  return Buffer.concat(chunks).toString('utf8');
+};
+
+const serverCause = (error: SalesforceError | undefined, statusCode: number): Error => {
+  const cause = new Error(error?.message ?? `Apex Symbols request failed with HTTP status ${statusCode}.`);
+  cause.name = error?.errorCode ?? `HTTP_${statusCode}`;
+  return cause;
+};
+
+export const throwIfApexSymbolsErrorResponse = async (response: ApexSymbolsStreamResponse): Promise<void> => {
+  if (response.statusCode < 400) {
+    return;
+  }
+
+  const responseBody = await readErrorBody(response);
+  const errors = parseSalesforceErrors(responseBody);
+  const firstError = errors[0];
+  const cause = serverCause(firstError, response.statusCode);
+  const data = {
+    statusCode: response.statusCode,
+    apiVersion: response.apiVersion,
+    errors,
+  };
+
+  if (firstError?.errorCode === REQUEST_IN_PROGRESS_CODE && firstError.message === REQUEST_IN_PROGRESS_MESSAGE) {
+    throw SfError.create({
+      message: firstError.message,
+      name: APEX_SYMBOLS_REQUEST_IN_PROGRESS_ERROR,
+      cause,
+      data,
+    });
+  }
+
+  if (response.statusCode === 404) {
+    throw SfError.create({
+      message:
+        `The Apex Symbols endpoint is unavailable at REST API version ${response.apiVersion}. ` +
+        `The org might be older than core release ${MINIMUM_ORG_RELEASE}.`,
+      name: APEX_SYMBOLS_ENDPOINT_UNAVAILABLE_ERROR,
+      cause,
+      data: { ...data, minimumOrgRelease: MINIMUM_ORG_RELEASE },
+    });
+  }
+
+  throw SfError.create({
+    message: firstError?.message ?? cause.message,
+    name: APEX_SYMBOLS_REQUEST_ERROR,
+    cause,
+    data,
+  });
+};

--- a/src/org/apexSymbolsMaterializer.ts
+++ b/src/org/apexSymbolsMaterializer.ts
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-import { SfError } from '../sfError';
 import {
   ApexSymbolsMaterializedControls,
-  ApexSymbolsRequest,
   ApexSymbolsStreamResponse,
   ApexTypeStub,
   ApexTypeStubResponse,
 } from './apexSymbols';
-import { APEX_SYMBOLS_MALFORMED_RESPONSE_ERROR } from './apexSymbolsErrors';
 import {
   DEFAULT_APEX_SYMBOLS_MAX_STUB_BYTES,
   DEFAULT_APEX_SYMBOLS_MAX_TYPE_STUBS,
@@ -34,35 +31,10 @@ export { DEFAULT_APEX_SYMBOLS_MAX_STUB_BYTES, DEFAULT_APEX_SYMBOLS_MAX_TYPE_STUB
 
 export const DEFAULT_APEX_SYMBOLS_MATERIALIZED_MAX_RESPONSE_BYTES = 64 * 1024 * 1024;
 
-const readBody = async (response: ApexSymbolsStreamResponse): Promise<Buffer> => {
-  const chunks: Uint8Array[] = [];
-  for await (const chunk of response.body) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks);
-};
-
-const parseJson = (body: Buffer): unknown => {
-  try {
-    return JSON.parse(body.toString('utf8')) as unknown;
-  } catch (error) {
-    throw SfError.create({
-      message: 'The Apex Symbols endpoint returned malformed JSON.',
-      name: APEX_SYMBOLS_MALFORMED_RESPONSE_ERROR,
-      ...(error instanceof Error ? { cause: error } : {}),
-    });
-  }
-};
-
 export const materializeApexSymbolsResponse = async (
-  request: ApexSymbolsRequest,
   response: ApexSymbolsStreamResponse,
   controls?: ApexSymbolsMaterializedControls
-): Promise<unknown> => {
-  if (request.format !== undefined && request.format !== 'TYPE_STUB') {
-    return parseJson(await readBody(response));
-  }
-
+): Promise<ApexTypeStubResponse> => {
   const typeStubs: ApexTypeStub[] = [];
   for await (const typeStub of iterateApexTypeStubs(response.body, {
     maxResponseBytes: controls?.maxResponseBytes ?? DEFAULT_APEX_SYMBOLS_MATERIALIZED_MAX_RESPONSE_BYTES,

--- a/src/org/apexSymbolsMaterializer.ts
+++ b/src/org/apexSymbolsMaterializer.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SfError } from '../sfError';
+import {
+  ApexSymbolsMaterializedControls,
+  ApexSymbolsRequest,
+  ApexSymbolsStreamResponse,
+  ApexTypeStub,
+  ApexTypeStubResponse,
+} from './apexSymbols';
+import { APEX_SYMBOLS_MALFORMED_RESPONSE_ERROR } from './apexSymbolsErrors';
+import {
+  DEFAULT_APEX_SYMBOLS_MAX_STUB_BYTES,
+  DEFAULT_APEX_SYMBOLS_MAX_TYPE_STUBS,
+  iterateApexTypeStubs,
+} from './apexTypeStubIterator';
+
+export { APEX_SYMBOLS_MALFORMED_RESPONSE_ERROR } from './apexSymbolsErrors';
+export { DEFAULT_APEX_SYMBOLS_MAX_STUB_BYTES, DEFAULT_APEX_SYMBOLS_MAX_TYPE_STUBS } from './apexTypeStubIterator';
+
+export const DEFAULT_APEX_SYMBOLS_MATERIALIZED_MAX_RESPONSE_BYTES = 64 * 1024 * 1024;
+
+const readBody = async (response: ApexSymbolsStreamResponse): Promise<Buffer> => {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of response.body) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+};
+
+const parseJson = (body: Buffer): unknown => {
+  try {
+    return JSON.parse(body.toString('utf8')) as unknown;
+  } catch (error) {
+    throw SfError.create({
+      message: 'The Apex Symbols endpoint returned malformed JSON.',
+      name: APEX_SYMBOLS_MALFORMED_RESPONSE_ERROR,
+      ...(error instanceof Error ? { cause: error } : {}),
+    });
+  }
+};
+
+export const materializeApexSymbolsResponse = async (
+  request: ApexSymbolsRequest,
+  response: ApexSymbolsStreamResponse,
+  controls?: ApexSymbolsMaterializedControls
+): Promise<unknown> => {
+  if (request.format !== undefined && request.format !== 'TYPE_STUB') {
+    return parseJson(await readBody(response));
+  }
+
+  const typeStubs: ApexTypeStub[] = [];
+  for await (const typeStub of iterateApexTypeStubs(response.body, {
+    maxResponseBytes: controls?.maxResponseBytes ?? DEFAULT_APEX_SYMBOLS_MATERIALIZED_MAX_RESPONSE_BYTES,
+    maxTypeStubs: controls?.maxTypeStubs ?? DEFAULT_APEX_SYMBOLS_MAX_TYPE_STUBS,
+    maxStubBytes: controls?.maxStubBytes ?? DEFAULT_APEX_SYMBOLS_MAX_STUB_BYTES,
+    ...(controls?.signal ? { signal: controls.signal } : {}),
+  })) {
+    typeStubs.push(typeStub);
+  }
+
+  return { typeStubs } satisfies ApexTypeStubResponse;
+};

--- a/src/org/apexSymbolsTransport.ts
+++ b/src/org/apexSymbolsTransport.ts
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Dispatcher, EnvHttpProxyAgent, fetch, ProxyAgent } from 'undici';
+import { SfError } from '../sfError';
+import { ApexSymbolsStreamResponse } from './apexSymbols';
+
+export const APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR = 'ApexSymbolsResponseTooLargeError';
+export const APEX_SYMBOLS_REQUEST_TIMEOUT_ERROR = 'ApexSymbolsRequestTimeoutError';
+export const APEX_SYMBOLS_REQUEST_ABORTED_ERROR = 'ApexSymbolsRequestAbortedError';
+export const APEX_SYMBOLS_IDLE_TIMEOUT_ERROR = 'ApexSymbolsIdleTimeoutError';
+export const APEX_SYMBOLS_INVALID_CONTROL_ERROR = 'ApexSymbolsInvalidControlError';
+
+export const DEFAULT_APEX_SYMBOLS_TIMEOUT_MS = 30 * 60 * 1_000;
+export const DEFAULT_APEX_SYMBOLS_IDLE_TIMEOUT_MS = 60 * 1_000;
+export const DEFAULT_APEX_SYMBOLS_MAX_RESPONSE_BYTES = 512 * 1024 * 1024;
+
+export type ApexSymbolsTransportRequest = {
+  readonly url: string;
+  readonly apiVersion: string;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly timeoutMs: number;
+  readonly idleTimeoutMs: number;
+  readonly maxResponseBytes: number;
+  readonly signal?: AbortSignal;
+  readonly httpProxy?: string;
+  readonly onComplete?: (metrics: ApexSymbolsTransportMetrics) => void;
+};
+
+export type ApexSymbolsTransportMetrics = {
+  readonly apiVersion: string;
+  readonly statusCode?: number;
+  readonly timeToFirstByteMs?: number;
+  readonly totalTimeMs: number;
+  readonly responseBytes: number;
+  readonly requestId?: string;
+  readonly errorName?: string;
+};
+
+const hasEnvironmentProxy = (): boolean =>
+  Boolean(
+    process.env.https_proxy ?? process.env.http_proxy ?? process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY ?? undefined
+  );
+
+const createDispatcher = (httpProxy?: string): Dispatcher | undefined => {
+  if (httpProxy) {
+    return new ProxyAgent(httpProxy);
+  }
+
+  return hasEnvironmentProxy() ? new EnvHttpProxyAgent() : undefined;
+};
+
+const errorWithOptionalCause = (message: string, name: string, cause?: unknown): SfError =>
+  SfError.create({
+    message,
+    name,
+    ...(cause instanceof Error ? { cause } : {}),
+  });
+
+const validatePositiveInteger = (value: number, name: string): void => {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new SfError(
+      `Apex Symbols ${name} must be a positive integer. Received ${value}.`,
+      APEX_SYMBOLS_INVALID_CONTROL_ERROR
+    );
+  }
+};
+
+export const requestApexSymbolsStream = async (
+  request: ApexSymbolsTransportRequest
+): Promise<ApexSymbolsStreamResponse> => {
+  validatePositiveInteger(request.timeoutMs, 'timeoutMs');
+  validatePositiveInteger(request.idleTimeoutMs, 'idleTimeoutMs');
+  validatePositiveInteger(request.maxResponseBytes, 'maxResponseBytes');
+
+  const dispatcher = createDispatcher(request.httpProxy);
+  const controller = new AbortController();
+  const startedAt = performance.now();
+  let abortError: SfError | undefined;
+  let idleTimer: NodeJS.Timeout | undefined;
+  let cleanedUp = false;
+  let firstByteAt: number | undefined;
+  let responseBytes = 0;
+  const diagnosticState: { statusCode?: number; requestId?: string } = {};
+
+  const cleanup = async (): Promise<void> => {
+    if (cleanedUp) {
+      return;
+    }
+    cleanedUp = true;
+    clearTimeout(totalTimer);
+    clearTimeout(idleTimer);
+    request.signal?.removeEventListener('abort', onCallerAbort);
+    await dispatcher?.close();
+    try {
+      request.onComplete?.({
+        apiVersion: request.apiVersion,
+        statusCode: diagnosticState.statusCode,
+        ...(firstByteAt === undefined ? {} : { timeToFirstByteMs: firstByteAt - startedAt }),
+        totalTimeMs: performance.now() - startedAt,
+        responseBytes,
+        ...(diagnosticState.requestId ? { requestId: diagnosticState.requestId } : {}),
+        ...(abortError ? { errorName: abortError.name } : {}),
+      });
+    } catch {
+      // Diagnostics must never change the request outcome.
+    }
+  };
+
+  const abortWith = (error: SfError): void => {
+    if (controller.signal.aborted) {
+      return;
+    }
+    abortError = error;
+    controller.abort(error);
+  };
+
+  const onCallerAbort = (): void => {
+    abortWith(
+      errorWithOptionalCause(
+        'The Apex Symbols request was aborted.',
+        APEX_SYMBOLS_REQUEST_ABORTED_ERROR,
+        request.signal?.reason
+      )
+    );
+  };
+
+  if (request.signal?.aborted) {
+    await dispatcher?.close();
+    throw errorWithOptionalCause(
+      'The Apex Symbols request was aborted before it was sent.',
+      APEX_SYMBOLS_REQUEST_ABORTED_ERROR,
+      request.signal.reason
+    );
+  }
+
+  request.signal?.addEventListener('abort', onCallerAbort, { once: true });
+
+  const totalTimer = setTimeout(() => {
+    abortWith(
+      new SfError(
+        `The Apex Symbols request exceeded the ${request.timeoutMs}ms total timeout.`,
+        APEX_SYMBOLS_REQUEST_TIMEOUT_ERROR
+      )
+    );
+  }, request.timeoutMs);
+
+  let response: Awaited<ReturnType<typeof fetch>>;
+  try {
+    response = await fetch(request.url, {
+      method: 'GET',
+      headers: request.headers,
+      redirect: 'follow',
+      signal: controller.signal,
+      ...(dispatcher ? { dispatcher } : {}),
+    });
+  } catch (error) {
+    await cleanup();
+    throw abortError ?? error;
+  }
+
+  const headers = Object.fromEntries(response.headers.entries());
+  diagnosticState.statusCode = response.status;
+  diagnosticState.requestId = headers['x-sfdc-request-id'] ?? headers['x-request-id'];
+  const contentLength = Number(headers['content-length']);
+  const contentEncoding = headers['content-encoding'];
+  if (
+    (!contentEncoding || contentEncoding === 'identity') &&
+    Number.isFinite(contentLength) &&
+    contentLength > request.maxResponseBytes
+  ) {
+    const error = new SfError(
+      `The Apex Symbols response content-length of ${contentLength} bytes exceeds the ${request.maxResponseBytes}-byte limit.`,
+      APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR
+    );
+    abortWith(error);
+    await response.body?.cancel(error).catch(() => undefined);
+    await cleanup();
+    throw error;
+  }
+
+  const body = (async function* (): AsyncIterable<Uint8Array> {
+    if (!response.body) {
+      await cleanup();
+      return;
+    }
+
+    const reader = response.body.getReader();
+    let completed = false;
+    try {
+      while (true) {
+        idleTimer = setTimeout(() => {
+          abortWith(
+            new SfError(
+              `The Apex Symbols response produced no data for ${request.idleTimeoutMs}ms.`,
+              APEX_SYMBOLS_IDLE_TIMEOUT_ERROR
+            )
+          );
+        }, request.idleTimeoutMs);
+
+        let result: Awaited<ReturnType<typeof reader.read>>;
+        try {
+          // Sequential reads are required to preserve consumer backpressure.
+          // eslint-disable-next-line no-await-in-loop
+          result = await reader.read();
+        } catch (error) {
+          throw abortError ?? error;
+        } finally {
+          clearTimeout(idleTimer);
+          idleTimer = undefined;
+        }
+
+        if (result.done) {
+          completed = true;
+          return;
+        }
+
+        firstByteAt ??= performance.now();
+
+        const value: unknown = result.value;
+        if (!(value instanceof Uint8Array)) {
+          throw new TypeError('The Apex Symbols response contained a non-byte stream chunk.');
+        }
+
+        responseBytes += value.byteLength;
+        if (responseBytes > request.maxResponseBytes) {
+          const error = new SfError(
+            `The Apex Symbols response exceeded the ${request.maxResponseBytes}-byte limit.`,
+            APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR
+          );
+          abortWith(error);
+          throw error;
+        }
+
+        yield value;
+      }
+    } finally {
+      if (!completed && !controller.signal.aborted) {
+        abortWith(new SfError('Apex Symbols response consumption stopped early.', APEX_SYMBOLS_REQUEST_ABORTED_ERROR));
+      }
+      if (!completed) {
+        await reader.cancel(abortError).catch(() => undefined);
+      }
+      reader.releaseLock();
+      await cleanup();
+    }
+  })();
+
+  controller.signal.addEventListener(
+    'abort',
+    () => {
+      if (response.body && !response.body.locked) {
+        void response.body.cancel(abortError).catch(() => undefined);
+      }
+      void cleanup();
+    },
+    { once: true }
+  );
+
+  return {
+    apiVersion: request.apiVersion,
+    statusCode: response.status,
+    headers,
+    body,
+    cancel: (reason?: unknown): void => {
+      abortWith(
+        errorWithOptionalCause('The Apex Symbols request was canceled.', APEX_SYMBOLS_REQUEST_ABORTED_ERROR, reason)
+      );
+    },
+  };
+};

--- a/src/org/apexTypeStubIterator.ts
+++ b/src/org/apexTypeStubIterator.ts
@@ -167,7 +167,7 @@ const trackEnvelopeToken = (state: EnvelopeTrackingState, tokenInfo: ParsedToken
  * @example
  * ```ts
  * const response = await connection.retrieveApexSymbols(
- *   { category: 'DATABASE', format: 'TYPE_STUB' },
+ *   { category: 'DATABASE' },
  *   { mode: 'stream' }
  * );
  * for await (const stub of iterateApexTypeStubs(response.body)) {

--- a/src/org/apexTypeStubIterator.ts
+++ b/src/org/apexTypeStubIterator.ts
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JSONParser, ParsedElementInfo, ParsedTokenInfo, TokenType } from '@streamparser/json';
+import { SfError } from '../sfError';
+import { ApexTypeStub, ApexTypeStubIterationOptions } from './apexSymbols';
+import { APEX_SYMBOLS_MALFORMED_RESPONSE_ERROR } from './apexSymbolsErrors';
+import {
+  APEX_SYMBOLS_INVALID_CONTROL_ERROR,
+  APEX_SYMBOLS_REQUEST_ABORTED_ERROR,
+  APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR,
+  DEFAULT_APEX_SYMBOLS_MAX_RESPONSE_BYTES,
+} from './apexSymbolsTransport';
+
+export const DEFAULT_APEX_SYMBOLS_MAX_TYPE_STUBS = 10_000;
+export const DEFAULT_APEX_SYMBOLS_MAX_STUB_BYTES = 8 * 1024 * 1024;
+
+const PARSER_CHUNK_BYTES = 64 * 1024;
+
+const validatePositiveInteger = (value: number, name: string): void => {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new SfError(
+      `Apex Symbols ${name} must be a positive integer. Received ${value}.`,
+      APEX_SYMBOLS_INVALID_CONTROL_ERROR
+    );
+  }
+};
+
+const malformedResponse = (message: string, cause?: unknown): SfError =>
+  SfError.create({
+    message,
+    name: APEX_SYMBOLS_MALFORMED_RESPONSE_ERROR,
+    ...(cause instanceof Error ? { cause } : {}),
+  });
+
+const responseTooLarge = (message: string): SfError => new SfError(message, APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR);
+
+const requestAborted = (reason?: unknown): SfError =>
+  SfError.create({
+    message: 'Apex Symbols type-stub iteration was aborted.',
+    name: APEX_SYMBOLS_REQUEST_ABORTED_ERROR,
+    ...(reason instanceof Error ? { cause: reason } : {}),
+  });
+
+const isApexTypeStub = (value: unknown): value is ApexTypeStub =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isContainerStart = (token: TokenType): boolean =>
+  token === TokenType.LEFT_BRACE || token === TokenType.LEFT_BRACKET;
+
+const isContainerEnd = (token: TokenType): boolean =>
+  token === TokenType.RIGHT_BRACE || token === TokenType.RIGHT_BRACKET;
+
+type EnvelopeTrackingState = {
+  readonly containers: TokenType[];
+  rootStarted: boolean;
+  rootEnded: boolean;
+  expectingRootKey: boolean;
+  awaitingTypeStubsValue: boolean;
+  typeStubsState: 'missing' | 'in-array' | 'complete';
+  typeStubsArrayDepth?: number;
+  currentStubStart?: number;
+  completedStubBytes?: number;
+};
+
+const trackRootToken = (state: EnvelopeTrackingState, { token, value }: ParsedTokenInfo): void => {
+  const atRoot = state.containers.length === 1 && state.containers[0] === TokenType.LEFT_BRACE;
+  if (!atRoot) {
+    return;
+  }
+
+  if (state.expectingRootKey) {
+    if (token === TokenType.RIGHT_BRACE) {
+      state.rootEnded = true;
+    } else if (token === TokenType.STRING) {
+      state.expectingRootKey = false;
+      if (value === 'typeStubs') {
+        if (state.typeStubsState !== 'missing' || state.awaitingTypeStubsValue) {
+          throw malformedResponse('The Apex Symbols TYPE_STUB response contains more than one typeStubs field.');
+        }
+        state.awaitingTypeStubsValue = true;
+      }
+    }
+    return;
+  }
+
+  if (state.awaitingTypeStubsValue && token !== TokenType.COLON) {
+    if (token !== TokenType.LEFT_BRACKET) {
+      throw malformedResponse('The Apex Symbols TYPE_STUB response did not contain a typeStubs array.');
+    }
+    state.awaitingTypeStubsValue = false;
+    state.typeStubsState = 'in-array';
+    state.typeStubsArrayDepth = state.containers.length + 1;
+  } else if (token === TokenType.COMMA) {
+    state.expectingRootKey = true;
+  } else if (token === TokenType.RIGHT_BRACE) {
+    state.rootEnded = true;
+  }
+};
+
+const trackTypeStubArrayToken = (state: EnvelopeTrackingState, { token, offset }: ParsedTokenInfo): void => {
+  if (state.typeStubsState !== 'in-array' || state.containers.length !== state.typeStubsArrayDepth) {
+    return;
+  }
+
+  if (token === TokenType.RIGHT_BRACKET) {
+    state.typeStubsState = 'complete';
+    state.typeStubsArrayDepth = undefined;
+  } else if (token !== TokenType.COMMA && state.currentStubStart === undefined) {
+    state.currentStubStart = offset;
+  }
+};
+
+const trackCompletedStub = (state: EnvelopeTrackingState, { token, offset }: ParsedTokenInfo): void => {
+  if (
+    state.currentStubStart !== undefined &&
+    state.containers.length === (state.typeStubsArrayDepth ?? 0) + 1 &&
+    isContainerEnd(token)
+  ) {
+    state.completedStubBytes = offset + 1 - state.currentStubStart;
+  }
+};
+
+const updateContainers = (containers: TokenType[], token: TokenType): void => {
+  if (isContainerStart(token)) {
+    containers.push(token);
+  } else if (isContainerEnd(token)) {
+    containers.pop();
+  }
+};
+
+const trackEnvelopeToken = (state: EnvelopeTrackingState, tokenInfo: ParsedTokenInfo): void => {
+  if (!state.rootStarted) {
+    if (tokenInfo.token !== TokenType.LEFT_BRACE) {
+      throw malformedResponse('The Apex Symbols TYPE_STUB response must be a JSON object.');
+    }
+    state.rootStarted = true;
+    state.containers.push(tokenInfo.token);
+    return;
+  }
+
+  trackRootToken(state, tokenInfo);
+  trackTypeStubArrayToken(state, tokenInfo);
+  trackCompletedStub(state, tokenInfo);
+  updateContainers(state.containers, tokenInfo.token);
+};
+
+/**
+ * Incrementally parses the `typeStubs` array from a Tooling Apex Symbols `TYPE_STUB` response.
+ *
+ * Completed stubs are emitted without retaining the response envelope or previously emitted siblings. Stopping
+ * iteration early closes the supplied async iterator, which cancels an `ApexSymbolsStreamResponse.body` upstream.
+ *
+ * @example
+ * ```ts
+ * const response = await connection.retrieveApexSymbols(
+ *   { category: 'DATABASE', format: 'TYPE_STUB' },
+ *   { mode: 'stream' }
+ * );
+ * for await (const stub of iterateApexTypeStubs(response.body)) {
+ *   console.log(stub.namespacePrefix, stub.name);
+ * }
+ * ```
+ *
+ * @param body Decompressed UTF-8 response bytes, normally from `ApexSymbolsStreamResponse.body`.
+ * @param options Finite response, item-count, per-item, and cancellation limits.
+ */
+export const iterateApexTypeStubs = async function* (
+  body: AsyncIterable<Uint8Array>,
+  options: ApexTypeStubIterationOptions = {}
+): AsyncIterable<ApexTypeStub> {
+  const maxResponseBytes = options.maxResponseBytes ?? DEFAULT_APEX_SYMBOLS_MAX_RESPONSE_BYTES;
+  const maxTypeStubs = options.maxTypeStubs ?? DEFAULT_APEX_SYMBOLS_MAX_TYPE_STUBS;
+  const maxStubBytes = options.maxStubBytes ?? DEFAULT_APEX_SYMBOLS_MAX_STUB_BYTES;
+  validatePositiveInteger(maxResponseBytes, 'maxResponseBytes');
+  validatePositiveInteger(maxTypeStubs, 'maxTypeStubs');
+  validatePositiveInteger(maxStubBytes, 'maxStubBytes');
+
+  if (options.signal?.aborted) {
+    throw requestAborted(options.signal.reason);
+  }
+
+  const pending: ApexTypeStub[] = [];
+  let totalBytes = 0;
+  let typeStubCount = 0;
+  const envelope: EnvelopeTrackingState = {
+    containers: [],
+    rootStarted: false,
+    rootEnded: false,
+    expectingRootKey: true,
+    awaitingTypeStubsValue: false,
+    typeStubsState: 'missing',
+  };
+
+  const checkAborted = (): void => {
+    if (options.signal?.aborted) {
+      throw requestAborted(options.signal.reason);
+    }
+  };
+
+  const parser = new JSONParser({ paths: ['$.typeStubs.*'], keepStack: false, stringBufferSize: 64 * 1024 });
+  parser.onToken = (tokenInfo): void => trackEnvelopeToken(envelope, tokenInfo);
+  parser.onValue = ({ value }: ParsedElementInfo): void => {
+    if (!isApexTypeStub(value)) {
+      throw malformedResponse('The Apex Symbols typeStubs array contained a value that is not an object.');
+    }
+
+    typeStubCount += 1;
+    if (typeStubCount > maxTypeStubs) {
+      throw responseTooLarge(`The Apex Symbols response exceeded the ${maxTypeStubs}-stub limit.`);
+    }
+
+    const stubBytes = envelope.completedStubBytes ?? Buffer.byteLength(JSON.stringify(value), 'utf8');
+    if (stubBytes > maxStubBytes) {
+      throw responseTooLarge(
+        `A type stub in the Apex Symbols response exceeded the ${maxStubBytes}-byte per-stub limit.`
+      );
+    }
+
+    pending.push(value);
+    envelope.currentStubStart = undefined;
+    envelope.completedStubBytes = undefined;
+  };
+
+  const parse = (operation: () => void): void => {
+    try {
+      operation();
+    } catch (error) {
+      if (error instanceof SfError) {
+        throw error;
+      }
+      throw malformedResponse('The Apex Symbols endpoint returned a malformed TYPE_STUB response.', error);
+    }
+  };
+
+  for await (const chunk of body) {
+    checkAborted();
+    const parserChunkBytes = Math.min(PARSER_CHUNK_BYTES, maxStubBytes);
+
+    for (let offset = 0; offset < chunk.byteLength; offset += parserChunkBytes) {
+      checkAborted();
+      const parserChunk = chunk.subarray(offset, offset + parserChunkBytes);
+      totalBytes += parserChunk.byteLength;
+      if (totalBytes > maxResponseBytes) {
+        throw responseTooLarge(`The Apex Symbols response exceeded the ${maxResponseBytes}-byte limit.`);
+      }
+
+      parse(() => parser.write(parserChunk));
+      if (envelope.currentStubStart !== undefined && totalBytes - envelope.currentStubStart > maxStubBytes) {
+        throw responseTooLarge(
+          `A type stub in the Apex Symbols response exceeded the ${maxStubBytes}-byte per-stub limit.`
+        );
+      }
+
+      for (const stub of pending) {
+        checkAborted();
+        yield stub;
+      }
+      pending.length = 0;
+    }
+  }
+
+  if (!parser.isEnded) {
+    parse(() => parser.end());
+  }
+  for (const stub of pending) {
+    checkAborted();
+    yield stub;
+  }
+
+  if (!envelope.rootEnded || envelope.typeStubsState !== 'complete') {
+    throw malformedResponse('The Apex Symbols TYPE_STUB response did not contain a complete typeStubs array.');
+  }
+};

--- a/src/org/connection.ts
+++ b/src/org/connection.ts
@@ -40,6 +40,27 @@ import { Messages } from '../messages';
 import { Lifecycle } from '../lifecycleEvents';
 import { Global } from '../global';
 import { AuthFields, AuthInfo } from './authInfo';
+import {
+  ApexSymbolsMaterializedControls,
+  ApexSymbolsRequest,
+  ApexSymbolsRequestControls,
+  ApexSymbolsStreamControls,
+  ApexSymbolsStreamResponse,
+  ApexTypeStubResponse,
+  ApexTypeStubSymbolsRequest,
+  buildApexSymbolsUrl,
+} from './apexSymbols';
+import { throwIfApexSymbolsErrorResponse } from './apexSymbolsErrors';
+import {
+  DEFAULT_APEX_SYMBOLS_MATERIALIZED_MAX_RESPONSE_BYTES,
+  materializeApexSymbolsResponse,
+} from './apexSymbolsMaterializer';
+import {
+  DEFAULT_APEX_SYMBOLS_IDLE_TIMEOUT_MS,
+  DEFAULT_APEX_SYMBOLS_MAX_RESPONSE_BYTES,
+  DEFAULT_APEX_SYMBOLS_TIMEOUT_MS,
+  requestApexSymbolsStream,
+} from './apexSymbolsTransport';
 import { OrgConfigProperties } from './orgConfigProperties';
 
 Messages.importMessagesDirectory(__dirname);
@@ -207,6 +228,100 @@ export class Connection<S extends Schema = Schema> extends JSForceConnection<S> 
     };
     this.logger.getRawLogger().debug(httpRequest, 'request');
     return super.request(httpRequest, options);
+  }
+
+  /**
+   * Retrieve a bounded materialized response or unbuffered stream from the Tooling Apex Symbols endpoint.
+   *
+   * The endpoint is available on org core release 264 and later. The server's maximum REST API version is selected
+   * internally without changing the version configured on this connection.
+   *
+   * `BUILTIN` retrieves standard Apex types, `DATABASE` retrieves org-defined and installed-package Apex types, and
+   * `DYNAMIC` retrieves dynamic Apex types. Core sends exactly one category per invocation and does not retry, queue,
+   * merge, or fall back across categories.
+   *
+   * @example Exact standard Apex class lookup
+   * ```ts
+   * const result = await connection.retrieveApexSymbols({
+   *   category: 'BUILTIN',
+   *   namespace: 'System',
+   *   name: 'String',
+   *   format: 'TYPE_STUB',
+   * });
+   * ```
+   *
+   * @example Broad incremental lookup
+   * ```ts
+   * const response = await connection.retrieveApexSymbols(
+   *   { category: 'DATABASE', format: 'TYPE_STUB' },
+   *   { mode: 'stream' }
+   * );
+   * for await (const stub of iterateApexTypeStubs(response.body)) {
+   *   // Process one stub at a time.
+   * }
+   * ```
+   *
+   * @param request Apex symbol category, format, and optional exact lookup filters.
+   * @param controls Response mode, limits, and cancellation controls. Omitted controls select bounded materialization.
+   */
+  public retrieveApexSymbols(
+    request: ApexTypeStubSymbolsRequest,
+    controls?: ApexSymbolsMaterializedControls
+  ): Promise<ApexTypeStubResponse>;
+  public retrieveApexSymbols(request: ApexSymbolsRequest, controls?: ApexSymbolsMaterializedControls): Promise<unknown>;
+  public retrieveApexSymbols(
+    request: ApexSymbolsRequest,
+    controls: ApexSymbolsStreamControls
+  ): Promise<ApexSymbolsStreamResponse>;
+  public retrieveApexSymbols(request: ApexSymbolsRequest, controls: ApexSymbolsRequestControls): Promise<unknown>;
+  public async retrieveApexSymbols(
+    request: ApexSymbolsRequest,
+    controls?: ApexSymbolsRequestControls
+  ): Promise<unknown> {
+    const apiVersion = await this.retrieveMaxApiVersion();
+    // JSforce stores the public Connection callOptions configuration on this inherited field.
+    // eslint-disable-next-line no-underscore-dangle
+    const callOptions = Object.entries(this._callOptions ?? {})
+      .map(([name, value]) => `${name}=${value}`)
+      .join(', ');
+
+    const mode = controls?.mode ?? 'materialized';
+    const response = await requestApexSymbolsStream({
+      url: buildApexSymbolsUrl(this.instanceUrl, apiVersion, request),
+      apiVersion,
+      headers: {
+        ...SFDX_HTTP_HEADERS,
+        ...(this.accessToken ? { authorization: `Bearer ${this.accessToken}` } : {}),
+        ...(callOptions ? { 'sforce-call-options': callOptions } : {}),
+      },
+      timeoutMs: controls?.timeoutMs ?? DEFAULT_APEX_SYMBOLS_TIMEOUT_MS,
+      idleTimeoutMs: controls?.idleTimeoutMs ?? DEFAULT_APEX_SYMBOLS_IDLE_TIMEOUT_MS,
+      maxResponseBytes:
+        controls?.maxResponseBytes ??
+        (mode === 'stream'
+          ? DEFAULT_APEX_SYMBOLS_MAX_RESPONSE_BYTES
+          : DEFAULT_APEX_SYMBOLS_MATERIALIZED_MAX_RESPONSE_BYTES),
+      signal: controls?.signal,
+      httpProxy: this.options.connectionOptions?.httpProxy,
+      onComplete: (metrics): void => {
+        this.logger.getRawLogger().debug(
+          {
+            event: 'apexSymbolsRequest',
+            category: request.category,
+            format: request.format ?? 'TYPE_STUB',
+            hasNamespaceFilter: request.namespace !== undefined,
+            hasNameFilter: request.name !== undefined,
+            ...metrics,
+          },
+          'Apex Symbols request completed'
+        );
+      },
+    });
+    await throwIfApexSymbolsErrorResponse(response);
+    if (controls?.mode === 'stream') {
+      return response;
+    }
+    return materializeApexSymbolsResponse(request, response, controls);
   }
 
   /**

--- a/src/org/connection.ts
+++ b/src/org/connection.ts
@@ -47,7 +47,6 @@ import {
   ApexSymbolsStreamControls,
   ApexSymbolsStreamResponse,
   ApexTypeStubResponse,
-  ApexTypeStubSymbolsRequest,
   buildApexSymbolsUrl,
 } from './apexSymbols';
 import { throwIfApexSymbolsErrorResponse } from './apexSymbolsErrors';
@@ -246,14 +245,13 @@ export class Connection<S extends Schema = Schema> extends JSForceConnection<S> 
    *   category: 'BUILTIN',
    *   namespace: 'System',
    *   name: 'String',
-   *   format: 'TYPE_STUB',
    * });
    * ```
    *
    * @example Broad incremental lookup
    * ```ts
    * const response = await connection.retrieveApexSymbols(
-   *   { category: 'DATABASE', format: 'TYPE_STUB' },
+   *   { category: 'DATABASE' },
    *   { mode: 'stream' }
    * );
    * for await (const stub of iterateApexTypeStubs(response.body)) {
@@ -261,23 +259,25 @@ export class Connection<S extends Schema = Schema> extends JSForceConnection<S> 
    * }
    * ```
    *
-   * @param request Apex symbol category, format, and optional exact lookup filters.
+   * @param request Apex symbol category and optional exact lookup filters. The endpoint's TYPE_STUB format is implicit.
    * @param controls Response mode, limits, and cancellation controls. Omitted controls select bounded materialization.
    */
   public retrieveApexSymbols(
-    request: ApexTypeStubSymbolsRequest,
+    request: ApexSymbolsRequest,
     controls?: ApexSymbolsMaterializedControls
   ): Promise<ApexTypeStubResponse>;
-  public retrieveApexSymbols(request: ApexSymbolsRequest, controls?: ApexSymbolsMaterializedControls): Promise<unknown>;
   public retrieveApexSymbols(
     request: ApexSymbolsRequest,
     controls: ApexSymbolsStreamControls
   ): Promise<ApexSymbolsStreamResponse>;
-  public retrieveApexSymbols(request: ApexSymbolsRequest, controls: ApexSymbolsRequestControls): Promise<unknown>;
+  public retrieveApexSymbols(
+    request: ApexSymbolsRequest,
+    controls: ApexSymbolsRequestControls
+  ): Promise<ApexTypeStubResponse | ApexSymbolsStreamResponse>;
   public async retrieveApexSymbols(
     request: ApexSymbolsRequest,
     controls?: ApexSymbolsRequestControls
-  ): Promise<unknown> {
+  ): Promise<ApexTypeStubResponse | ApexSymbolsStreamResponse> {
     const apiVersion = await this.retrieveMaxApiVersion();
     // JSforce stores the public Connection callOptions configuration on this inherited field.
     // eslint-disable-next-line no-underscore-dangle
@@ -308,7 +308,6 @@ export class Connection<S extends Schema = Schema> extends JSForceConnection<S> 
           {
             event: 'apexSymbolsRequest',
             category: request.category,
-            format: request.format ?? 'TYPE_STUB',
             hasNamespaceFilter: request.namespace !== undefined,
             hasNameFilter: request.name !== undefined,
             ...metrics,
@@ -321,7 +320,7 @@ export class Connection<S extends Schema = Schema> extends JSForceConnection<S> 
     if (controls?.mode === 'stream') {
       return response;
     }
-    return materializeApexSymbolsResponse(request, response, controls);
+    return materializeApexSymbolsResponse(response, controls);
   }
 
   /**

--- a/test/unit/org/apexSymbols.test.ts
+++ b/test/unit/org/apexSymbols.test.ts
@@ -19,6 +19,7 @@ import {
   apexSymbolCategories,
   apexTypeKinds,
   ApexSymbolsMaterializedControls,
+  ApexSymbolsRequest,
   ApexSymbolsRequestControls,
   ApexSymbolsStreamControls,
   ApexTypeStubResponse,
@@ -47,6 +48,15 @@ describe('Apex Symbols', () => {
 
       expect(controls.map(({ mode }) => mode)).to.deep.equal(['materialized', 'stream']);
     });
+
+    it('does not expose a result format selector', () => {
+      const request: ApexSymbolsRequest = { category: 'DATABASE' };
+      // @ts-expect-error TYPE_STUB is implicit and format is intentionally not part of the request.
+      const invalidRequest: ApexSymbolsRequest = { category: 'DATABASE', format: 'TYPE_STUB' };
+
+      expect(request).to.deep.equal({ category: 'DATABASE' });
+      expect(invalidRequest).to.have.property('format', 'TYPE_STUB');
+    });
   });
 
   describe('buildApexSymbolsUrl', () => {
@@ -62,16 +72,15 @@ describe('Apex Symbols', () => {
       ]);
     });
 
-    it('preserves and encodes exact lookup filters and result format', () => {
+    it('preserves and encodes exact lookup filters', () => {
       const url = buildApexSymbolsUrl('https://example.my.salesforce.com/path', '68.0', {
         category: 'DATABASE',
-        format: 'TYPE_STUB',
         namespace: 'My Package/Name',
         name: 'Outer.Inner?',
       });
 
       expect(url).to.equal(
-        'https://example.my.salesforce.com/services/data/v68.0/tooling/symbols?category=DATABASE&format=TYPE_STUB&namespace=My+Package%2FName&name=Outer.Inner%3F'
+        'https://example.my.salesforce.com/services/data/v68.0/tooling/symbols?category=DATABASE&namespace=My+Package%2FName&name=Outer.Inner%3F'
       );
     });
 

--- a/test/unit/org/apexSymbols.test.ts
+++ b/test/unit/org/apexSymbols.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import {
+  apexSymbolCategories,
+  apexTypeKinds,
+  ApexSymbolsMaterializedControls,
+  ApexSymbolsRequestControls,
+  ApexSymbolsStreamControls,
+  ApexTypeStubResponse,
+} from '../../../src';
+import { buildApexSymbolsUrl } from '../../../src/org/apexSymbols';
+
+describe('Apex Symbols', () => {
+  describe('request contract', () => {
+    it('exposes every Apex symbol category and type kind', () => {
+      expect(apexSymbolCategories).to.deep.equal(['BUILTIN', 'DATABASE', 'DYNAMIC']);
+      expect(apexTypeKinds).to.deep.equal(['CLASS', 'INTERFACE', 'ENUM', 'TRIGGER']);
+    });
+
+    it('uses a discriminated union for materialized and streaming controls', () => {
+      const materialized: ApexSymbolsMaterializedControls = {
+        mode: 'materialized',
+        maxResponseBytes: 1_000,
+        maxTypeStubs: 10,
+        maxStubBytes: 500,
+      };
+      const stream: ApexSymbolsStreamControls = {
+        mode: 'stream',
+        maxResponseBytes: 1_000,
+      };
+      const controls: ApexSymbolsRequestControls[] = [materialized, stream];
+
+      expect(controls.map(({ mode }) => mode)).to.deep.equal(['materialized', 'stream']);
+    });
+  });
+
+  describe('buildApexSymbolsUrl', () => {
+    it('builds the route for every category', () => {
+      expect(
+        apexSymbolCategories.map((category) =>
+          buildApexSymbolsUrl('https://example.my.salesforce.com', '68.0', { category })
+        )
+      ).to.deep.equal([
+        'https://example.my.salesforce.com/services/data/v68.0/tooling/symbols?category=BUILTIN',
+        'https://example.my.salesforce.com/services/data/v68.0/tooling/symbols?category=DATABASE',
+        'https://example.my.salesforce.com/services/data/v68.0/tooling/symbols?category=DYNAMIC',
+      ]);
+    });
+
+    it('preserves and encodes exact lookup filters and result format', () => {
+      const url = buildApexSymbolsUrl('https://example.my.salesforce.com/path', '68.0', {
+        category: 'DATABASE',
+        format: 'TYPE_STUB',
+        namespace: 'My Package/Name',
+        name: 'Outer.Inner?',
+      });
+
+      expect(url).to.equal(
+        'https://example.my.salesforce.com/services/data/v68.0/tooling/symbols?category=DATABASE&format=TYPE_STUB&namespace=My+Package%2FName&name=Outer.Inner%3F'
+      );
+    });
+
+    it('omits undefined filters without changing case', () => {
+      const url = buildApexSymbolsUrl('https://example.my.salesforce.com', '68.0', {
+        category: 'BUILTIN',
+        namespace: 'SyStEm',
+        name: 'sTrInG',
+      });
+
+      expect(url).to.equal(
+        'https://example.my.salesforce.com/services/data/v68.0/tooling/symbols?category=BUILTIN&namespace=SyStEm&name=sTrInG'
+      );
+    });
+
+    it('preserves explicitly empty filters', () => {
+      const url = buildApexSymbolsUrl('https://example.my.salesforce.com', '68.0', {
+        category: 'DYNAMIC',
+        namespace: '',
+        name: '',
+      });
+
+      expect(url).to.equal(
+        'https://example.my.salesforce.com/services/data/v68.0/tooling/symbols?category=DYNAMIC&namespace=&name='
+      );
+    });
+  });
+
+  it('models resolved, recursive, generic, and compile-error type stubs', () => {
+    const response: ApexTypeStubResponse = {
+      typeStubs: [
+        {
+          name: 'List',
+          namespacePrefix: 'System',
+          kind: 'CLASS',
+          modifiers: ['global'],
+          annotations: [],
+          superClass: null,
+          interfaces: [{ namespacePrefix: 'System', name: 'Iterable', typeParameters: null }],
+          typeParameters: [{ namespacePrefix: null, name: 'T', typeParameters: null }],
+          fields: [],
+          properties: [],
+          methods: [],
+          innerTypes: [
+            {
+              name: 'List.Iterator',
+              namespacePrefix: 'System',
+              kind: 'INTERFACE',
+              modifiers: ['global'],
+              annotations: [],
+              interfaces: [],
+              fields: [],
+              properties: [],
+              methods: [],
+              innerTypes: [],
+              compileError: null,
+            },
+          ],
+          triggerOperations: null,
+          triggerObjectType: null,
+          documentation: 'A generic collection.',
+          compileError: null,
+        },
+        {
+          name: 'BrokenClass',
+          namespacePrefix: 'Example',
+          compileError: 'Compilation failed.',
+          kind: null,
+          modifiers: [],
+          annotations: [],
+          interfaces: [],
+          fields: [],
+          properties: [],
+          methods: [],
+          innerTypes: [],
+        },
+      ],
+    };
+
+    expect(response.typeStubs[0].name).to.equal('List');
+    expect(response.typeStubs[1].compileError).to.equal('Compilation failed.');
+  });
+});

--- a/test/unit/org/apexSymbolsErrors.test.ts
+++ b/test/unit/org/apexSymbolsErrors.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { ApexSymbolsStreamResponse } from '../../../src/org/apexSymbols';
+import {
+  APEX_SYMBOLS_ENDPOINT_UNAVAILABLE_ERROR,
+  APEX_SYMBOLS_REQUEST_ERROR,
+  APEX_SYMBOLS_REQUEST_IN_PROGRESS_ERROR,
+  throwIfApexSymbolsErrorResponse,
+} from '../../../src/org/apexSymbolsErrors';
+import { APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR } from '../../../src/org/apexSymbolsTransport';
+import { shouldThrow } from '../../../src/testSetup';
+
+const responseFor = (statusCode: number, body: string): ApexSymbolsStreamResponse => ({
+  apiVersion: '68.0',
+  statusCode,
+  headers: {},
+  body: (async function* (): AsyncIterable<Uint8Array> {
+    yield Buffer.from(body);
+  })(),
+  cancel: () => undefined,
+});
+
+describe('Apex Symbols errors', () => {
+  it('does not consume successful responses', async () => {
+    let consumed = false;
+    const response: ApexSymbolsStreamResponse = {
+      ...responseFor(200, ''),
+      body: (async function* (): AsyncIterable<Uint8Array> {
+        consumed = true;
+        yield Buffer.from('success');
+      })(),
+    };
+
+    await throwIfApexSymbolsErrorResponse(response);
+
+    expect(consumed).to.be.false;
+  });
+
+  it('maps the exact server concurrency error without retrying it', async () => {
+    const response = responseFor(
+      500,
+      JSON.stringify([
+        {
+          message: 'Symbol table request already in progress for this org. Please retry later.',
+          errorCode: 'UNKNOWN_EXCEPTION',
+        },
+      ])
+    );
+
+    try {
+      await shouldThrow(throwIfApexSymbolsErrorResponse(response));
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_REQUEST_IN_PROGRESS_ERROR);
+      expect(error).to.have.nested.property('cause.name', 'UNKNOWN_EXCEPTION');
+    }
+  });
+
+  it('does not misclassify other UNKNOWN_EXCEPTION responses', async () => {
+    const response = responseFor(
+      500,
+      JSON.stringify([{ message: 'A different server failure.', errorCode: 'UNKNOWN_EXCEPTION' }])
+    );
+
+    try {
+      await shouldThrow(throwIfApexSymbolsErrorResponse(response));
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_REQUEST_ERROR);
+      expect(error).to.have.nested.property('cause.name', 'UNKNOWN_EXCEPTION');
+    }
+  });
+
+  it('maps route-level 404 responses to the minimum-release error', async () => {
+    const response = responseFor(404, JSON.stringify([{ message: 'Not Found', errorCode: 'NOT_FOUND' }]));
+
+    try {
+      await shouldThrow(throwIfApexSymbolsErrorResponse(response));
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_ENDPOINT_UNAVAILABLE_ERROR);
+      expect(error).to.have.nested.property('data.minimumOrgRelease', 264);
+      expect(error).to.have.nested.property('data.apiVersion', '68.0');
+    }
+  });
+
+  it('bounds malformed HTTP error bodies', async () => {
+    const response = responseFor(500, 'x'.repeat(1024 * 1024 + 1));
+
+    try {
+      await shouldThrow(throwIfApexSymbolsErrorResponse(response));
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR);
+    }
+  });
+});

--- a/test/unit/org/apexSymbolsMaterializer.test.ts
+++ b/test/unit/org/apexSymbolsMaterializer.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { ApexSymbolsStreamResponse } from '../../../src/org/apexSymbols';
+import {
+  APEX_SYMBOLS_MALFORMED_RESPONSE_ERROR,
+  materializeApexSymbolsResponse,
+} from '../../../src/org/apexSymbolsMaterializer';
+import { APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR } from '../../../src/org/apexSymbolsTransport';
+import { shouldThrow } from '../../../src/testSetup';
+
+const responseFor = (body: string): ApexSymbolsStreamResponse => ({
+  apiVersion: '68.0',
+  statusCode: 200,
+  headers: { 'content-type': 'application/json' },
+  body: (async function* (): AsyncIterable<Uint8Array> {
+    const midpoint = Math.floor(body.length / 2);
+    yield Buffer.from(body.slice(0, midpoint));
+    yield Buffer.from(body.slice(midpoint));
+  })(),
+  cancel: () => undefined,
+});
+
+describe('Apex Symbols materializer', () => {
+  it('materializes a typed response split across chunks', async () => {
+    const result = await materializeApexSymbolsResponse(
+      { category: 'BUILTIN', namespace: 'System', name: 'String', format: 'TYPE_STUB' },
+      responseFor('{"typeStubs":[]}'),
+      { mode: 'materialized' }
+    );
+
+    expect(result).to.deep.equal({ typeStubs: [] });
+  });
+
+  it('treats omitted format as TYPE_STUB', async () => {
+    const result = await materializeApexSymbolsResponse({ category: 'DYNAMIC' }, responseFor('{"typeStubs":[]}'));
+
+    expect(result).to.deep.equal({ typeStubs: [] });
+  });
+
+  it('returns parsed unknown formats without imposing the TYPE_STUB envelope', async () => {
+    const result = await materializeApexSymbolsResponse(
+      { category: 'DATABASE', format: 'FUTURE_FORMAT' },
+      responseFor('{"future":true}')
+    );
+
+    expect(result).to.deep.equal({ future: true });
+  });
+
+  it('rejects malformed JSON', async () => {
+    try {
+      await shouldThrow(materializeApexSymbolsResponse({ category: 'BUILTIN', format: 'TYPE_STUB' }, responseFor('{')));
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_MALFORMED_RESPONSE_ERROR);
+    }
+  });
+
+  it('rejects an invalid TYPE_STUB envelope', async () => {
+    try {
+      await shouldThrow(
+        materializeApexSymbolsResponse({ category: 'BUILTIN', format: 'TYPE_STUB' }, responseFor('{"typeStubs":{}}'))
+      );
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_MALFORMED_RESPONSE_ERROR);
+    }
+  });
+
+  it('enforces the type-stub count limit', async () => {
+    try {
+      await shouldThrow(
+        materializeApexSymbolsResponse(
+          { category: 'DATABASE', format: 'TYPE_STUB' },
+          responseFor('{"typeStubs":[{},{}]}'),
+          { mode: 'materialized', maxTypeStubs: 1 }
+        )
+      );
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR);
+    }
+  });
+
+  it('enforces the per-stub byte limit', async () => {
+    try {
+      await shouldThrow(
+        materializeApexSymbolsResponse(
+          { category: 'DATABASE', format: 'TYPE_STUB' },
+          responseFor('{"typeStubs":[{"name":"LongClassName"}]}'),
+          { mode: 'materialized', maxStubBytes: 5 }
+        )
+      );
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR);
+    }
+  });
+});

--- a/test/unit/org/apexSymbolsMaterializer.test.ts
+++ b/test/unit/org/apexSymbolsMaterializer.test.ts
@@ -37,33 +37,20 @@ const responseFor = (body: string): ApexSymbolsStreamResponse => ({
 
 describe('Apex Symbols materializer', () => {
   it('materializes a typed response split across chunks', async () => {
-    const result = await materializeApexSymbolsResponse(
-      { category: 'BUILTIN', namespace: 'System', name: 'String', format: 'TYPE_STUB' },
-      responseFor('{"typeStubs":[]}'),
-      { mode: 'materialized' }
-    );
+    const result = await materializeApexSymbolsResponse(responseFor('{"typeStubs":[]}'), { mode: 'materialized' });
 
     expect(result).to.deep.equal({ typeStubs: [] });
   });
 
-  it('treats omitted format as TYPE_STUB', async () => {
-    const result = await materializeApexSymbolsResponse({ category: 'DYNAMIC' }, responseFor('{"typeStubs":[]}'));
+  it('uses TYPE_STUB as the sole materialized response contract', async () => {
+    const result = await materializeApexSymbolsResponse(responseFor('{"typeStubs":[]}'));
 
     expect(result).to.deep.equal({ typeStubs: [] });
-  });
-
-  it('returns parsed unknown formats without imposing the TYPE_STUB envelope', async () => {
-    const result = await materializeApexSymbolsResponse(
-      { category: 'DATABASE', format: 'FUTURE_FORMAT' },
-      responseFor('{"future":true}')
-    );
-
-    expect(result).to.deep.equal({ future: true });
   });
 
   it('rejects malformed JSON', async () => {
     try {
-      await shouldThrow(materializeApexSymbolsResponse({ category: 'BUILTIN', format: 'TYPE_STUB' }, responseFor('{')));
+      await shouldThrow(materializeApexSymbolsResponse(responseFor('{')));
     } catch (error) {
       expect(error).to.have.property('name', APEX_SYMBOLS_MALFORMED_RESPONSE_ERROR);
     }
@@ -71,9 +58,7 @@ describe('Apex Symbols materializer', () => {
 
   it('rejects an invalid TYPE_STUB envelope', async () => {
     try {
-      await shouldThrow(
-        materializeApexSymbolsResponse({ category: 'BUILTIN', format: 'TYPE_STUB' }, responseFor('{"typeStubs":{}}'))
-      );
+      await shouldThrow(materializeApexSymbolsResponse(responseFor('{"typeStubs":{}}')));
     } catch (error) {
       expect(error).to.have.property('name', APEX_SYMBOLS_MALFORMED_RESPONSE_ERROR);
     }
@@ -82,11 +67,7 @@ describe('Apex Symbols materializer', () => {
   it('enforces the type-stub count limit', async () => {
     try {
       await shouldThrow(
-        materializeApexSymbolsResponse(
-          { category: 'DATABASE', format: 'TYPE_STUB' },
-          responseFor('{"typeStubs":[{},{}]}'),
-          { mode: 'materialized', maxTypeStubs: 1 }
-        )
+        materializeApexSymbolsResponse(responseFor('{"typeStubs":[{},{}]}'), { mode: 'materialized', maxTypeStubs: 1 })
       );
     } catch (error) {
       expect(error).to.have.property('name', APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR);
@@ -96,11 +77,10 @@ describe('Apex Symbols materializer', () => {
   it('enforces the per-stub byte limit', async () => {
     try {
       await shouldThrow(
-        materializeApexSymbolsResponse(
-          { category: 'DATABASE', format: 'TYPE_STUB' },
-          responseFor('{"typeStubs":[{"name":"LongClassName"}]}'),
-          { mode: 'materialized', maxStubBytes: 5 }
-        )
+        materializeApexSymbolsResponse(responseFor('{"typeStubs":[{"name":"LongClassName"}]}'), {
+          mode: 'materialized',
+          maxStubBytes: 5,
+        })
       );
     } catch (error) {
       expect(error).to.have.property('name', APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR);

--- a/test/unit/org/apexSymbolsTransport.test.ts
+++ b/test/unit/org/apexSymbolsTransport.test.ts
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createServer, Server, ServerResponse } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { gzipSync } from 'node:zlib';
+import { expect } from 'chai';
+import { shouldThrow } from '../../../src/testSetup';
+import {
+  APEX_SYMBOLS_IDLE_TIMEOUT_ERROR,
+  APEX_SYMBOLS_REQUEST_ABORTED_ERROR,
+  APEX_SYMBOLS_REQUEST_TIMEOUT_ERROR,
+  APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR,
+  ApexSymbolsTransportMetrics,
+  ApexSymbolsTransportRequest,
+  requestApexSymbolsStream,
+} from '../../../src/org/apexSymbolsTransport';
+
+const defaultRequest = (url: string): ApexSymbolsTransportRequest => ({
+  url,
+  apiVersion: '68.0',
+  headers: {},
+  timeoutMs: 2_000,
+  idleTimeoutMs: 1_000,
+  maxResponseBytes: 1_000_000,
+});
+
+const collect = async (body: AsyncIterable<Uint8Array>): Promise<string> => {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of body) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+};
+
+describe('Apex Symbols transport', () => {
+  let server: Server | undefined;
+
+  const listen = async (handler: (response: ServerResponse) => void): Promise<string> => {
+    server = createServer((_request, response) => handler(response));
+    await new Promise<void>((resolve, reject) => {
+      server?.once('error', reject);
+      server?.listen(0, '127.0.0.1', resolve);
+    });
+    const address = server.address() as AddressInfo;
+    return `http://127.0.0.1:${address.port}`;
+  };
+
+  afterEach(async () => {
+    server?.closeAllConnections();
+    await new Promise<void>((resolve) => server?.close(() => resolve()) ?? resolve());
+    server = undefined;
+  });
+
+  it('emits bytes before the HTTP response completes', async () => {
+    let responseEnded = false;
+    let metrics: ApexSymbolsTransportMetrics | undefined;
+    const url = await listen((response) => {
+      response.writeHead(200, { 'content-type': 'application/json', 'x-sfdc-request-id': 'request-123' });
+      response.write('{"typeStubs":[');
+      setTimeout(() => {
+        responseEnded = true;
+        response.end(']}');
+      }, 100);
+    });
+
+    const response = await requestApexSymbolsStream({
+      ...defaultRequest(url),
+      onComplete: (value): void => {
+        metrics = value;
+      },
+    });
+    const iterator = response.body[Symbol.asyncIterator]();
+    const first = await iterator.next();
+
+    if (first.done) {
+      expect.fail('Expected the first response chunk before stream completion.');
+    }
+    expect(Buffer.from(first.value).toString('utf8')).to.equal('{"typeStubs":[');
+    expect(responseEnded).to.be.false;
+
+    const remaining = await collect({ [Symbol.asyncIterator]: () => iterator });
+    expect(remaining).to.equal(']}');
+    expect(metrics).to.deep.include({
+      apiVersion: '68.0',
+      statusCode: 200,
+      responseBytes: Buffer.byteLength('{"typeStubs":[]}'),
+      requestId: 'request-123',
+    });
+    expect(metrics?.timeToFirstByteMs).to.be.a('number');
+    expect(metrics?.totalTimeMs).to.be.a('number');
+  });
+
+  it('cancels the underlying HTTP request', async () => {
+    let resolveClosed: (() => void) | undefined;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+    const url = await listen((response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      const interval = setInterval(() => response.write('data'), 10);
+      response.once('close', () => {
+        clearInterval(interval);
+        resolveClosed?.();
+      });
+    });
+
+    const response = await requestApexSymbolsStream(defaultRequest(url));
+    const iterator = response.body[Symbol.asyncIterator]();
+    await iterator.next();
+    response.cancel();
+    await closed;
+    await iterator.return?.();
+  });
+
+  it('does not retry HTTP 420 responses', async () => {
+    let requestCount = 0;
+    const url = await listen((response) => {
+      requestCount += 1;
+      response.writeHead(420, { 'content-type': 'application/json' });
+      response.end('[]');
+    });
+
+    const response = await requestApexSymbolsStream(defaultRequest(url));
+
+    expect(response.statusCode).to.equal(420);
+    expect(await collect(response.body)).to.equal('[]');
+    expect(requestCount).to.equal(1);
+  });
+
+  it('rejects a response whose content-length exceeds the byte limit', async () => {
+    const url = await listen((response) => {
+      response.writeHead(200, { 'content-type': 'application/json', 'content-length': '20' });
+      response.end('x'.repeat(20));
+    });
+
+    try {
+      await shouldThrow(requestApexSymbolsStream({ ...defaultRequest(url), maxResponseBytes: 10 }));
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR);
+    }
+  });
+
+  it('enforces the incremental byte limit when content-length is absent', async () => {
+    const url = await listen((response) => {
+      response.writeHead(200, { 'content-type': 'application/json', 'transfer-encoding': 'chunked' });
+      response.write('123456');
+      response.end('7890');
+    });
+    const response = await requestApexSymbolsStream({ ...defaultRequest(url), maxResponseBytes: 5 });
+
+    try {
+      await shouldThrow(collect(response.body));
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR);
+    }
+  });
+
+  it('enforces the byte limit against the decompressed response', async () => {
+    const compressed = gzipSync('x'.repeat(10_000));
+    const url = await listen((response) => {
+      response.writeHead(200, {
+        'content-type': 'application/json',
+        'content-encoding': 'gzip',
+        'content-length': compressed.byteLength,
+      });
+      response.end(compressed);
+    });
+    const response = await requestApexSymbolsStream({ ...defaultRequest(url), maxResponseBytes: 5_000 });
+
+    try {
+      await shouldThrow(collect(response.body));
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR);
+    }
+  });
+
+  it('aborts when the total timeout expires before response headers arrive', async () => {
+    const url = await listen((response) => {
+      setTimeout(() => response.end('{}'), 200);
+    });
+
+    try {
+      await shouldThrow(requestApexSymbolsStream({ ...defaultRequest(url), timeoutMs: 25 }));
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_REQUEST_TIMEOUT_ERROR);
+    }
+  });
+
+  it('aborts an idle response', async () => {
+    const url = await listen((response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.write('first');
+      setTimeout(() => response.end('second'), 200);
+    });
+    const response = await requestApexSymbolsStream({ ...defaultRequest(url), idleTimeoutMs: 25 });
+    const iterator = response.body[Symbol.asyncIterator]();
+    await iterator.next();
+
+    try {
+      await shouldThrow(iterator.next());
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_IDLE_TIMEOUT_ERROR);
+    }
+  });
+
+  it('does not send an already-aborted request', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    try {
+      await shouldThrow(
+        requestApexSymbolsStream({ ...defaultRequest('http://127.0.0.1:1'), signal: controller.signal })
+      );
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_REQUEST_ABORTED_ERROR);
+    }
+  });
+});

--- a/test/unit/org/apexTypeStubIterator.test.ts
+++ b/test/unit/org/apexTypeStubIterator.test.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { shouldThrow } from '../../../src/testSetup';
+import { APEX_SYMBOLS_MALFORMED_RESPONSE_ERROR } from '../../../src/org/apexSymbolsErrors';
+import {
+  APEX_SYMBOLS_REQUEST_ABORTED_ERROR,
+  APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR,
+} from '../../../src/org/apexSymbolsTransport';
+import { iterateApexTypeStubs } from '../../../src/org/apexTypeStubIterator';
+
+const bodyFor = (json: string, chunkBytes = json.length): AsyncIterable<Uint8Array> =>
+  (async function* (): AsyncIterable<Uint8Array> {
+    const bytes = Buffer.from(json);
+    for (let offset = 0; offset < bytes.byteLength; offset += chunkBytes) {
+      yield bytes.subarray(offset, offset + chunkBytes);
+    }
+  })();
+
+const collect = async (body: AsyncIterable<unknown>): Promise<unknown[]> => {
+  const values: unknown[] = [];
+  for await (const value of body) {
+    values.push(value);
+  }
+  return values;
+};
+
+describe('Apex type-stub iterator', () => {
+  it('emits stubs across one-byte UTF-8 boundaries without retaining the envelope', async () => {
+    const values = await collect(
+      iterateApexTypeStubs(
+        bodyFor(
+          '{"requestId":"ignored","typeStubs":[{"name":"Café","compileError":null},{"name":"Broken","compileError":"bad"}],"more":"ignored"}',
+          1
+        )
+      )
+    );
+
+    expect(values).to.deep.equal([
+      { name: 'Café', compileError: null },
+      { name: 'Broken', compileError: 'bad' },
+    ]);
+  });
+
+  it('does not pull another upstream chunk until the emitted stub is consumed', async () => {
+    let pulls = 0;
+    let sourceClosed = false;
+    const body = (async function* (): AsyncIterable<Uint8Array> {
+      try {
+        pulls += 1;
+        yield Buffer.from('{"typeStubs":[{"name":"One"}');
+        pulls += 1;
+        yield Buffer.from(',{"name":"Two"}]}');
+      } finally {
+        sourceClosed = true;
+      }
+    })();
+    const iterator = iterateApexTypeStubs(body)[Symbol.asyncIterator]();
+
+    expect(await iterator.next()).to.deep.include({ done: false, value: { name: 'One' } });
+    expect(pulls).to.equal(1);
+
+    await iterator.return?.();
+    expect(sourceClosed).to.be.true;
+  });
+
+  it('accepts an empty typeStubs array', async () => {
+    expect(await collect(iterateApexTypeStubs(bodyFor('{"typeStubs":[]}')))).to.deep.equal([]);
+  });
+
+  for (const [description, json] of [
+    ['a non-object envelope', '[]'],
+    ['a missing typeStubs field', '{"other":[]}'],
+    ['a non-array typeStubs field', '{"typeStubs":{}}'],
+    ['a duplicate typeStubs field', '{"typeStubs":[],"typeStubs":[]}'],
+    ['a non-object type stub', '{"typeStubs":[null]}'],
+    ['a truncated response', '{"typeStubs":[{"name":"A"}'],
+    ['trailing JSON', '{"typeStubs":[]}{}'],
+  ] as const) {
+    it(`rejects ${description}`, async () => {
+      try {
+        await shouldThrow(collect(iterateApexTypeStubs(bodyFor(json, 1))));
+      } catch (error) {
+        expect(error).to.have.property('name', APEX_SYMBOLS_MALFORMED_RESPONSE_ERROR);
+      }
+    });
+  }
+
+  it('enforces the total response byte limit', async () => {
+    try {
+      await shouldThrow(collect(iterateApexTypeStubs(bodyFor('{"typeStubs":[]}'), { maxResponseBytes: 5 })));
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR);
+    }
+  });
+
+  it('enforces the type-stub count limit before emitting an extra stub', async () => {
+    try {
+      await shouldThrow(collect(iterateApexTypeStubs(bodyFor('{"typeStubs":[{},{}]}'), { maxTypeStubs: 1 })));
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR);
+    }
+  });
+
+  it('enforces the per-stub byte limit while a stub is still being parsed', async () => {
+    let sourceClosed = false;
+    const body = (async function* (): AsyncIterable<Uint8Array> {
+      try {
+        yield Buffer.from(`{"typeStubs":[{"documentation":"${'x'.repeat(100_000)}"}]}`);
+      } finally {
+        sourceClosed = true;
+      }
+    })();
+
+    try {
+      await shouldThrow(collect(iterateApexTypeStubs(body, { maxStubBytes: 1_000 })));
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR);
+      expect(sourceClosed).to.be.true;
+    }
+  });
+
+  it('honors a pre-aborted signal without pulling from the body', async () => {
+    let pulled = false;
+    const body = (async function* (): AsyncIterable<Uint8Array> {
+      pulled = true;
+      yield Buffer.from('{"typeStubs":[]}');
+    })();
+    const controller = new AbortController();
+    controller.abort();
+
+    try {
+      await shouldThrow(collect(iterateApexTypeStubs(body, { signal: controller.signal })));
+    } catch (error) {
+      expect(error).to.have.property('name', APEX_SYMBOLS_REQUEST_ABORTED_ERROR);
+      expect(pulled).to.be.false;
+    }
+  });
+});

--- a/test/unit/org/apexTypeStubMemory.fixture.ts
+++ b/test/unit/org/apexTypeStubMemory.fixture.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApexSymbolsStreamResponse } from '../../../src/org/apexSymbols';
+import { materializeApexSymbolsResponse } from '../../../src/org/apexSymbolsMaterializer';
+import { APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR } from '../../../src/org/apexSymbolsTransport';
+import { iterateApexTypeStubs } from '../../../src/org/apexTypeStubIterator';
+
+const stubCount = 2_048;
+const documentation = 'x'.repeat(64 * 1024);
+
+const syntheticBody = (): AsyncIterable<Uint8Array> =>
+  (async function* (): AsyncIterable<Uint8Array> {
+    yield Buffer.from('{"typeStubs":[');
+    for (let index = 0; index < stubCount; index += 1) {
+      yield Buffer.from(`${index === 0 ? '' : ','}{"name":"Class${index}","documentation":"${documentation}"}`);
+    }
+    yield Buffer.from(']}');
+  })();
+
+const streamResponse = (): ApexSymbolsStreamResponse => ({
+  apiVersion: '68.0',
+  statusCode: 200,
+  headers: {},
+  body: syntheticBody(),
+  cancel: () => undefined,
+});
+
+const run = async (): Promise<void> => {
+  let emitted = 0;
+  let peakRss = process.memoryUsage().rss;
+  for await (const stub of iterateApexTypeStubs(syntheticBody(), {
+    maxResponseBytes: 160 * 1024 * 1024,
+    maxTypeStubs: stubCount,
+    maxStubBytes: 70 * 1024,
+  })) {
+    if (!stub.name) {
+      throw new Error('The memory fixture received a type stub without a name.');
+    }
+    emitted += 1;
+    peakRss = Math.max(peakRss, process.memoryUsage().rss);
+  }
+
+  let materializedError: string | undefined;
+  try {
+    await materializeApexSymbolsResponse({ category: 'DATABASE', format: 'TYPE_STUB' }, streamResponse(), {
+      mode: 'materialized',
+      maxResponseBytes: 4 * 1024 * 1024,
+      maxTypeStubs: stubCount,
+      maxStubBytes: 70 * 1024,
+    });
+  } catch (error) {
+    materializedError = error instanceof Error ? error.name : undefined;
+  }
+
+  process.stdout.write(
+    JSON.stringify({
+      emitted,
+      totalResponseBytes: stubCount * documentation.length,
+      peakRss,
+      materializedError,
+      expectedMaterializedError: APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR,
+    })
+  );
+};
+
+void run();

--- a/test/unit/org/apexTypeStubMemory.fixture.ts
+++ b/test/unit/org/apexTypeStubMemory.fixture.ts
@@ -56,7 +56,7 @@ const run = async (): Promise<void> => {
 
   let materializedError: string | undefined;
   try {
-    await materializeApexSymbolsResponse({ category: 'DATABASE', format: 'TYPE_STUB' }, streamResponse(), {
+    await materializeApexSymbolsResponse(streamResponse(), {
       mode: 'materialized',
       maxResponseBytes: 4 * 1024 * 1024,
       maxTypeStubs: stubCount,

--- a/test/unit/org/apexTypeStubMemory.test.ts
+++ b/test/unit/org/apexTypeStubMemory.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { execFile } from 'node:child_process';
+import { resolve } from 'node:path';
+import { expect } from 'chai';
+import { APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR } from '../../../src/org/apexSymbolsTransport';
+
+type MemoryResult = {
+  emitted: number;
+  totalResponseBytes: number;
+  peakRss: number;
+  materializedError?: string;
+};
+
+const runMemoryFixture = async (): Promise<MemoryResult> =>
+  new Promise((resolvePromise, reject) => {
+    execFile(
+      process.execPath,
+      [
+        '--max-old-space-size=96',
+        '-r',
+        'ts-node/register/transpile-only',
+        resolve('test/unit/org/apexTypeStubMemory.fixture.ts'),
+      ],
+      { timeout: 20_000 },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(`Apex Symbols memory fixture failed: ${stderr || error.message}`));
+          return;
+        }
+        resolvePromise(JSON.parse(stdout) as MemoryResult);
+      }
+    );
+  });
+
+describe('Apex type-stub iterator memory', () => {
+  it('consumes a response larger than the heap and bounds materialization', async () => {
+    const result = await runMemoryFixture();
+
+    expect(result.emitted).to.equal(2_048);
+    expect(result.totalResponseBytes).to.be.greaterThan(128 * 1024 * 1024 - 1);
+    expect(result.peakRss).to.be.lessThan(256 * 1024 * 1024);
+    expect(result.materializedError).to.equal(APEX_SYMBOLS_RESPONSE_TOO_LARGE_ERROR);
+  });
+});

--- a/test/unit/org/connection.test.ts
+++ b/test/unit/org/connection.test.ts
@@ -20,7 +20,7 @@ import { fromStub, StubbedType, stubInterface, stubMethod } from '@salesforce/ts
 import { Duration } from '@salesforce/kit';
 import { Connection as JSForceConnection, HttpRequest } from '@jsforce/jsforce-node';
 import { AuthInfo } from '../../../src/org/authInfo';
-import { ApexSymbolsStreamResponse } from '../../../src/org/apexSymbols';
+import { ApexSymbolsStreamResponse, ApexTypeStubResponse } from '../../../src/org/apexSymbols';
 import * as apexSymbolsTransport from '../../../src/org/apexSymbolsTransport';
 import { MyDomainResolver } from '../../../src/status/myDomainResolver';
 import { Connection, DNS_ERROR_NAME, SFDX_HTTP_HEADERS, SingleRecordQueryErrors } from '../../../src/org/connection';
@@ -272,7 +272,7 @@ describe('Connection', () => {
     const debugStub = $$.SANDBOX.stub(conn['logger'].getRawLogger(), 'debug');
 
     const result = await conn.retrieveApexSymbols(
-      { category: 'DYNAMIC', format: 'TYPE_STUB', namespace: 'Example', name: 'DynamicClass' },
+      { category: 'DYNAMIC', namespace: 'Example', name: 'DynamicClass' },
       { mode: 'stream', timeoutMs: 100, idleTimeoutMs: 50, maxResponseBytes: 1_000 }
     );
 
@@ -280,7 +280,7 @@ describe('Connection', () => {
     expect(conn.getApiVersion()).to.equal('42.0');
     expect(transportStub.calledOnce).to.be.true;
     expect(transportStub.firstCall.args[0]).to.deep.include({
-      url: 'https://connectiontest/services/data/v50.0/tooling/symbols?category=DYNAMIC&format=TYPE_STUB&namespace=Example&name=DynamicClass',
+      url: 'https://connectiontest/services/data/v50.0/tooling/symbols?category=DYNAMIC&namespace=Example&name=DynamicClass',
       apiVersion: '50.0',
       timeoutMs: 100,
       idleTimeoutMs: 50,
@@ -302,7 +302,6 @@ describe('Connection', () => {
     expect(debugStub.lastCall.args[0]).to.deep.include({
       event: 'apexSymbolsRequest',
       category: 'DYNAMIC',
-      format: 'TYPE_STUB',
       hasNamespaceFilter: true,
       hasNameFilter: true,
       apiVersion: '50.0',
@@ -328,7 +327,11 @@ describe('Connection', () => {
       connectionOptions: { version: '42.0' },
     });
 
-    const result = await conn.retrieveApexSymbols({ category: 'BUILTIN', namespace: 'System', name: 'String' });
+    const result: ApexTypeStubResponse = await conn.retrieveApexSymbols({
+      category: 'BUILTIN',
+      namespace: 'System',
+      name: 'String',
+    });
 
     expect(result).to.deep.equal({ typeStubs: [] });
     expect(conn.getApiVersion()).to.equal('42.0');

--- a/test/unit/org/connection.test.ts
+++ b/test/unit/org/connection.test.ts
@@ -20,6 +20,8 @@ import { fromStub, StubbedType, stubInterface, stubMethod } from '@salesforce/ts
 import { Duration } from '@salesforce/kit';
 import { Connection as JSForceConnection, HttpRequest } from '@jsforce/jsforce-node';
 import { AuthInfo } from '../../../src/org/authInfo';
+import { ApexSymbolsStreamResponse } from '../../../src/org/apexSymbols';
+import * as apexSymbolsTransport from '../../../src/org/apexSymbolsTransport';
 import { MyDomainResolver } from '../../../src/status/myDomainResolver';
 import { Connection, DNS_ERROR_NAME, SFDX_HTTP_HEADERS, SingleRecordQueryErrors } from '../../../src/org/connection';
 import { shouldThrow, shouldThrowSync, TestContext } from '../../../src/testSetup';
@@ -244,6 +246,94 @@ describe('Connection', () => {
     expect(requestMock.secondCall.args[0]).to.deep.equal(expectedRequestInfo);
     expect(requestMock.secondCall.args[1]).to.be.undefined;
     expect(response1).to.deep.equal(testResponse);
+  });
+
+  it('retrieveApexSymbols() streams with the server maximum version without mutating the connection version', async () => {
+    testAuthInfoWithDomain.getConnectionOptions.returns({
+      ...testConnectionOptions,
+      instanceUrl: 'https://connectionTest/instanceUrl',
+      accessToken: 'test-access-token',
+      httpProxy: 'http://localhost:8080',
+    });
+    const streamResponse: ApexSymbolsStreamResponse = {
+      apiVersion: '50.0',
+      statusCode: 200,
+      headers: {},
+      body: (async function* (): AsyncIterable<Uint8Array> {
+        yield Buffer.from('{"typeStubs":[]}');
+      })(),
+      cancel: () => undefined,
+    };
+    const transportStub = $$.SANDBOX.stub(apexSymbolsTransport, 'requestApexSymbolsStream').resolves(streamResponse);
+    const conn = await Connection.create({
+      authInfo: fromStub(testAuthInfoWithDomain),
+      connectionOptions: { version: '42.0' },
+    });
+    const debugStub = $$.SANDBOX.stub(conn['logger'].getRawLogger(), 'debug');
+
+    const result = await conn.retrieveApexSymbols(
+      { category: 'DYNAMIC', format: 'TYPE_STUB', namespace: 'Example', name: 'DynamicClass' },
+      { mode: 'stream', timeoutMs: 100, idleTimeoutMs: 50, maxResponseBytes: 1_000 }
+    );
+
+    expect(result).to.equal(streamResponse);
+    expect(conn.getApiVersion()).to.equal('42.0');
+    expect(transportStub.calledOnce).to.be.true;
+    expect(transportStub.firstCall.args[0]).to.deep.include({
+      url: 'https://connectiontest/services/data/v50.0/tooling/symbols?category=DYNAMIC&format=TYPE_STUB&namespace=Example&name=DynamicClass',
+      apiVersion: '50.0',
+      timeoutMs: 100,
+      idleTimeoutMs: 50,
+      maxResponseBytes: 1_000,
+      httpProxy: 'http://localhost:8080',
+    });
+    expect(transportStub.firstCall.args[0].headers).to.include({
+      authorization: 'Bearer test-access-token',
+    });
+    expect(transportStub.firstCall.args[0].headers['sforce-call-options']).to.contain('client=sfdx toolbelt:');
+    transportStub.firstCall.args[0].onComplete?.({
+      apiVersion: '50.0',
+      statusCode: 200,
+      timeToFirstByteMs: 10,
+      totalTimeMs: 20,
+      responseBytes: 100,
+      requestId: 'request-123',
+    });
+    expect(debugStub.lastCall.args[0]).to.deep.include({
+      event: 'apexSymbolsRequest',
+      category: 'DYNAMIC',
+      format: 'TYPE_STUB',
+      hasNamespaceFilter: true,
+      hasNameFilter: true,
+      apiVersion: '50.0',
+      requestId: 'request-123',
+    });
+    expect(JSON.stringify(debugStub.lastCall.args[0])).not.to.contain('Example');
+    expect(JSON.stringify(debugStub.lastCall.args[0])).not.to.contain('DynamicClass');
+  });
+
+  it('retrieveApexSymbols() defaults to bounded TYPE_STUB materialization', async () => {
+    const streamResponse: ApexSymbolsStreamResponse = {
+      apiVersion: '50.0',
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: (async function* (): AsyncIterable<Uint8Array> {
+        yield Buffer.from('{"typeStubs":[]}');
+      })(),
+      cancel: () => undefined,
+    };
+    const transportStub = $$.SANDBOX.stub(apexSymbolsTransport, 'requestApexSymbolsStream').resolves(streamResponse);
+    const conn = await Connection.create({
+      authInfo: fromStub(testAuthInfoWithDomain),
+      connectionOptions: { version: '42.0' },
+    });
+
+    const result = await conn.retrieveApexSymbols({ category: 'BUILTIN', namespace: 'System', name: 'String' });
+
+    expect(result).to.deep.equal({ typeStubs: [] });
+    expect(conn.getApiVersion()).to.equal('42.0');
+    expect(transportStub.calledOnce).to.be.true;
+    expect(transportStub.firstCall.args[0].maxResponseBytes).to.equal(64 * 1024 * 1024);
   });
 
   it('request() should add SFDX headers and call super() for a RequestInfo and options arg', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,6 +977,11 @@
   resolved "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz"
   integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
 
+"@streamparser/json@^0.0.26":
+  version "0.0.26"
+  resolved "https://registry.yarnpkg.com/@streamparser/json/-/json-0.0.26.tgz#b78d7da6c3ad426e075b0669feabcfeac91ce57b"
+  integrity sha512-46597LNFI+MFdUnzX2QJWwmdTRdq0XVD+vVNJTtGVzIrnCuhG9pFo1OAzbNBqci8UJgk/X5KJZ6LcV+y7PTuDQ==
+
 "@tony.ganchev/eslint-plugin-header@^3.4.4":
   version "3.4.4"
   resolved "https://registry.yarnpkg.com/@tony.ganchev/eslint-plugin-header/-/eslint-plugin-header-3.4.4.tgz#7cda6401851b801d5d7b02bbdf82a15e5174a08a"
@@ -5497,6 +5502,11 @@ undici@^8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-8.5.0.tgz#31ba9021a3d84c15e61cc5e28be2d7c451e66a66"
   integrity sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==
+
+undici@^8.9.0:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-8.10.0.tgz#67ed7c4087f0f40fba7bef3a46f2be80572f2473"
+  integrity sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==
 
 unist-util-is@^6.0.0:
   version "6.0.1"


### PR DESCRIPTION
## Summary

- expose the Tooling Apex Symbols endpoint through Connection.retrieveApexSymbols()
- support BUILTIN, DATABASE, and DYNAMIC Apex categories with materialized and raw streaming modes
- expose TYPE_STUB as the single current response contract; format is implicit and is not a public request option
- add incremental type-stub iteration with response, item-count, and per-stub bounds
- use a cancellable direct Undici transport with no retry, queueing, coalescing, or local concurrency guard
- raise the Node minimum to 22.19 and use patched Undici 8.x

## Behavior

- materialized calls return ApexTypeStubResponse; explicit stream mode returns ApexSymbolsStreamResponse for the same TYPE_STUB payload
- resolves the server maximum REST API version without mutating the Connection version
- maps endpoint-unavailable and request-in-progress responses to stable Core errors
- supports proxy configuration, gzip decompression, total and idle timeouts, caller abort, and early-consumer cancellation
- logs diagnostic summaries without namespace or artifact names

## Verification

- repository pre-push workflow passed
- 1,214 unit tests passed with 2 pending
- 57 NUT tests passed
- full lint, source and test type checks, bundle check, and frozen-lockfile install passed
- memory regression consumed a 128 MiB synthetic response under a 96 MiB V8 heap cap and verified deterministic bounded-materialization failure

## Work item

[W-23973889](https://gus.lightning.force.com/a07EE00002ifSUUYA2)