### PR TITLE
fix: persist rotated refresh token in buildRefreshTokenConfig

### DIFF
--- a/src/org/authInfo.ts
+++ b/src/org/authInfo.ts
@@ -1180,7 +1180,7 @@ export class AuthInfo extends AsyncOptionalCreatable<AuthInfo.Options> {
       accessToken: authFieldsBuilder.access_token,
       instanceUrl: authFieldsBuilder.instance_url,
       loginUrl: fullOptions.loginUrl ?? authFieldsBuilder.instance_url,
-      refreshToken: fullOptions.refreshToken,
+      refreshToken: authFieldsBuilder.refresh_token ?? fullOptions.refreshToken,
       clientId: fullOptions.clientId,
       clientSecret: fullOptions.clientSecret,
     };


### PR DESCRIPTION
### What does this PR do?

`AuthInfo.buildRefreshTokenConfig` performs the OAuth refresh token grant but
discards the refresh token the server returns, re-emitting the one it was called
with:

```ts
// src/org/authInfo.ts
const authFieldsBuilder = await oauth2.refreshToken(ensure(fullOptions.refreshToken));
...
return {
  orgId,
  username,
  accessToken: authFieldsBuilder.access_token,
  instanceUrl: authFieldsBuilder.instance_url,
  loginUrl: fullOptions.loginUrl ?? authFieldsBuilder.instance_url,
  refreshToken: fullOptions.refreshToken,   // <-- the incoming (old) token
  clientId: fullOptions.clientId,
  clientSecret: fullOptions.clientSecret,
};
```

`exchangeToken` in the same file already does the right thing and returns
`authFields.refresh_token`, so the two auth paths are inconsistent.

This breaks any org whose Connected App has **Enable Refresh Token Rotation**
turned on. With rotation, the token endpoint returns a new `refresh_token` on every
refresh and invalidates the previous one. Because `refreshFn` calls
`initAuthOptions` → `buildRefreshTokenConfig` and then `save()`, the auth file is
rewritten with the *stale* refresh token. The next refresh replays an already-used
token, Salesforce's reuse detection revokes the entire token family, and every
subsequent command fails with:

```
Unable to refresh session due to: Error authenticating with the refresh token
due to: expired access/refresh token
```

The failure is silent and unrecoverable locally — the only fix is a full
re-authentication, and the org breaks again on the next refresh. From the user's
perspective it looks like the CLI "stopped refreshing", but the CLI does attempt
the refresh; it is sending a dead token. Debug log from an affected org:

```
[16:59:38] sf:oclif:connection  GET /services/data/v67.0/query
[16:59:38] sf:oclif:AuthInfo    Access token has expired. Updating...
[16:59:39] sf:oclif             Error: Unable to refresh session due to: Error
                                authenticating with the refresh token due to:
                                expired access/refresh token
```

**The change:** prefer the freshly issued refresh token, falling back to the
existing one when the server does not rotate:

```ts
refreshToken: authFieldsBuilder.refresh_token ?? fullOptions.refreshToken,
```

The fallback keeps behavior byte-for-byte identical for non-rotating Connected
Apps, so this is not a breaking change.


