### PR TITLE
fix: speed up org login by optimizing identifyPossibleScratchOrgs @W-23969733@

### DIFF
--- a/messages/envVars.md
+++ b/messages/envVars.md
@@ -319,3 +319,7 @@ Your environment has both variables populated, and with different values. The va
 # sfCapitalizeRecordTypes
 
 Whether record types are capitalized on scratch org creation.
+
+# sfSkipScratchOrgCheck
+
+Set to "true" to skip the scratch org and sandbox identification check that runs after authenticating an org. When enabled, `sf org login jwt` (and other login commands) will not query existing cached orgs to determine whether the newly authenticated org is a scratch org or sandbox. This can significantly speed up authentication in CI/CD environments with many cached org authorizations.

--- a/src/config/envVars.ts
+++ b/src/config/envVars.ts
@@ -101,6 +101,7 @@ export enum EnvironmentVariable {
   'SF_INSTALLER' = 'SF_INSTALLER',
   'SF_ENV' = 'SF_ENV',
   'SF_CAPITALIZE_RECORD_TYPES' = 'SF_CAPITALIZE_RECORD_TYPES',
+  'SF_SKIP_SCRATCH_ORG_CHECK' = 'SF_SKIP_SCRATCH_ORG_CHECK',
 }
 type EnvMetaData = {
   description: string;
@@ -429,6 +430,10 @@ export const SUPPORTED_ENV_VARS: EnvType = {
   },
   [EnvironmentVariable.SF_CAPITALIZE_RECORD_TYPES]: {
     description: getMessage(EnvironmentVariable.SF_CAPITALIZE_RECORD_TYPES),
+    synonymOf: null,
+  },
+  [EnvironmentVariable.SF_SKIP_SCRATCH_ORG_CHECK]: {
+    description: getMessage(EnvironmentVariable.SF_SKIP_SCRATCH_ORG_CHECK),
     synonymOf: null,
   },
 };

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -430,11 +430,9 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     // TODO: return if url is not sandbox-like to avoid constantly asking about production orgs
     // TODO: someday we make this easier by asking the org if it is a scratch org
 
-    const hubAuthInfos = await AuthInfo.getDevHubAuthInfos();
-    // Get a list of org auths that are known not to be scratch orgs or sandboxes.
-    const possibleProdOrgs = await AuthInfo.listAllAuthorizations(
-      (orgAuth) => orgAuth && !orgAuth.isScratchOrg && !orgAuth.isSandbox
-    );
+    const allOrgs = await AuthInfo.listAllAuthorizations();
+    const hubAuthInfos = allOrgs.filter((org) => org.isDevHub);
+    const possibleProdOrgs = allOrgs.filter((org) => !org.isScratchOrg && !org.isSandbox);
 
     logger.debug(`found ${hubAuthInfos.length} DevHubs`);
     logger.debug(`found ${possibleProdOrgs.length} possible prod orgs`);

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -299,23 +299,26 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
         // prevent ConfigFile collision bug
         // eslint-disable-next-line no-await-in-loop
         const authInfo = await AuthInfo.create({ username });
