### PR TITLE
W-23663641: bump jsforce

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "messageTransformer/messageTransformer.ts"
   ],
   "dependencies": {
-    "@jsforce/jsforce-node": "^3.10.23",
+    "@jsforce/jsforce-node": "^3.10.24",
     "@salesforce/kit": "^4.0.0",
     "@salesforce/ts-types": "^3.0.0",
     "ajv": "^8.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -694,10 +694,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@jsforce/jsforce-node@^3.10.23":
-  version "3.10.23"
-  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.23.tgz#464be5621ee638a29d3bd43d97ade5b16470118f"
-  integrity sha512-sepBNb9Bt0vSdXqZqq97p/EP8NJjjOnDQoRmiH2Lcm/nsznQsrsUttoNmNxfxrRubuJTIL9m4H1I7uOb8HrgRg==
+"@jsforce/jsforce-node@^3.10.24":
+  version "3.10.24"
+  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.24.tgz#e5e7a32dec73373c370c339295f18c7325b991fc"
+  integrity sha512-EejRrqFmn5No4lCiHYPlN5UFRCLo7gEoflNNisxca8AMZFzEO+sdj/aUHGzjzXf4a9K2cbXNZ+4eL4lkiIEsGw==
   dependencies:
     "@sindresorhus/is" "^4"
     base64url "^3.0.1"


### PR DESCRIPTION
### What does this PR do?
bumps jsforce to support jwt-based Access tokens in api version 68+ 

### What issues does this PR fix or reference?
[@W-23663641@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-23663641)