### PR TITLE
fix(W-24027084): add salesforce.mil to allowlisted Salesforce domains

### DIFF
--- a/src/util/sfdcUrl.ts
+++ b/src/util/sfdcUrl.ts
@@ -118,6 +118,7 @@ export class SfdcUrl extends URL {
       '.force.com',
       '.salesforce.com',
       '.salesforceliveagent.com',
+      '.salesforce.mil',
       '.secure.force.com',
       '.crmforce.mil',
       '.sfcrmproducts.cn',

--- a/test/unit/util/sfdcUrl.test.ts
+++ b/test/unit/util/sfdcUrl.test.ts
@@ -161,6 +161,11 @@ describe('util/sfdcUrl', () => {
       expect(url.isSalesforceDomain()).to.be.true;
     });
 
+    it('is allowlist mil domain', () => {
+      const url = new SfdcUrl('https://foo.my.salesforce.mil');
+      expect(url.isSalesforceDomain()).to.be.true;
+    });
+
     it('cnEdition', () => {
       const url = new SfdcUrl('https://foo.my.sfcrmproducts.cn');
       expect(url.isSalesforceDomain()).to.be.true;


### PR DESCRIPTION
### What does this PR do?

Adds `.salesforce.mil` to the list of allowlisted Salesforce domains in `SfdcUrl` so that URLs on that domain (e.g. `https://foo.my.salesforce.mil`)
are correctly recognized as Salesforce domains by `isSalesforceDomain()`.

### What issues does this PR fix or reference?

[@W-24027084@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002j5itrYAA/view)

Covered by a new unit test in test/unit/util/sfdcUrl.test.ts that asserts isSalesforceDomain() returns true for a .salesforce.mil URL.