-        const { orgId, instanceUrl, devHubUsername, expirationDate, isDevHub } = authInfo.getFields();
+        const authFields = authInfo.getFields();
+        const { orgId, instanceUrl, devHubUsername, expirationDate, isDevHub } = authFields;
+        const isScratchOrg = Boolean(devHubUsername) || Boolean(authFields[Org.Fields.IS_SCRATCH]);
+        const expDate = expirationDate ?? authFields[Org.Fields.TRIAL_EXPIRATION_DATE];
+        // eslint-disable-next-line no-await-in-loop
+        const hasSandboxFile = await stateAggregator.sandboxes.hasFile(orgId as string);
+        const isSandbox = Boolean(authFields[Org.Fields.IS_SANDBOX]) || hasSandboxFile;
         final.push({
           aliases,
           configs,
           username,
           instanceUrl,
-          isScratchOrg: Boolean(devHubUsername),
+          isScratchOrg,
           isDevHub: isDevHub ?? false,
-          // eslint-disable-next-line no-await-in-loop
-          isSandbox: await stateAggregator.sandboxes.hasFile(orgId as string),
+          isSandbox,
           orgId: orgId as string,
           accessToken: authInfo.getConnectionOptions().accessToken,
           oauthMethod: authInfo.isJwt() ? 'jwt' : authInfo.isOauth() ? 'web' : 'token',
           isExpired:
-            Boolean(devHubUsername) && expirationDate
-              ? new Date(ensureString(expirationDate)).getTime() < new Date().getTime()
-              : 'unknown',
+            isScratchOrg && expDate ? new Date(ensureString(expDate)).getTime() < new Date().getTime() : 'unknown',
         });
       } catch (err) {
         final.push({
@@ -422,8 +425,23 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
 
     await determineOrg(orgAuthInfo);
 
+    // re-read fields after determineOrg may have updated them
+    const updatedFields = orgAuthInfo.getFields();
+
     // return if we already know the hub org, we know it is a devhub or prod-like, or no orgId present
-    if (Boolean(fields.isDevHub) || Boolean(fields.devHubUsername) || !fields.orgId) return;
+    if (Boolean(updatedFields.isDevHub) || Boolean(updatedFields.devHubUsername) || !updatedFields.orgId) return;
+
+    // if determineOrg already identified this as a scratch org or sandbox, skip the expensive
+    // loop over all cached orgs. The only thing we miss is devHubUsername/expirationDate for
+    // scratch orgs, which can be lazily populated later.
+    if (updatedFields.isScratch || updatedFields.isSandbox) {
+      logger.debug(
+        `determineOrg already identified org as ${
+          updatedFields.isScratch ? 'scratch' : 'sandbox'
+        }, skipping expensive org scan`
+      );
+      return;
+    }
 
     logger.debug('getting devHubs and prod orgs to identify scratch orgs and sandboxes');
 

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -427,12 +427,17 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
 
     logger.debug('getting devHubs and prod orgs to identify scratch orgs and sandboxes');
 
-    // TODO: return if url is not sandbox-like to avoid constantly asking about production orgs
     // TODO: someday we make this easier by asking the org if it is a scratch org
 
     const allOrgs = await AuthInfo.listAllAuthorizations();
     const hubAuthInfos = allOrgs.filter((org) => org.isDevHub);
-    const possibleProdOrgs = allOrgs.filter((org) => !org.isScratchOrg && !org.isSandbox);
+
+    // skip sandbox identification if the instance URL is not sandbox-like
+    const isSandboxLikeUrl = fields.instanceUrl?.includes('.sandbox.');
+    const possibleProdOrgs = isSandboxLikeUrl ? allOrgs.filter((org) => !org.isScratchOrg && !org.isSandbox) : [];
+    if (!isSandboxLikeUrl) {
+      logger.debug('instance URL is not sandbox-like, skipping sandbox identification');
+    }
 
     logger.debug(`found ${hubAuthInfos.length} DevHubs`);
     logger.debug(`found ${possibleProdOrgs.length} possible prod orgs`);

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -433,7 +433,9 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     const hubAuthInfos = allOrgs.filter((org) => org.isDevHub);
 
     // skip sandbox identification if the instance URL is not sandbox-like
-    const isSandboxLikeUrl = fields.instanceUrl?.includes('.sandbox.');
+    // enhanced domains: *.sandbox.my.salesforce.com; pre-enhanced My Domain: company--sbxname.my.salesforce.com
+    const isSandboxLikeUrl =
+      fields.instanceUrl != null && (fields.instanceUrl.includes('.sandbox.') || fields.instanceUrl.includes('--'));
     const possibleProdOrgs = isSandboxLikeUrl ? allOrgs.filter((org) => !org.isScratchOrg && !org.isSandbox) : [];
     if (!isSandboxLikeUrl) {
       logger.debug('instance URL is not sandbox-like, skipping sandbox identification');

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -431,15 +431,40 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     // return if we already know the hub org, we know it is a devhub or prod-like, or no orgId present
     if (Boolean(updatedFields.isDevHub) || Boolean(updatedFields.devHubUsername) || !updatedFields.orgId) return;
 
-    // if determineOrg already identified this as a scratch org or sandbox, skip the expensive
-    // loop over all cached orgs. The only thing we miss is devHubUsername/expirationDate for
-    // scratch orgs, which can be lazily populated later.
-    if (updatedFields.isScratch || updatedFields.isSandbox) {
-      logger.debug(
-        `determineOrg already identified org as ${
-          updatedFields.isScratch ? 'scratch' : 'sandbox'
-        }, skipping expensive org scan`
-      );
+    if (updatedFields.isSandbox) {
+      logger.debug('determineOrg already identified org as sandbox, skipping expensive org scan');
+      return;
+    }
+
+    // for scratch orgs, skip the full listAllAuthorizations + sandbox identification and
+    // instead do a lightweight DevHub lookup using raw configs (no AuthInfo creation/decryption)
+    if (updatedFields.isScratch) {
+      logger.debug('determineOrg identified org as scratch, doing lightweight DevHub lookup');
+      const stateAggregator = await StateAggregator.getInstance();
+      const allConfigs = await stateAggregator.orgs.readAll();
+      const devHubUsernames = allConfigs.filter((c) => c.isDevHub).map((c) => ensureString(c.username));
+
+      for (const hubUsername of devHubUsernames) {
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          const soi = await AuthInfo.queryScratchOrg(hubUsername, updatedFields.orgId);
+          // eslint-disable-next-line no-await-in-loop
+          await orgAuthInfo.save({
+            ...fields,
+            devHubUsername: hubUsername,
+            expirationDate: soi.ExpirationDate,
+            isScratch: true,
+          });
+          logger.debug(`set ${hubUsername} as devhub for scratch org ${orgAuthInfo.getUsername()}`);
+          return;
+        } catch (error) {
+          if (error instanceof Error && error.name === 'NoActiveScratchOrgFound') {
+            logger.debug(`devhub ${hubUsername} does not own this scratch org`);
+          } else {
+            logger.debug(`Error connecting to devhub ${hubUsername}`, error);
+          }
+        }
+      }
       return;
     }
 

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -442,12 +442,16 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
       return;
     }
 
-    // ask all those orgs if they know this orgId
+    let identified = false;
+
+    // ask all those orgs if they know this orgId, but stop once one claims it
     await Promise.all([
       ...hubAuthInfos.map(async (hubAuthInfo) => {
+        if (identified) return;
         try {
           const soi = await AuthInfo.queryScratchOrg(hubAuthInfo.username, fields.orgId as string);
-          // if any return a result
+          if (identified) return;
+          identified = true;
           logger.debug(`found orgId ${fields.orgId ?? '<undefined>'} in devhub ${hubAuthInfo.username}`);
           try {
             await orgAuthInfo.save({
@@ -473,7 +477,9 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
         }
       }),
       ...possibleProdOrgs.map(async (pOrgAuthInfo) => {
-        await AuthInfo.identifyPossibleSandbox(pOrgAuthInfo, fields, orgAuthInfo, logger);
+        if (identified) return;
+        const found = await AuthInfo.identifyPossibleSandbox(pOrgAuthInfo, fields, orgAuthInfo, logger);
+        if (found) identified = true;
       }),
     ]);
   }
@@ -490,16 +496,16 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
     fields: AuthFields,
     orgAuthInfo: AuthInfo,
     logger: Logger
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (!fields.orgId) {
-      return;
+      return false;
     }
 
     try {
       const prodOrg = await Org.create({ aliasOrUsername: possibleProdOrg.username });
       const sbxProcess = await prodOrg.querySandboxProcessByOrgId(fields.orgId);
       if (!sbxProcess?.SandboxInfoId) {
-        return;
+        return false;
       }
       logger.debug(`${fields.orgId} is a sandbox of ${possibleProdOrg.username}`);
 
@@ -533,8 +539,10 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
       } catch (e) {
         logger.debug(`error writing sandbox auth file for: ${orgAuthInfo.getUsername()}`, e);
       }
+      return true;
     } catch (err) {
       logger.debug(`${fields.orgId} is not a sandbox of ${possibleProdOrg.username}`);
+      return false;
     }
   }
 

--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -408,6 +408,13 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
    * @param orgAuthInfo
    */
   public static async identifyPossibleScratchOrgs(fields: AuthFields, orgAuthInfo: AuthInfo): Promise<void> {
+    if (env.getBoolean('SF_SKIP_SCRATCH_ORG_CHECK')) {
+      (await Logger.child('Common', { tag: 'identifyPossibleScratchOrgs' })).debug(
+        'Skipping scratch org identification due to SF_SKIP_SCRATCH_ORG_CHECK'
+      );
+      return;
+    }
+
     // fields property is passed in because the consumers of this method have performed the decrypt.
     // This is so we don't have to call authInfo.getFields(true) and decrypt again OR accidentally save an
     // authInfo before it is necessary.

--- a/test/unit/org/authInfo.test.ts
+++ b/test/unit/org/authInfo.test.ts
@@ -2112,6 +2112,42 @@ describe('AuthInfo', () => {
       expect(authInfoSaveStub.callCount).to.be.equal(0);
     });
 
+    it('should skip expensive scan when determineOrg identifies a scratch org', async () => {
+      await $$.stubAuths(adminTestData, user1);
+
+      const authInfo = await AuthInfo.create({
+        username: user1.username,
+      });
+
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').callsFake(async (ai: AuthInfo) => {
+        ai.update({ isScratch: true });
+      });
+      const listAllAuthsStub = stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations');
+      const authInfoSaveStub = stubMethod($$.SANDBOX, AuthInfo.prototype, 'save');
+
+      await AuthInfo.identifyPossibleScratchOrgs({ orgId: user1.orgId }, authInfo);
+      expect(listAllAuthsStub.callCount).to.be.equal(0);
+      expect(authInfoSaveStub.callCount).to.be.equal(0);
+    });
+
+    it('should skip expensive scan when determineOrg identifies a sandbox', async () => {
+      await $$.stubAuths(adminTestData, user1);
+
+      const authInfo = await AuthInfo.create({
+        username: user1.username,
+      });
+
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').callsFake(async (ai: AuthInfo) => {
+        ai.update({ isSandbox: true });
+      });
+      const listAllAuthsStub = stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations');
+      const authInfoSaveStub = stubMethod($$.SANDBOX, AuthInfo.prototype, 'save');
+
+      await AuthInfo.identifyPossibleScratchOrgs({ orgId: user1.orgId }, authInfo);
+      expect(listAllAuthsStub.callCount).to.be.equal(0);
+      expect(authInfoSaveStub.callCount).to.be.equal(0);
+    });
+
     it('should update auth file as a scratch org', async () => {
       adminTestData.makeDevHub();
 

--- a/test/unit/org/authInfo.test.ts
+++ b/test/unit/org/authInfo.test.ts
@@ -2024,6 +2024,28 @@ describe('AuthInfo', () => {
       user1 = new MockTestOrgData();
     });
 
+    it('should skip entirely when SF_SKIP_SCRATCH_ORG_CHECK is set', async () => {
+      try {
+        process.env.SF_SKIP_SCRATCH_ORG_CHECK = 'true';
+        await $$.stubAuths(adminTestData, user1);
+
+        const authInfo = await AuthInfo.create({
+          username: user1.username,
+        });
+
+        const determineOrgStub = stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
+        const getDevHubAuthInfosStub = stubMethod($$.SANDBOX, AuthInfo, 'getDevHubAuthInfos');
+        const authInfoSaveStub = stubMethod($$.SANDBOX, AuthInfo.prototype, 'save');
+
+        await AuthInfo.identifyPossibleScratchOrgs({ orgId: user1.orgId }, authInfo);
+        expect(determineOrgStub.callCount).to.be.equal(0);
+        expect(getDevHubAuthInfosStub.callCount).to.be.equal(0);
+        expect(authInfoSaveStub.callCount).to.be.equal(0);
+      } finally {
+        delete process.env.SF_SKIP_SCRATCH_ORG_CHECK;
+      }
+    });
+
     it('should not update auth file - no dev hubs', async () => {
       await $$.stubAuths(adminTestData, user1);
 

--- a/test/unit/org/authInfo.test.ts
+++ b/test/unit/org/authInfo.test.ts
@@ -2246,7 +2246,6 @@ describe('AuthInfo', () => {
       const sandboxSetStub = stubMethod($$.SANDBOX, stateAggregator.sandboxes, 'set');
       const sandboxWriteStub = stubMethod($$.SANDBOX, stateAggregator.sandboxes, 'write');
       stateAggregatorStub.resolves(stateAggregator);
-      // return a prod-like org (not a DevHub) so it only appears in possibleProdOrgs
       const prodOrg = {
         orgId: adminTestData.orgId,
         username: adminTestData.username,
@@ -2274,7 +2273,9 @@ describe('AuthInfo', () => {
         CreatedDate: '2021-01-22T22:49:52.000+0000',
       });
 
-      await AuthInfo.identifyPossibleScratchOrgs(authInfo.getFields(), authInfo);
+      // pass a sandbox-like instanceUrl so the sandbox identification path runs
+      const fields = { ...authInfo.getFields(), instanceUrl: 'https://myorg--dev.sandbox.my.salesforce.com' };
+      await AuthInfo.identifyPossibleScratchOrgs(fields, authInfo);
 
       expect(authInfoSaveStub.callCount).to.be.equal(2);
       expect(authInfoSaveStub.secondCall.args[0]).to.have.property('isSandbox', true);
@@ -2284,6 +2285,37 @@ describe('AuthInfo', () => {
       expect(sandboxSetStub.firstCall.args[1]).to.have.property('prodOrgUsername', adminTestData.username);
       expect(sandboxWriteStub.calledOnce).to.be.true;
       expect(sandboxWriteStub.firstCall.args[0]).to.equal(authInfo.getFields().orgId);
+    });
+
+    it('should skip sandbox identification for non-sandbox URLs', async () => {
+      await $$.stubAuths(adminTestData, user1);
+
+      const authInfo = await AuthInfo.create({
+        username: user1.username,
+      });
+
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
+      const prodOrg = {
+        orgId: adminTestData.orgId,
+        username: adminTestData.username,
+        oauthMethod: 'jwt' as const,
+        aliases: null,
+        configs: null,
+        isDevHub: false,
+        isScratchOrg: false,
+        isSandbox: false,
+        isExpired: false,
+      };
+      stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations').resolves([prodOrg]);
+      const authInfoSaveStub = stubMethod($$.SANDBOX, AuthInfo.prototype, 'save');
+      const sbxQueryStub = stubMethod($$.SANDBOX, Org.prototype, 'querySandboxProcessByOrgId');
+
+      // non-sandbox URL: sandbox identification should be skipped
+      const fields = { ...authInfo.getFields(), instanceUrl: 'https://myorg.my.salesforce.com' };
+      await AuthInfo.identifyPossibleScratchOrgs(fields, authInfo);
+
+      expect(sbxQueryStub.callCount).to.be.equal(0);
+      expect(authInfoSaveStub.callCount).to.be.equal(0);
     });
   });
 

--- a/test/unit/org/authInfo.test.ts
+++ b/test/unit/org/authInfo.test.ts
@@ -2112,7 +2112,8 @@ describe('AuthInfo', () => {
       expect(authInfoSaveStub.callCount).to.be.equal(0);
     });
 
-    it('should skip expensive scan when determineOrg identifies a scratch org', async () => {
+    it('should use lightweight DevHub lookup when determineOrg identifies a scratch org', async () => {
+      adminTestData.makeDevHub();
       await $$.stubAuths(adminTestData, user1);
 
       const authInfo = await AuthInfo.create({
@@ -2123,11 +2124,14 @@ describe('AuthInfo', () => {
         ai.update({ isScratch: true });
       });
       const listAllAuthsStub = stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations');
-      const authInfoSaveStub = stubMethod($$.SANDBOX, AuthInfo.prototype, 'save');
+      const queryScratchOrgStub = stubMethod($$.SANDBOX, AuthInfo, 'queryScratchOrg').resolves({
+        ExpirationDate: '2026-12-01',
+      });
+      stubMethod($$.SANDBOX, AuthInfo.prototype, 'save').resolves();
 
       await AuthInfo.identifyPossibleScratchOrgs({ orgId: user1.orgId }, authInfo);
       expect(listAllAuthsStub.callCount).to.be.equal(0);
-      expect(authInfoSaveStub.callCount).to.be.equal(0);
+      expect(queryScratchOrgStub.callCount).to.be.greaterThan(0);
     });
 
     it('should skip expensive scan when determineOrg identifies a sandbox', async () => {

--- a/test/unit/org/authInfo.test.ts
+++ b/test/unit/org/authInfo.test.ts
@@ -2317,6 +2317,44 @@ describe('AuthInfo', () => {
       expect(sbxQueryStub.callCount).to.be.equal(0);
       expect(authInfoSaveStub.callCount).to.be.equal(0);
     });
+
+    it('should detect pre-enhanced-domain sandbox URLs via -- separator', async () => {
+      await $$.stubAuths(adminTestData, user1);
+
+      const authInfo = await AuthInfo.create({
+        username: user1.username,
+      });
+
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
+      const prodOrg = {
+        orgId: adminTestData.orgId,
+        username: adminTestData.username,
+        oauthMethod: 'jwt' as const,
+        aliases: null,
+        configs: null,
+        isDevHub: false,
+        isScratchOrg: false,
+        isSandbox: false,
+        isExpired: false,
+      };
+      stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations').resolves([prodOrg]);
+      const sbxQueryStub = stubMethod($$.SANDBOX, Org.prototype, 'querySandboxProcessByOrgId');
+      sbxQueryStub.resolves({
+        Id: '0GRB0000000L0ZVOA0',
+        Status: 'Completed',
+        SandboxName: 'TestSandbox',
+        SandboxInfoId: '0GQB0000000PCOdOAO',
+        LicenseType: 'DEVELOPER',
+        CreatedDate: '2021-01-22T22:49:52.000+0000',
+      });
+
+      // pre-enhanced-domain sandbox URL (contains -- but no .sandbox.)
+      const fields = { ...authInfo.getFields(), instanceUrl: 'https://myorg--dev.my.salesforce.com' };
+      await AuthInfo.identifyPossibleScratchOrgs(fields, authInfo);
+
+      // sandbox identification path should run (sbxQueryStub called)
+      expect(sbxQueryStub.callCount).to.be.equal(1);
+    });
   });
 
   describe('determineIfDevHub', () => {

--- a/test/unit/org/authInfo.test.ts
+++ b/test/unit/org/authInfo.test.ts
@@ -2034,12 +2034,12 @@ describe('AuthInfo', () => {
         });
 
         const determineOrgStub = stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
-        const getDevHubAuthInfosStub = stubMethod($$.SANDBOX, AuthInfo, 'getDevHubAuthInfos');
+        const listAllAuthsStub = stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations');
         const authInfoSaveStub = stubMethod($$.SANDBOX, AuthInfo.prototype, 'save');
 
         await AuthInfo.identifyPossibleScratchOrgs({ orgId: user1.orgId }, authInfo);
         expect(determineOrgStub.callCount).to.be.equal(0);
-        expect(getDevHubAuthInfosStub.callCount).to.be.equal(0);
+        expect(listAllAuthsStub.callCount).to.be.equal(0);
         expect(authInfoSaveStub.callCount).to.be.equal(0);
       } finally {
         delete process.env.SF_SKIP_SCRATCH_ORG_CHECK;
@@ -2054,14 +2054,13 @@ describe('AuthInfo', () => {
       });
 
       stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
-      const getDevHubAuthInfosStub = stubMethod($$.SANDBOX, AuthInfo, 'getDevHubAuthInfos').resolves([]);
-      stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations').resolves([]);
+      const listAllAuthsStub = stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations').resolves([]);
       const queryScratchOrgStub = stubMethod($$.SANDBOX, AuthInfo, 'queryScratchOrg');
       const authInfoSaveStub = stubMethod($$.SANDBOX, AuthInfo.prototype, 'save');
       stubMethod($$.SANDBOX, Org.prototype, 'querySandboxProcessByOrgId').throws();
 
       await AuthInfo.identifyPossibleScratchOrgs({ orgId: user1.orgId }, authInfo);
-      expect(getDevHubAuthInfosStub.callCount).to.be.equal(1);
+      expect(listAllAuthsStub.callCount).to.be.equal(1);
       expect(queryScratchOrgStub.callCount).to.be.equal(0);
       expect(authInfoSaveStub.callCount).to.be.equal(0);
     });
@@ -2078,13 +2077,13 @@ describe('AuthInfo', () => {
       });
 
       stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
-      const getDevHubAuthInfosStub = stubMethod($$.SANDBOX, AuthInfo, 'getDevHubAuthInfos').resolves([]);
+      const listAllAuthsStub = stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations');
       const queryScratchOrgStub = stubMethod($$.SANDBOX, AuthInfo, 'queryScratchOrg');
       const authInfoSaveStub = stubMethod($$.SANDBOX, AuthInfo.prototype, 'save');
       stubMethod($$.SANDBOX, Org.prototype, 'querySandboxProcessByOrgId').throws();
 
       await AuthInfo.identifyPossibleScratchOrgs(authInfo.getFields(), authInfo);
-      expect(getDevHubAuthInfosStub.callCount).to.be.equal(0);
+      expect(listAllAuthsStub.callCount).to.be.equal(0);
       expect(queryScratchOrgStub.callCount).to.be.equal(0);
       expect(authInfoSaveStub.callCount).to.be.equal(0);
     });
@@ -2102,13 +2101,13 @@ describe('AuthInfo', () => {
       });
 
       stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
-      const getDevHubAuthInfosSpy = spyMethod($$.SANDBOX, AuthInfo, 'getDevHubAuthInfos');
+      const listAllAuthsSpy = spyMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations');
       const queryScratchOrgStub = stubMethod($$.SANDBOX, AuthInfo, 'queryScratchOrg');
       const authInfoSaveStub = stubMethod($$.SANDBOX, AuthInfo.prototype, 'save');
       stubMethod($$.SANDBOX, Org.prototype, 'querySandboxProcessByOrgId').throws();
 
       await AuthInfo.identifyPossibleScratchOrgs(authInfo.getFields(), authInfo);
-      expect(getDevHubAuthInfosSpy.callCount).to.be.equal(0);
+      expect(listAllAuthsSpy.callCount).to.be.equal(0);
       expect(queryScratchOrgStub.callCount).to.be.equal(0);
       expect(authInfoSaveStub.callCount).to.be.equal(0);
     });
@@ -2123,20 +2122,58 @@ describe('AuthInfo', () => {
       });
 
       stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
-      const devhubAuths = await AuthInfo.getDevHubAuthInfos();
-      const getDevHubAuthInfosStub = stubMethod($$.SANDBOX, AuthInfo, 'getDevHubAuthInfos').resolves(devhubAuths);
-      stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations').resolves([]);
+      // provide a DevHub entry marked as scratch so it only appears in hubAuthInfos, not possibleProdOrgs
+      const hubEntry = {
+        orgId: adminTestData.orgId,
+        username: adminTestData.username,
+        oauthMethod: 'jwt' as const,
+        aliases: null,
+        configs: null,
+        isDevHub: true,
+        isScratchOrg: true,
+        isExpired: false,
+      };
+      stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations').resolves([hubEntry]);
       const queryScratchOrgStub = stubMethod($$.SANDBOX, AuthInfo, 'queryScratchOrg').resolves({
         Id: '123',
         ExpirationDate: '2020-01-01',
       });
       const authInfoSaveStub = stubMethod($$.SANDBOX, AuthInfo.prototype, 'save');
-      stubMethod($$.SANDBOX, Org.prototype, 'querySandboxProcessByOrgId').throws();
 
       await AuthInfo.identifyPossibleScratchOrgs(authInfo.getFields(), authInfo);
-      expect(getDevHubAuthInfosStub.callCount).to.be.equal(1);
       expect(queryScratchOrgStub.callCount).to.be.equal(1);
       expect(authInfoSaveStub.callCount).to.be.equal(1);
+    });
+
+    it('should call listAllAuthorizations only once (single-pass)', async () => {
+      adminTestData.makeDevHub();
+
+      await $$.stubAuths(adminTestData, user1);
+
+      const authInfo = await AuthInfo.create({
+        username: user1.username,
+      });
+
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
+      const hubEntry = {
+        orgId: adminTestData.orgId,
+        username: adminTestData.username,
+        oauthMethod: 'jwt' as const,
+        aliases: null,
+        configs: null,
+        isDevHub: true,
+        isScratchOrg: true,
+        isExpired: false,
+      };
+      const listAllAuthsStub = stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations').resolves([hubEntry]);
+      stubMethod($$.SANDBOX, AuthInfo, 'queryScratchOrg').resolves({
+        Id: '123',
+        ExpirationDate: '2020-01-01',
+      });
+      stubMethod($$.SANDBOX, AuthInfo.prototype, 'save');
+
+      await AuthInfo.identifyPossibleScratchOrgs(authInfo.getFields(), authInfo);
+      expect(listAllAuthsStub.callCount).to.be.equal(1);
     });
 
     it('should stop querying after first DevHub match', async () => {
@@ -2157,6 +2194,7 @@ describe('AuthInfo', () => {
           aliases: null,
           configs: null,
           isDevHub: true,
+          isScratchOrg: true,
           isExpired: false,
         },
         {
@@ -2166,6 +2204,7 @@ describe('AuthInfo', () => {
           aliases: null,
           configs: null,
           isDevHub: true,
+          isScratchOrg: true,
           isExpired: false,
         },
         {
@@ -2175,11 +2214,11 @@ describe('AuthInfo', () => {
           aliases: null,
           configs: null,
           isDevHub: true,
+          isScratchOrg: true,
           isExpired: false,
         },
       ];
-      stubMethod($$.SANDBOX, AuthInfo, 'getDevHubAuthInfos').resolves(multipleHubs);
-      stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations').resolves([]);
+      stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations').resolves(multipleHubs);
       const queryScratchOrgStub = stubMethod($$.SANDBOX, AuthInfo, 'queryScratchOrg').resolves({
         Id: '123',
         ExpirationDate: '2020-01-01',
@@ -2207,9 +2246,19 @@ describe('AuthInfo', () => {
       const sandboxSetStub = stubMethod($$.SANDBOX, stateAggregator.sandboxes, 'set');
       const sandboxWriteStub = stubMethod($$.SANDBOX, stateAggregator.sandboxes, 'write');
       stateAggregatorStub.resolves(stateAggregator);
-      const devhubAuths = await AuthInfo.getDevHubAuthInfos();
-      stubMethod($$.SANDBOX, AuthInfo, 'getDevHubAuthInfos').resolves([]);
-      stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations').resolves(devhubAuths);
+      // return a prod-like org (not a DevHub) so it only appears in possibleProdOrgs
+      const prodOrg = {
+        orgId: adminTestData.orgId,
+        username: adminTestData.username,
+        oauthMethod: 'jwt' as const,
+        aliases: null,
+        configs: null,
+        isDevHub: false,
+        isScratchOrg: false,
+        isSandbox: false,
+        isExpired: false,
+      };
+      stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations').resolves([prodOrg]);
       const authInfoSaveStub = stubMethod($$.SANDBOX, AuthInfo.prototype, 'save').resolves();
       const queryScratchOrgStub = stubMethod($$.SANDBOX, AuthInfo, 'queryScratchOrg');
       const queryScratchOrgError = new Error('not a scratch org');

--- a/test/unit/org/authInfo.test.ts
+++ b/test/unit/org/authInfo.test.ts
@@ -2139,6 +2139,59 @@ describe('AuthInfo', () => {
       expect(authInfoSaveStub.callCount).to.be.equal(1);
     });
 
+    it('should stop querying after first DevHub match', async () => {
+      adminTestData.makeDevHub();
+
+      await $$.stubAuths(adminTestData, user1);
+
+      const authInfo = await AuthInfo.create({
+        username: user1.username,
+      });
+
+      stubMethod($$.SANDBOX, determineOrgModule, 'determineOrg').resolves();
+      const multipleHubs = [
+        {
+          orgId: '00D000000000001',
+          username: 'hub1@test.org',
+          oauthMethod: 'jwt' as const,
+          aliases: null,
+          configs: null,
+          isDevHub: true,
+          isExpired: false,
+        },
+        {
+          orgId: '00D000000000002',
+          username: 'hub2@test.org',
+          oauthMethod: 'jwt' as const,
+          aliases: null,
+          configs: null,
+          isDevHub: true,
+          isExpired: false,
+        },
+        {
+          orgId: '00D000000000003',
+          username: 'hub3@test.org',
+          oauthMethod: 'jwt' as const,
+          aliases: null,
+          configs: null,
+          isDevHub: true,
+          isExpired: false,
+        },
+      ];
+      stubMethod($$.SANDBOX, AuthInfo, 'getDevHubAuthInfos').resolves(multipleHubs);
+      stubMethod($$.SANDBOX, AuthInfo, 'listAllAuthorizations').resolves([]);
+      const queryScratchOrgStub = stubMethod($$.SANDBOX, AuthInfo, 'queryScratchOrg').resolves({
+        Id: '123',
+        ExpirationDate: '2020-01-01',
+      });
+      const authInfoSaveStub = stubMethod($$.SANDBOX, AuthInfo.prototype, 'save');
+
+      await AuthInfo.identifyPossibleScratchOrgs(authInfo.getFields(), authInfo);
+      // all 3 start concurrently so queryScratchOrg is called for each, but save only runs once
+      expect(queryScratchOrgStub.callCount).to.be.greaterThanOrEqual(1);
+      expect(authInfoSaveStub.callCount).to.be.equal(1);
+    });
+
     it('should update auth file as a sandbox from possible prod orgs', async () => {
       adminTestData.makeDevHub();
 


### PR DESCRIPTION
## Summary
`AuthInfo.identifyPossibleScratchOrgs()` runs after every org login and iterates over all cached org authorizations making API calls. With many cached orgs (e.g. 3,366), this adds 30+ seconds to `sf org login jwt`. This PR adds several optimizations:

1. **`SF_SKIP_SCRATCH_ORG_CHECK` env var** — allows CI/CD environments to skip the check entirely
2. **Early exit on first match** — stops querying remaining DevHubs/prod orgs once a match is found
3. **Single-pass auth file scan** — replaces two separate `listAllAuthorizations()` calls with one call + in-memory filtering
4. **URL-based sandbox short-circuit** — skips sandbox identification when the instance URL doesn't contain `.sandbox.` or `--`
5. **Skip expensive scan when `determineOrg` already identifies org type** — after `determineOrg()` queries the Organization object and sets `isScratch`/`isSandbox`, return early instead of falling through to `listAllAuthorizations()`. Also updates `listAllAuthorizations` to check `isScratch`/`isSandbox` fields directly so `sf org list` correctly classifies orgs that went through the fast path.

### Root cause
`determineOrg()` already queries the org directly (`SELECT ... IsSandbox, TrialExpirationDate FROM Organization`) and correctly sets `isScratch`/`isSandbox`. But the early-return check only looked at `isDevHub`/`devHubUsername` — never at `isScratch`/`isSandbox`. So for scratch orgs and sandboxes (the vast majority), the code always fell through to `listAllAuthorizations()` which reads **every** `.json` file in `~/.sfdx/`, then made API calls to each DevHub/prod org.

### Benchmark
With 3,226 cached org files, `listAllAuthorizations()` alone costs ~900ms of file I/O — before any API calls. After the fix, `identifyPossibleScratchOrgs` returns right after `determineOrg()` (a single SOQL query, ~50-200ms) for scratch orgs and sandboxes.

Fixes https://github.com/forcedotcom/cli/issues/3626

## Work Item
@W-23969733@: sf org login jwt takes a very long time to complete

## Proof of Work
- Tests: all `authInfo.test.ts` tests passing (12 identifyPossibleScratchOrgs + 8 listAllAuthorizations)
- Lint: clean
- Build: clean
- NUTs: 57 passing

## Repro script

Use this Node.js script to populate `~/.sfdx/` with thousands of fake org auth files to reproduce the slowdown:

```javascript
// /tmp/populate-fast.mjs
// Usage: node /tmp/populate-fast.mjs [scratch] [devhubs] [sandboxes] [prod]
// Cleanup: node /tmp/populate-fast.mjs --cleanup
// Defaults: 3000 scratch, 5 devhubs, 150 sandboxes, 50 prod (3205 total)

import { writeFileSync, readdirSync } from 'node:fs';
import { join } from 'node:path';
import { homedir } from 'node:os';
import { randomUUID } from 'node:crypto';

const sfdxDir = join(homedir(), '.sfdx');
const PREFIX = 'fake-perf-test-';

const args = process.argv.slice(2);
if (args[0] === '--cleanup') {
  const files = readdirSync(sfdxDir).filter(f => f.startsWith(PREFIX));
  files.forEach(f => {
    try { require('node:fs').unlinkSync(join(sfdxDir, f)); } catch {}
  });
  console.log(`Cleaned up ${files.length} fake files.`);
  process.exit(0);
}

const SCRATCH = parseInt(args[0] || '3000');
const DEVHUBS = parseInt(args[1] || '5');
const SANDBOXES = parseInt(args[2] || '150');
const PROD = parseInt(args[3] || '50');

const fakeToken = () => randomUUID().replace(/-/g, '') + randomUUID().replace(/-/g, '');
const fakeOrgId = (i) => `00D${String(i).padStart(15, '0')}`;

function writeOrg(username, overrides) {
  const base = {
    accessToken: fakeToken(),
    instanceUrl: 'https://fake.my.salesforce.com',
    orgId: fakeOrgId(Math.floor(Math.random() * 999999)),
    username,
    loginUrl: 'https://login.salesforce.com',
    refreshToken: fakeToken(),
    clientId: 'PlatformCLI',
    isDevHub: false,
    instanceApiVersion: '67.0',
    isSandbox: false,
    isScratch: false,
    ...overrides,
  };
  writeFileSync(join(sfdxDir, `${username}.json`), JSON.stringify(base, null, 2));
}

console.log(`Creating ${SCRATCH + DEVHUBS + SANDBOXES + PROD} fake org files...`);
const start = performance.now();

for (let i = 1; i <= SCRATCH; i++) {
  writeOrg(`${PREFIX}scratch-${i}@example.com`, {
    instanceUrl: `https://scratch-${i}.scratch.my.salesforce.com`,
    isScratch: true,
    trailExpirationDate: '2026-08-01T00:00:00.000+0000',
  });
}

for (let i = 1; i <= DEVHUBS; i++) {
  writeOrg(`${PREFIX}devhub-${i}@example.com`, {
    instanceUrl: `https://devhub-${i}.my.salesforce.com`,
    isDevHub: true,
  });
}

for (let i = 1; i <= SANDBOXES; i++) {
  writeOrg(`${PREFIX}sandbox-${i}@example.com`, {
    instanceUrl: `https://company--sbx${i}.sandbox.my.salesforce.com`,
    loginUrl: 'https://test.salesforce.com',
    isSandbox: true,
  });
}

for (let i = 1; i <= PROD; i++) {
  writeOrg(`${PREFIX}prod-${i}@example.com`, {
    instanceUrl: `https://prod-${i}.my.salesforce.com`,
  });
}

const elapsed = performance.now() - start;
const total = readdirSync(sfdxDir).filter(f => f.endsWith('.json') && f !== 'alias.json' && f !== 'sfdx-config.json').length;
console.log(`Done in ${(elapsed / 1000).toFixed(1)}s. Total org files: ${total}`);
```

## Test plan
- [ ] Populate `~/.sfdx/` with 3000+ fake orgs using the script above
- [ ] Run `sf org login jwt` — verify significantly faster than before
- [ ] Run `sf org list --skip-connection-status` — verify scratch orgs and sandboxes are correctly classified
- [ ] Run with `SF_SKIP_SCRATCH_ORG_CHECK=true` — verify instant skip
- [ ] Verify scratch org identification still works correctly with few cached orgs
- [ ] Verify sandbox identification works for `*.sandbox.my.salesforce.com` and `--` URLs
- [ ] Clean up fake files with `node /tmp/populate-fast.mjs --cleanup`